### PR TITLE
Make the absorber translucent

### DIFF
--- a/src/particles-options/absorber.json
+++ b/src/particles-options/absorber.json
@@ -497,7 +497,7 @@
             "value": "#0a73c9"
         },
         "draggable": false,
-        "opacity": 1,
+        "opacity": 0,
         "destroy": false,
         "orbits": false,
         "size": {


### PR DESCRIPTION
- Makes the absorber invisible since it gets stretched on wide screens

Closes #38 