### PR TITLE
Complete portfolio UI redesign with modern 2026 design patterns

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -7,7 +7,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -15,21 +15,22 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#0a0a14',
+        color: '#f0f0f5',
         position: 'relative',
         minHeight: '100vh',
       }}
     >
       <NavBar />
 
+      {/* Hero */}
       <Box
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
+          background: 'linear-gradient(135deg, #0c0a20, #1a1040, #0c1525, #150a28)',
           backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
+          animation: 'gradShift 20s ease infinite',
           '@keyframes gradShift': {
             '0%': { backgroundPosition: '0% 50%' },
             '50%': { backgroundPosition: '100% 50%' },
@@ -41,37 +42,69 @@ const MainPage = () => {
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        {/* About — Bento grid */}
         <Box
           id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
+            background: 'linear-gradient(180deg, #0c0a1e 0%, #0a0a14 100%)',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
           }}
         >
           <About />
         </Box>
 
+        {/* Divider */}
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: '1200px',
+            mx: 'auto',
+            px: 4,
+          }}
+        >
+          <Box
+            sx={{
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)',
+            }}
+          />
+        </Box>
+
+        {/* Projects */}
         <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
+            bgcolor: '#0a0a14',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
           }}
         >
           <Projects />
         </Box>
 
+        {/* Divider */}
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: '1200px',
+            mx: 'auto',
+            px: 4,
+          }}
+        >
+          <Box
+            sx={{
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)',
+            }}
+          />
+        </Box>
+
+        {/* Contact */}
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
+            background: 'linear-gradient(180deg, #0a0a14 0%, #080810 100%)',
             width: '100%',
-            color: '#ffffff',
           }}
         >
           <Contact />
@@ -82,4 +115,5 @@ const MainPage = () => {
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,77 +1,401 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
+import { useEffect, useState, useRef } from 'react';
+import { Box, Typography, Chip, Stack, Grid, IconButton, Link, Button } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import SchoolIcon from '@mui/icons-material/School';
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const glassCard = {
+  background: 'rgba(255, 255, 255, 0.02)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '20px',
+  p: { xs: 3, md: 3.5 },
+  height: '100%',
+  transition: 'border-color 0.3s ease, background 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+    background: 'rgba(255, 255, 255, 0.03)',
+  },
+};
+
+const cardLabel = {
+  fontSize: '0.65rem',
+  fontWeight: 600,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'rgba(240,240,245,0.35)',
+  mb: 2.5,
+};
+
+const BioCard = () => (
+  <Box sx={glassCard}>
+    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 3, alignItems: { sm: 'flex-start' } }}>
+      <Box
+        sx={{
+          p: '2px',
+          borderRadius: '16px',
+          background: 'linear-gradient(135deg, #38c0f2, #8b5cf6)',
+          flexShrink: 0,
+          alignSelf: { xs: 'center', sm: 'flex-start' },
+        }}
+      >
+        <Box sx={{ borderRadius: '14px', overflow: 'hidden', bgcolor: '#0a0a14', width: 110, height: 110 }}>
+          <Image
+            alt="Photo of David Riva"
+            src="/images/headshot.webp"
+            width={110}
+            height={110}
+            style={{ objectFit: 'cover', display: 'block' }}
+            priority
+          />
+        </Box>
+      </Box>
+      <Box sx={{ flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: '1.65rem', letterSpacing: '-0.02em', lineHeight: 1.15, color: '#f0f0f5' }}>
+          David Riva
+        </Typography>
+        <Typography sx={{ fontWeight: 500, fontSize: '0.9rem', color: '#38c0f2', mt: 0.5, mb: 0.75 }}>
+          Training Engineer, Generative AI
+        </Typography>
+        <Typography sx={{ fontSize: '0.8rem', color: 'rgba(240,240,245,0.4)' }}>
+          Bay Area, CA
+        </Typography>
+      </Box>
+    </Box>
+
+    <Typography variant="body1" sx={{ mt: 3, color: 'rgba(240,240,245,0.65)', lineHeight: 1.75 }}>
+      Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
+      University with a B.S. in Computer Science, Summa Cum Laude. I&apos;m passionate about software &amp; applied AI
+      engineering, with experience in full-stack development, data engineering, and big data visualization.
+    </Typography>
+
+    <Stack direction="row" spacing={1.5} sx={{ mt: 3, flexWrap: 'wrap', alignItems: 'center' }}>
+      <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+        <IconButton
+          aria-label="GitHub Profile"
+          size="small"
+          sx={{
+            color: 'rgba(240,240,245,0.5)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: '10px',
+            width: 38,
+            height: 38,
+            transition: 'all 0.2s ease',
+            '&:hover': { color: '#f0f0f5', borderColor: 'rgba(255,255,255,0.2)', background: 'rgba(255,255,255,0.04)' },
+          }}
+        >
+          <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+        </IconButton>
+      </Link>
+      <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+        <IconButton
+          aria-label="LinkedIn Profile"
+          size="small"
+          sx={{
+            color: 'rgba(240,240,245,0.5)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: '10px',
+            width: 38,
+            height: 38,
+            transition: 'all 0.2s ease',
+            '&:hover': { color: '#38c0f2', borderColor: 'rgba(56,192,242,0.3)', background: 'rgba(56,192,242,0.06)' },
+          }}
+        >
+          <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+        </IconButton>
+      </Link>
+      <Link href="mailto:davidjriva@gmail.com">
+        <IconButton
+          aria-label="Email"
+          size="small"
+          sx={{
+            color: 'rgba(240,240,245,0.5)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: '10px',
+            width: 38,
+            height: 38,
+            transition: 'all 0.2s ease',
+            '&:hover': { color: '#f0f0f5', borderColor: 'rgba(255,255,255,0.2)', background: 'rgba(255,255,255,0.04)' },
+          }}
+        >
+          <EmailOutlinedIcon sx={{ fontSize: '1.1rem' }} />
+        </IconButton>
+      </Link>
+      <Button
+        href="/documents/resume.pdf"
+        target="_blank"
+        startIcon={<DescriptionOutlinedIcon sx={{ fontSize: '0.95rem !important' }} />}
+        sx={{
+          ml: 0.5,
+          color: 'rgba(240,240,245,0.6)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: '10px',
+          textTransform: 'none',
+          fontSize: '0.78rem',
+          fontWeight: 500,
+          px: 1.75,
+          py: 0.6,
+          transition: 'all 0.2s ease',
+          '&:hover': { color: '#f0f0f5', borderColor: 'rgba(255,255,255,0.2)', background: 'rgba(255,255,255,0.04)' },
+        }}
+      >
+        Resume
+      </Button>
+    </Stack>
+  </Box>
+);
+
+const skillCategoryColors = {
+  Languages: { bg: 'rgba(56,192,242,0.08)', border: 'rgba(56,192,242,0.2)', color: '#5ed0f7' },
+  'AI Orchestration & Machine Learning': { bg: 'rgba(139,92,246,0.08)', border: 'rgba(139,92,246,0.2)', color: '#a78bfa' },
+  'Web Development': { bg: 'rgba(52,211,153,0.08)', border: 'rgba(52,211,153,0.2)', color: '#6ee7b7' },
+  'Big Data & Cloud': { bg: 'rgba(251,146,60,0.08)', border: 'rgba(251,146,60,0.2)', color: '#fdba74' },
+  'Databases & Tools': { bg: 'rgba(240,240,245,0.05)', border: 'rgba(240,240,245,0.12)', color: 'rgba(240,240,245,0.65)' },
+  'Testing & Validation': { bg: 'rgba(244,114,182,0.08)', border: 'rgba(244,114,182,0.2)', color: '#f9a8d4' },
+  'Data Science Libraries': { bg: 'rgba(96,165,250,0.08)', border: 'rgba(96,165,250,0.2)', color: '#93c5fd' },
+};
+
+const SkillsCard = ({ skills }) => (
+  <Box sx={glassCard}>
+    <Typography sx={cardLabel}>Skills & Tools</Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {skills.map((category) => {
+        const colors = skillCategoryColors[category.title] || skillCategoryColors['Databases & Tools'];
+        return (
+          <Box key={category.title}>
+            <Typography sx={{ fontSize: '0.7rem', fontWeight: 600, color: colors.color, mb: 0.75, opacity: 0.8 }}>
+              {category.title}
+            </Typography>
+            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+              {category.items.map((item) => (
+                <Chip
+                  key={item}
+                  label={item}
+                  size="small"
+                  sx={{
+                    bgcolor: colors.bg,
+                    color: colors.color,
+                    border: `1px solid ${colors.border}`,
+                    fontSize: '0.68rem',
+                    fontWeight: 500,
+                    height: '24px',
+                    borderRadius: '6px',
+                    '& .MuiChip-label': { px: 1 },
+                  }}
+                />
+              ))}
+            </Stack>
+          </Box>
+        );
+      })}
+    </Box>
+  </Box>
+);
+
+const ExperienceCard = ({ experiences }) => {
+  const sorted = [...experiences]
+    .filter((e) => !e.title.startsWith('Graduated'))
+    .sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+
   return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
+    <Box sx={glassCard}>
+      <Typography sx={cardLabel}>Experience</Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+        {sorted.map((exp, i) => {
+          const isCurrent = exp.endDate === 'Present' || new Date(exp.endDate) > new Date('2026-01-01');
+          return (
+            <Box
+              key={exp.title}
+              sx={{
+                display: 'flex',
+                gap: 2,
+                py: 1.75,
+                borderBottom: i < sorted.length - 1 ? '1px solid rgba(255,255,255,0.04)' : 'none',
+                alignItems: 'flex-start',
+              }}
+            >
+              <Box
+                sx={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: '10px',
+                  bgcolor: 'rgba(255,255,255,0.06)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  mt: 0.25,
+                  border: isCurrent ? '1px solid rgba(56,192,242,0.2)' : '1px solid rgba(255,255,255,0.04)',
+                }}
+              >
+                <Image
+                  src={`/images/${exp.logoImage}`}
+                  alt={`${exp.company} logo`}
+                  width={20}
+                  height={20}
+                  style={{ objectFit: 'contain' }}
+                />
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography sx={{ fontWeight: 600, fontSize: '0.82rem', color: '#f0f0f5', lineHeight: 1.3 }}>
+                  {exp.title.split(',')[0]}
+                </Typography>
+                <Typography
+                  component="a"
+                  href={exp.companyWebsiteLink}
+                  target="_blank"
+                  rel="noopener"
+                  sx={{
+                    fontSize: '0.75rem',
+                    color: '#38c0f2',
+                    textDecoration: 'none',
+                    display: 'block',
+                    mt: 0.25,
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  {exp.company}
+                </Typography>
+                <Typography sx={{ fontSize: '0.68rem', color: 'rgba(240,240,245,0.35)', mt: 0.5 }}>
+                  {exp.startDate} &ndash; {isCurrent ? 'Present' : exp.endDate}
+                </Typography>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
     </Box>
   );
 };
 
+const awardIcons = {
+  '1st Place': <EmojiEventsIcon sx={{ fontSize: '1rem', color: '#fbbf24' }} />,
+  Summa: <SchoolIcon sx={{ fontSize: '1rem', color: '#a78bfa' }} />,
+  Excellence: <WorkspacePremiumIcon sx={{ fontSize: '1rem', color: '#38c0f2' }} />,
+  "Dean's": <SchoolIcon sx={{ fontSize: '1rem', color: '#6ee7b7' }} />,
+};
+
+const getAwardIcon = (title) => {
+  for (const [key, icon] of Object.entries(awardIcons)) {
+    if (title.includes(key)) return icon;
+  }
+  return <EmojiEventsIcon sx={{ fontSize: '1rem', color: '#fbbf24' }} />;
+};
+
+const AwardsCard = ({ awards }) => (
+  <Box sx={glassCard}>
+    <Typography sx={cardLabel}>Awards</Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+      {awards.map((award, i) => (
+        <Box
+          key={award.title}
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            py: 1.5,
+            borderBottom: i < awards.length - 1 ? '1px solid rgba(255,255,255,0.04)' : 'none',
+            alignItems: 'flex-start',
+          }}
+        >
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '8px',
+              bgcolor: 'rgba(255,255,255,0.04)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              mt: 0.25,
+            }}
+          >
+            {getAwardIcon(award.title)}
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.8rem', color: '#f0f0f5', lineHeight: 1.35 }}>
+              {award.title}
+            </Typography>
+            <Typography sx={{ fontSize: '0.72rem', color: 'rgba(240,240,245,0.4)', mt: 0.25 }}>
+              {award.date}
+            </Typography>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  </Box>
+);
+
 const About = () => {
+  const [skills, setSkills] = useState([]);
+  const [experiences, setExperiences] = useState([]);
+  const [awards, setAwards] = useState([]);
+  const gridRef = useRef(null);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/data/skills.json').then((r) => r.json()),
+      fetch('/data/experiences.json').then((r) => r.json()),
+      fetch('/data/awards.json').then((r) => r.json()),
+    ]).then(([s, e, a]) => {
+      setSkills(s);
+      setExperiences(e);
+      setAwards(a);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!gridRef.current || !skills.length) return;
+    const cards = gridRef.current.querySelectorAll('.bento-card');
+    gsap.fromTo(
+      cards,
+      { y: 40, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.7,
+        stagger: 0.1,
+        ease: 'power3.out',
+        scrollTrigger: { trigger: gridRef.current, start: 'top 80%' },
+      }
+    );
+    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
+  }, [skills]);
+
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
         width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, sm: 3, md: 4 },
+        py: { xs: 6, md: 8 },
       }}
     >
-      <Box
-        sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
-        </Box>
-      </Box>
-
-      <AboutTextSection />
-
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
-      </Box>
+      <Grid ref={gridRef} container spacing={2.5}>
+        <Grid size={{ xs: 12, md: 7 }} className="bento-card">
+          <BioCard />
+        </Grid>
+        <Grid size={{ xs: 12, md: 5 }} className="bento-card">
+          {skills.length > 0 && <SkillsCard skills={skills} />}
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 5 }} className="bento-card">
+          {experiences.length > 0 && <ExperienceCard experiences={experiences} />}
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 7 }} className="bento-card">
+          {awards.length > 0 && <AwardsCard awards={awards} />}
+        </Grid>
+      </Grid>
     </Box>
   );
 };

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -13,13 +13,13 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         display: 'flex',
         alignItems: 'center',
         p: '4px 8px',
-        borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        borderRadius: '14px',
+        backgroundColor: 'rgba(255,255,255,0.03)',
+        border: '1px solid rgba(255,255,255,0.08)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.15)' },
+        '&:focus-within': { borderColor: 'rgba(56,192,242,0.4)' },
       }}
     >
       <InputBase
@@ -34,24 +34,29 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
+          color: '#f0f0f5',
+          fontSize: '0.9rem',
           fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          '& input::placeholder': { color: 'rgba(240,240,245,0.3)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          ml: 0.5,
+          width: 34,
+          height: 34,
+          borderRadius: '10px',
+          background: 'linear-gradient(135deg, #38c0f2, #8b5cf6)',
+          transition: 'opacity 0.2s ease',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#fff', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -9,9 +9,9 @@ const MessageItem = ({ msg }) => {
   const mdStyles = {
     fontFamily: 'var(--font-montserrat), Arial, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#f0f0f5',
     marginBottom: '4px',
   };
 
@@ -28,17 +28,15 @@ const MessageItem = ({ msg }) => {
           maxWidth: '80%',
           px: 2.5,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(56,192,242,0.08)' : 'rgba(255,255,255,0.03)',
+          border: isUser ? '1px solid rgba(56,192,242,0.15)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={7} dotColor="#38c0f2" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -47,18 +45,19 @@ const MessageItem = ({ msg }) => {
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
                 strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />,
+                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />,
+                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />,
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
                       color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      backgroundColor: 'rgba(56,192,242,0.06)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
+                      fontSize: '0.85rem',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +66,32 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.3)',
+                      color: '#f0f0f5',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      border: '1px solid rgba(255,255,255,0.04)',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{ color: '#38c0f2', textDecoration: 'none', fontWeight: 500 }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#f0f0f5' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,5 +1,4 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
 
@@ -12,24 +11,31 @@ const Contact = () => {
         alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
-        pt: '60px',
-        pb: '60px',
+        pt: { xs: 6, md: 8 },
+        pb: { xs: 6, md: 8 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      <SectionHeading sectionName="Contact" />
+
+      <Typography
+        sx={{
+          color: 'rgba(240,240,245,0.45)',
+          fontSize: '0.9rem',
+          textAlign: 'center',
+          mb: 4,
+          maxWidth: '420px',
+          px: 2,
+          lineHeight: 1.7,
+        }}
+      >
+        Have a question or want to work together? Drop me a message.
+      </Typography>
 
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          width: '100%',
+          maxWidth: '560px',
+          px: { xs: 2, sm: 3 },
         }}
       >
         <ContactForm />

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,24 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': {
+    color: 'rgba(240,240,245,0.35)',
+    fontSize: '0.85rem',
+    fontWeight: 500,
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#f0f0f5',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.12)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(56,192,242,0.4)', borderWidth: '1px' },
   },
 };
 
@@ -49,19 +57,18 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        bgcolor: 'rgba(255, 255, 255, 0.02)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        color: '#f0f0f5',
+        p: { xs: 3, sm: 4 },
+        borderRadius: '20px',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
         <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
 
@@ -78,20 +85,27 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.95rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
+            py: 1.4,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #38c0f2, #8b5cf6)',
+            color: '#fff',
+            borderRadius: '12px',
             border: 'none',
+            textTransform: 'none',
+            letterSpacing: '0.01em',
+            transition: 'all 0.25s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #5ed0f7, #a78bfa)',
+              transform: 'translateY(-1px)',
+              boxShadow: '0 8px 24px rgba(56,192,242,0.15)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(255, 255, 255, 0.2)',
             },
           }}
         >
@@ -100,16 +114,32 @@ const ContactForm = () => {
       </form>
 
       {status && (
-        <Typography
-          variant="body2"
+        <Box
           sx={{
-            marginTop: 2,
-            textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            mt: 2.5,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.75,
+            py: 1,
+            borderRadius: '10px',
+            bgcolor: status.includes('success') ? 'rgba(52,211,153,0.06)' : 'rgba(244,63,94,0.06)',
+            border: status.includes('success') ? '1px solid rgba(52,211,153,0.15)' : '1px solid rgba(244,63,94,0.15)',
           }}
         >
-          {status}
-        </Typography>
+          {status.includes('success') && <CheckCircleOutlineIcon sx={{ fontSize: '1rem', color: '#6ee7b7' }} />}
+          <Typography
+            variant="body2"
+            sx={{
+              textAlign: 'center',
+              color: status.includes('success') ? '#6ee7b7' : '#fca5a5',
+              fontSize: '0.82rem',
+              fontWeight: 500,
+            }}
+          >
+            {status}
+          </Typography>
+        </Box>
       )}
     </Box>
   );

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,76 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton, Link, Stack } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        color: 'rgba(240, 240, 245, 0.3)',
         width: '100%',
-        height: '10vh',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        py: 4,
+        px: 3,
+        gap: 2.5,
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <IconButton
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          color: 'rgba(240,240,245,0.3)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          borderRadius: '10px',
+          width: 36,
+          height: 36,
+          transition: 'all 0.25s ease',
+          '&:hover': {
+            color: '#38c0f2',
+            borderColor: 'rgba(56,192,242,0.2)',
+            background: 'rgba(56,192,242,0.04)',
+            transform: 'translateY(-2px)',
+          },
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        <KeyboardArrowUpIcon sx={{ fontSize: '1.1rem' }} />
+      </IconButton>
+
+      <Stack direction="row" spacing={1}>
+        <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+          <IconButton
+            aria-label="GitHub"
+            size="small"
+            sx={{
+              color: 'rgba(240,240,245,0.3)',
+              transition: 'color 0.2s ease',
+              '&:hover': { color: 'rgba(240,240,245,0.7)' },
+            }}
+          >
+            <GitHubIcon sx={{ fontSize: '1rem' }} />
+          </IconButton>
+        </Link>
+        <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+          <IconButton
+            aria-label="LinkedIn"
+            size="small"
+            sx={{
+              color: 'rgba(240,240,245,0.3)',
+              transition: 'color 0.2s ease',
+              '&:hover': { color: '#38c0f2' },
+            }}
+          >
+            <LinkedInIcon sx={{ fontSize: '1rem' }} />
+          </IconButton>
+        </Link>
+      </Stack>
+
+      <Typography sx={{ fontSize: '0.7rem', color: 'rgba(240,240,245,0.2)', textAlign: 'center' }}>
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -6,78 +6,73 @@ import { Typography } from '@mui/material';
 const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const baseTypingSpeed = 100;
+  const baseDeletingSpeed = 50;
+  const delayBeforeDeleting = 1200;
+  const delayBetweenRoles = 500;
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
   const getRandomSpeed = (baseSpeed) => {
     return baseSpeed + Math.random() * 50;
   };
 
-  // Typing and deleting effect logic
   useEffect(() => {
     const currentRole = `${ROLES[roleIndex]}.`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, getRandomSpeed(baseTypingSpeed));
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
       timer = setTimeout(() => {
         setDeleting(true);
       }, delayBeforeDeleting);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, getRandomSpeed(baseDeletingSpeed));
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, delayBetweenRoles);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
     const blinkCursor = setInterval(() => {
       setCursorVisible((prev) => !prev);
-    }, 300);
+    }, 400);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.15rem', sm: '1.5rem', md: '1.75rem' },
+        fontWeight: 500,
+        color: 'rgba(240, 240, 245, 0.6)',
+        letterSpacing: '-0.01em',
+        minHeight: '2.5rem',
       }}
     >
       I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0, transition: 'opacity 0.1s' }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -40,34 +40,34 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', variant: 'primary' },
+  { label: 'Tell me about your experience', variant: 'secondary' },
+  { label: 'Featured projects', variant: 'neutral' },
 ];
+
+const chipStyles = {
+  primary: {
+    bg: 'rgba(56,192,242,0.08)',
+    border: 'rgba(56,192,242,0.25)',
+    color: '#38c0f2',
+    hoverBg: 'rgba(56,192,242,0.16)',
+    hoverBorder: 'rgba(56,192,242,0.5)',
+  },
+  secondary: {
+    bg: 'rgba(139,92,246,0.08)',
+    border: 'rgba(139,92,246,0.25)',
+    color: '#a78bfa',
+    hoverBg: 'rgba(139,92,246,0.16)',
+    hoverBorder: 'rgba(139,92,246,0.5)',
+  },
+  neutral: {
+    bg: 'rgba(255,255,255,0.04)',
+    border: 'rgba(255,255,255,0.12)',
+    color: 'rgba(240,240,245,0.7)',
+    hoverBg: 'rgba(255,255,255,0.08)',
+    hoverBorder: 'rgba(255,255,255,0.25)',
+  },
+};
 
 const HeroChat = () => {
   const [input, setInput] = useState('');
@@ -89,7 +89,7 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#f0f0f5', zIndex: 1 }}>
       {/* Pre-chat view */}
       <Box
         sx={{
@@ -99,7 +99,7 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
           transform: started ? 'translateY(-10px)' : 'translateY(0)',
@@ -110,73 +110,85 @@ const HeroChat = () => {
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
+            fontSize: 'clamp(2.25rem, 6vw, 3.75rem)',
+            fontWeight: 800,
             lineHeight: 1.1,
             textAlign: 'center',
+            letterSpacing: '-0.03em',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          <span style={{ color: '#f0f0f5' }}>Hello, I&apos;m </span>
+          <Box
+            component="span"
+            sx={{
+              background: 'linear-gradient(135deg, #38c0f2, #8b5cf6)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
+            David
+          </Box>
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask me anything about David...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', textTransform: 'none', letterSpacing: 0, minHeight: '1.2em' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
-          {CHIPS.map((chip) => (
-            <Chip
-              key={chip.label}
-              label={chip.label}
-              disabled={!hasToken}
-              onClick={() => {
-                const cached = CHIP_CACHE[chip.label];
-                if (cached) addCachedExchange(chip.label, cached);
-                else sendMessage(chip.label);
-                setInput('');
-              }}
-              sx={{
-                height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
-                },
-                '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
-                },
-                '&.Mui-disabled': { opacity: 0.4 },
-              }}
-            />
-          ))}
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ mt: 0.5 }}>
+          {CHIPS.map((chip) => {
+            const s = chipStyles[chip.variant];
+            return (
+              <Chip
+                key={chip.label}
+                label={chip.label}
+                disabled={!hasToken}
+                onClick={() => {
+                  const cached = CHIP_CACHE[chip.label];
+                  if (cached) addCachedExchange(chip.label, cached);
+                  else sendMessage(chip.label);
+                  setInput('');
+                }}
+                sx={{
+                  height: 'auto',
+                  background: s.bg,
+                  border: `1px solid ${s.border}`,
+                  borderRadius: '10px',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                  '& .MuiChip-label': {
+                    color: s.color,
+                    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+                    fontSize: '0.82rem',
+                    fontWeight: 500,
+                    px: 1.5,
+                    py: 0.85,
+                  },
+                  '&:hover': {
+                    background: s.hoverBg,
+                    borderColor: s.hoverBorder,
+                    transform: 'translateY(-1px)',
+                  },
+                  '&.Mui-disabled': { opacity: 0.35 },
+                }}
+              />
+            );
+          })}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -202,26 +214,44 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 36,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
+            gap: 0.75,
+            px: 2.5,
+            py: 1,
             borderRadius: '50px',
-            background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            color: 'rgba(240,240,245,0.6)',
+            fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+            fontWeight: 500,
+            fontSize: '0.8rem',
+            letterSpacing: '0.02em',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            backdropFilter: 'blur(8px)',
+            '&:hover': {
+              borderColor: 'rgba(255,255,255,0.25)',
+              color: '#f0f0f5',
+              background: 'rgba(255,255,255,0.06)',
+              transform: 'translateY(-2px)',
+            },
+            '@keyframes gentleBounce': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(3px)' },
+            },
+            animation: 'gentleBounce 2.5s ease-in-out infinite',
+            '&:hover': {
+              animation: 'none',
+              borderColor: 'rgba(255,255,255,0.25)',
+              color: '#f0f0f5',
+              background: 'rgba(255,255,255,0.06)',
+            },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          <KeyboardDoubleArrowDownIcon sx={{ fontSize: '1rem' }} />
+          Explore my work
         </Box>
       </Box>
 
@@ -237,7 +267,6 @@ const HeroChat = () => {
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +275,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.05)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #38c0f2, #8b5cf6)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
               fontWeight: 800,
-              fontSize: '1rem',
+              fontSize: '0.9rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +296,30 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2, color: '#f0f0f5' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.7rem', color: 'rgba(240,240,245,0.35)', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography sx={{ fontSize: '0.7rem', color: 'rgba(240,240,245,0.25)' }}>
+            &#8595; scroll for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.05)',
+            background: 'rgba(0,0,0,0.25)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +327,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,195 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
+import { Toolbar, Box, AppBar, Typography, IconButton, Drawer, List, ListItemButton, ListItemText } from '@mui/material';
 import { useState } from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
 import Logo from './Logo';
-import './ScrollLink.css';
-
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
 
 const pages = ['About', 'Projects', 'Contact'];
 
-const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
-
-  return (
-    <AppBar
-      position="fixed"
+const NavLink = ({ page, active, setActivePage }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-70}
+    duration={500}
+    onSetActive={() => setActivePage(page)}
+    style={{ textDecoration: 'none', cursor: 'pointer' }}
+  >
+    <Typography
       sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
+        mx: 2,
+        fontWeight: active ? 700 : 500,
+        fontSize: '0.85rem',
+        letterSpacing: '0.02em',
+        color: active ? '#38c0f2' : 'rgba(240, 240, 245, 0.5)',
+        position: 'relative',
+        py: 0.5,
+        transition: 'color 0.25s ease',
+        '&:hover': { color: '#f0f0f5' },
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          bottom: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: active ? '100%' : '0%',
+          height: '2px',
+          background: 'linear-gradient(90deg, #38c0f2, #8b5cf6)',
+          borderRadius: '1px',
+          transition: 'width 0.25s ease',
+        },
+        '&:hover::after': { width: '100%' },
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      {page}
+    </Typography>
+  </ScrollLink>
+);
+
+const MobileDrawerContent = ({ setOpen, setActivePage }) => (
+  <Box
+    sx={{
+      width: 280,
+      height: '100%',
+      background: 'rgba(10, 10, 20, 0.98)',
+      backdropFilter: 'blur(24px)',
+      display: 'flex',
+      flexDirection: 'column',
+    }}
+  >
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 2 }}>
+      <IconButton onClick={() => setOpen(false)} sx={{ color: 'rgba(240,240,245,0.5)' }}>
+        <CloseIcon />
+      </IconButton>
+    </Box>
+    <List sx={{ px: 2, mt: 2 }}>
+      {pages.map((page) => (
+        <ScrollLink
+          key={page}
+          to={page.toLowerCase()}
+          spy={true}
+          smooth={true}
+          offset={-70}
+          duration={500}
+          onSetActive={() => setActivePage(page)}
+          onClick={() => setOpen(false)}
+          style={{ textDecoration: 'none' }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
+          <ListItemButton
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              borderRadius: '12px',
+              mb: 1,
+              '&:hover': { background: 'rgba(255,255,255,0.04)' },
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
+            <ListItemText
+              primary={page}
+              primaryTypographyProps={{
+                fontWeight: 600,
+                fontSize: '1.1rem',
+                color: '#f0f0f5',
+                fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+              }}
+            />
+          </ListItemButton>
+        </ScrollLink>
+      ))}
+    </List>
+    <Box sx={{ mt: 'auto', p: 3, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+      <Typography sx={{ fontSize: '0.75rem', color: 'rgba(240,240,245,0.3)' }}>
+        davidriva.dev
+      </Typography>
+    </Box>
+  </Box>
+);
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
-        </Box>
-      </Toolbar>
-    </AppBar>
+const NavBar = () => {
+  const [activePage, setActivePage] = useState('About');
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <>
+      <AppBar
+        position="fixed"
+        sx={{
+          top: 0,
+          zIndex: 1100,
+          width: '100%',
+          bgcolor: 'rgba(10, 10, 20, 0.7)',
+          backdropFilter: 'blur(20px)',
+          height: '60px',
+          color: '#f0f0f5',
+          transition: 'all 0.3s ease',
+          borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
+          boxShadow: 'none',
+        }}
+      >
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: { xs: 2, md: 5 },
+            minHeight: '60px !important',
+          }}
+        >
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          >
+            <Logo />
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                fontSize: '1.15rem',
+                color: '#f0f0f5',
+              }}
+            >
+              DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
+            {pages.map((page) => (
+              <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            ))}
+          </Box>
+
+          <IconButton
+            onClick={() => setMobileOpen(true)}
+            sx={{
+              display: { xs: 'flex', md: 'none' },
+              color: 'rgba(240,240,245,0.7)',
+              '&:hover': { color: '#f0f0f5' },
+            }}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        anchor="right"
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        sx={{
+          display: { xs: 'block', md: 'none' },
+          '& .MuiDrawer-paper': {
+            background: 'transparent',
+            boxShadow: '-4px 0 24px rgba(0,0,0,0.4)',
+          },
+        }}
+      >
+        <MobileDrawerContent setOpen={setMobileOpen} setActivePage={setActivePage} />
+      </Drawer>
+    </>
   );
 };
 

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -6,125 +6,38 @@ import CardContent from '@mui/material/CardContent';
 import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
+const ProjectImage = ({ coverImage, title, featured }) => (
+  <Box
+    sx={{
+      position: 'relative',
+      height: featured ? '200px' : '170px',
+      width: '100%',
+      bgcolor: 'rgba(255,255,255,0.02)',
+      overflow: 'hidden',
+    }}
+  >
+    <Image
+      src={`/images/${coverImage}`}
+      alt={`${title} cover`}
+      style={{ objectFit: 'cover', transition: 'transform 0.6s cubic-bezier(0.16, 1, 0.3, 1)' }}
+      className="project-image"
+      fill
+      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+    />
     <Box
       sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
+        position: 'absolute',
+        inset: 0,
+        background: 'linear-gradient(to bottom, transparent 30%, rgba(10, 10, 20, 0.8) 100%)',
       }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
+    />
+  </Box>
+);
 
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
@@ -133,37 +46,98 @@ const ProjectCard = forwardRef(
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
-          borderRadius: '16px',
+          bgcolor: featured ? 'rgba(56,192,242,0.02)' : 'rgba(255, 255, 255, 0.02)',
+          color: '#f0f0f5',
+          border: featured ? '1px solid rgba(56, 192, 242, 0.12)' : '1px solid rgba(255,255,255,0.05)',
+          borderRadius: '18px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+          transition: 'all 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
           cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            border: featured ? '1px solid rgba(56, 192, 242, 0.25)' : '1px solid rgba(255,255,255,0.12)',
+            boxShadow: '0 16px 40px rgba(0,0,0,0.3)',
+            '& .project-image': { transform: 'scale(1.04)' },
           },
         }}
         onClick={onClick}
       >
         <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
-          />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 2.5 : 2.5 }}>
+          <Box sx={{ mb: 1.5 }}>
+            <Typography
+              component="h3"
+              sx={{ fontWeight: 700, mb: 0.5, color: '#f0f0f5', lineHeight: 1.3, fontSize: featured ? '0.95rem' : '0.9rem' }}
+            >
+              {title}
+            </Typography>
+            <Typography sx={{ color: 'rgba(240,240,245,0.3)', fontSize: '0.7rem', fontWeight: 500, mb: 1.5 }}>
+              {dateStarted} &ndash; {dateCompleted}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'rgba(240,240,245,0.5)',
+                lineHeight: 1.65,
+                mb: 2,
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                fontSize: '0.8rem',
+              }}
+            >
+              {short_description}
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
+            {allTools.map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(56, 192, 242, 0.06)',
+                  color: 'rgba(56, 192, 242, 0.8)',
+                  border: '1px solid rgba(56, 192, 242, 0.12)',
+                  fontSize: '0.65rem',
+                  fontWeight: 500,
+                  height: '22px',
+                  borderRadius: '6px',
+                  '& .MuiChip-label': { px: 0.75 },
+                }}
+              />
+            ))}
+          </Stack>
+
+          <Button
+            variant="outlined"
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={<LaunchIcon sx={{ fontSize: '0.85rem !important' }} />}
+            fullWidth
+            sx={{
+              mt: 'auto',
+              color: 'rgba(240,240,245,0.6)',
+              borderColor: 'rgba(255,255,255,0.08)',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '0.78rem',
+              fontWeight: 500,
+              py: 0.75,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                borderColor: 'rgba(56,192,242,0.3)',
+                color: '#38c0f2',
+                bgcolor: 'rgba(56, 192, 242, 0.04)',
+              },
+            }}
+          >
+            View Project
+          </Button>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -10,18 +10,13 @@ const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
+        pt: { xs: 6, md: 8 },
+        pb: { xs: 6, md: 8 },
         margin: '0 auto',
         textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
       }}
     >
       <SectionHeading sectionName="Projects" />
-
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,12 +18,12 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
+        duration: 0.65,
+        stagger: 0.1,
         ease: 'power3.out',
         scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
       }
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -54,14 +54,14 @@ const AllProjects = ({ projects }) => {
     const cards = containerRef.current.querySelectorAll('.all-card-item');
     gsap.fromTo(
       cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
+      { y: 20, opacity: 0 },
+      { y: 0, opacity: 1, duration: 0.5, stagger: 0.07, ease: 'power2.out' }
     );
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,22 +92,21 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%', maxWidth: '1200px', margin: '0 auto', px: { xs: 2, md: 4 } }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.02)', borderRadius: '18px', border: '1px solid rgba(255,255,255,0.05)' }}>
+                <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.2rem', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <Box>
           <FeaturedProjects projects={featuredProjects} />
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
@@ -115,22 +114,21 @@ const ProjectsContainer = () => {
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
+                color: 'rgba(240,240,245,0.45)',
+                borderColor: 'rgba(255,255,255,0.08)',
                 border: '1px solid',
                 borderRadius: '50px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.8rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
+                bgcolor: 'rgba(255,255,255,0.02)',
                 transition: 'all 0.25s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.05)',
+                  borderColor: 'rgba(255,255,255,0.15)',
+                  color: '#f0f0f5',
                 },
               }}
             >

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -2,40 +2,27 @@ import { Box, Typography } from '@mui/material';
 
 const SectionHeading = ({ sectionName }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: 6, display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 2 }}>
       <Typography
-        variant="h2"
+        variant="overline"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          color: '#38c0f2',
+          fontSize: '0.7rem',
+          letterSpacing: '0.15em',
+          fontWeight: 600,
+          mb: 1.5,
         }}
       >
         {sectionName}
       </Typography>
+      <Box
+        sx={{
+          width: 32,
+          height: 2,
+          background: 'linear-gradient(90deg, #38c0f2, #8b5cf6)',
+          borderRadius: '1px',
+        }}
+      />
     </Box>
   );
 };

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,40 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#0a0a14',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#f0f0f5',
+      secondary: 'rgba(240, 240, 245, 0.5)',
     },
     primary: {
       main: '#38c0f2',
+      light: '#5ed0f7',
+      dark: '#1a9fd4',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#8b5cf6',
+      light: '#a78bfa',
+      dark: '#6e40c9',
     },
+    divider: 'rgba(255, 255, 255, 0.06)',
+  },
+  shape: {
+    borderRadius: 16,
   },
   typography: {
     fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    h1: { fontWeight: 800, fontSize: '3.25rem', letterSpacing: '-0.03em', lineHeight: 1.1 },
+    h2: { fontWeight: 800, fontSize: '2.75rem', letterSpacing: '-0.02em', lineHeight: 1.15 },
+    h3: { fontWeight: 700, fontSize: '1.5rem', letterSpacing: '-0.01em', lineHeight: 1.3 },
+    h4: { fontWeight: 700, fontSize: '1.15rem', lineHeight: 1.4 },
+    h5: { fontWeight: 600, fontSize: '1rem', lineHeight: 1.4 },
+    h6: { fontWeight: 600, fontSize: '0.875rem', lineHeight: 1.4 },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '0.925rem' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.825rem' },
+    caption: { fontWeight: 500, fontSize: '0.7rem', letterSpacing: '0.08em' },
+    overline: { fontWeight: 600, fontSize: '0.7rem', letterSpacing: '0.12em', textTransform: 'uppercase' },
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual redesign of the portfolio website, touching every section and 16 files across the frontend. The redesign modernizes the UI with 2026 design patterns while preserving all existing functionality (chat agent, auth, API routes, data files).

### Key changes:

- **Bento grid About section** — replaces the old linear About layout with a 4-card grid (Bio, Skills, Experience, Awards), pulling in skills and awards data that previously had unused components
- **Mobile navigation** — adds a hamburger menu with a slide-out drawer, fixing the gap where mobile users had no way to navigate between sections
- **Refined design system** — consistent border-radius tokens (20px cards, 12px inputs, 10px icons), cohesive color palette, tighter typography scale, gradient fade section dividers
- **Polished component styling** — every component updated: NavBar (frosted glass), Hero (gradient text, refined chips), Projects (cleaner cards), Contact (side-by-side fields, better states), Footer (minimal), Chat (refined bubbles and input)

### What's preserved:
- All API routes (chat, token, contact, health) untouched
- Chat agent functionality (useChat hook, streaming, Turnstile auth) fully intact
- All data files and embeddings unchanged
- GSAP scroll animations retained and refined

## Test plan

- [ ] Verify hero section renders with animated typing and chat input
- [ ] Test chat agent: click a quick-reply chip, verify cached response renders
- [ ] Test chat agent: type a custom question, verify streaming response works
- [ ] Scroll down — verify About bento grid loads with bio, skills, experience, awards cards
- [ ] Verify GSAP scroll animations trigger on bento cards and project cards
- [ ] Test "View all N projects" expand/collapse
- [ ] Test contact form submission flow with Turnstile captcha
- [ ] Verify mobile: hamburger menu opens drawer, nav links scroll to sections and close drawer
- [ ] Verify footer back-to-top button scrolls to top
- [ ] Run `npm run build` with env vars to confirm clean compilation

https://claude.ai/code/session_016cC4g5uw6tevr3kYjtJdCt

---
_Generated by [Claude Code](https://claude.ai/code/session_016cC4g5uw6tevr3kYjtJdCt)_