### PR TITLE
Redesign portfolio with modern 2026 UI

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,40 +2,48 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    'Software engineer specializing in applied AI, full-stack development, and data systems. View projects, experience, and get in touch.',
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'AI Engineer',
+    'Full Stack Developer',
+    'Portfolio',
+    'React',
+    'Next.js',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI engineer and full-stack developer. Explore projects, experience, and more.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: 'David Riva — Software Engineer',
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI engineer and full-stack developer.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +51,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={inter.variable}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,84 +2,97 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
-
-const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
-const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
-const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
+
+const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience-Page/Experience'), { ssr: false });
+const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
+const Skills = dynamic(() => import('@/components/Skills-Page/Skills'), { ssr: false });
+const Awards = dynamic(() => import('@/components/Awards-Page/Awards'), { ssr: false });
+const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         position: 'relative',
         minHeight: '100vh',
       }}
     >
       <NavBar />
 
+      {/* Hero section */}
       <Box
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background: 'radial-gradient(ellipse at 50% 0%, rgba(56,189,248,0.06) 0%, transparent 60%)',
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
+        {/* Dot grid background */}
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: 'radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px)',
+            backgroundSize: '32px 32px',
+            maskImage: 'radial-gradient(ellipse at center, black 30%, transparent 70%)',
+            WebkitMaskImage: 'radial-gradient(ellipse at center, black 30%, transparent 70%)',
+          }}
+        />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
+      {/* Content sections */}
+      <Box id="about">
+        <About />
+      </Box>
 
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
+      <Box
+        id="experience"
+        sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+      >
+        <Experience />
+      </Box>
 
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+      <Box
+        id="projects"
+        sx={{
+          borderTop: '1px solid rgba(255,255,255,0.04)',
+          position: 'relative',
+        }}
+      >
+        <Projects />
+      </Box>
+
+      <Box
+        id="skills"
+        sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+      >
+        <Skills />
+      </Box>
+
+      <Box
+        id="awards"
+        sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+      >
+        <Awards />
+      </Box>
+
+      <Box
+        id="contact"
+        sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+      >
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,195 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
+import { Box, Typography, IconButton, Link, Button, Chip, Stack } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
+import FadeIn from '@/components/FadeIn';
+import SectionHeading from '@/components/SectionHeading';
+
+const glassCard = {
+  background: 'rgba(255, 255, 255, 0.02)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '16px',
+  p: { xs: 3, md: 4 },
+  transition: 'border-color 0.3s ease, background 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+    background: 'rgba(255, 255, 255, 0.03)',
+  },
 };
+
+const StatCard = ({ value, label, delay }) => (
+  <FadeIn delay={delay}>
+    <Box sx={{ ...glassCard, textAlign: 'center', p: 3 }}>
+      <Typography sx={{ fontSize: '2rem', fontWeight: 700, color: '#38bdf8', lineHeight: 1 }}>{value}</Typography>
+      <Typography sx={{ fontSize: '0.78rem', color: '#71717a', mt: 1, fontWeight: 500 }}>{label}</Typography>
+    </Box>
+  </FadeIn>
+);
 
 const About = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
-      }}
-    >
+    <Box sx={{ maxWidth: '1100px', mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="About" subtitle="Who I am" />
+
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '300px 1fr' },
+          gridTemplateRows: 'auto',
+          gap: 2.5,
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Photo card */}
+        <FadeIn delay={0.05}>
+          <Box
+            sx={{
+              ...glassCard,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              py: 5,
+              gridRow: { md: '1 / 3' },
+            }}
+          >
+            <Box
+              sx={{
+                width: 180,
+                height: 180,
+                borderRadius: '50%',
+                overflow: 'hidden',
+                border: '2px solid rgba(56, 189, 248, 0.15)',
+                mb: 3,
+              }}
+            >
+              <Image
+                src="/images/headshot.webp"
+                alt="David Riva"
+                width={180}
+                height={180}
+                style={{ objectFit: 'cover' }}
+                priority
+              />
+            </Box>
+
+            <Typography sx={{ fontWeight: 600, fontSize: '1.1rem', color: '#fafafa' }}>David Riva</Typography>
+            <Typography sx={{ fontSize: '0.82rem', color: '#38bdf8', fontWeight: 500, mt: 0.5 }}>
+              Training Engineer, Generative AI
+            </Typography>
+
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1.5, color: '#71717a' }}>
+              <LocationOnOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+              <Typography sx={{ fontSize: '0.78rem' }}>Bay Area, CA</Typography>
+            </Stack>
+
+            <Stack direction="row" spacing={0.5} sx={{ mt: 2.5 }}>
+              <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+                <IconButton
+                  aria-label="GitHub"
+                  size="small"
+                  sx={{
+                    color: '#71717a',
+                    '&:hover': { color: '#fafafa', backgroundColor: 'rgba(255,255,255,0.06)' },
+                  }}
+                >
+                  <GitHubIcon fontSize="small" />
+                </IconButton>
+              </Link>
+              <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+                <IconButton
+                  aria-label="LinkedIn"
+                  size="small"
+                  sx={{
+                    color: '#71717a',
+                    '&:hover': { color: '#38bdf8', backgroundColor: 'rgba(56,189,248,0.06)' },
+                  }}
+                >
+                  <LinkedInIcon fontSize="small" />
+                </IconButton>
+              </Link>
+              <Link href="mailto:davidjriva@gmail.com">
+                <IconButton
+                  aria-label="Email"
+                  size="small"
+                  sx={{
+                    color: '#71717a',
+                    '&:hover': { color: '#fafafa', backgroundColor: 'rgba(255,255,255,0.06)' },
+                  }}
+                >
+                  <EmailOutlinedIcon fontSize="small" />
+                </IconButton>
+              </Link>
+            </Stack>
+
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<DescriptionOutlinedIcon sx={{ fontSize: '0.9rem' }} />}
+              onClick={() => window.open('/documents/resume.pdf', '_blank')}
+              sx={{
+                mt: 2.5,
+                color: '#a1a1aa',
+                borderColor: 'rgba(255,255,255,0.1)',
+                borderRadius: '10px',
+                textTransform: 'none',
+                fontSize: '0.78rem',
+                fontWeight: 500,
+                px: 2,
+                '&:hover': {
+                  borderColor: 'rgba(255,255,255,0.2)',
+                  backgroundColor: 'rgba(255,255,255,0.04)',
+                  color: '#fafafa',
+                },
+              }}
+            >
+              View Resume
+            </Button>
+          </Box>
+        </FadeIn>
+
+        {/* Bio card */}
+        <FadeIn delay={0.1}>
+          <Box sx={glassCard}>
+            <Typography variant="body1" sx={{ color: '#d4d4d8', lineHeight: 1.8 }}>
+              Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area — a Colorado State University
+              graduate with a B.S. in Computer Science, Summa Cum Laude. I&apos;m passionate about applied AI and
+              building systems that work at scale.
+            </Typography>
+            <Typography variant="body1" sx={{ color: '#d4d4d8', lineHeight: 1.8, mt: 2 }}>
+              I specialize in full-stack development, AI/ML engineering, and data systems. I pride myself on elegant
+              problem-solving and consistently delivering high-quality work.
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 3 }}>
+              {['AI/ML', 'Full-Stack', 'RAG Systems', 'React', 'Python', 'TypeScript'].map((tag) => (
+                <Chip
+                  key={tag}
+                  label={tag}
+                  size="small"
+                  sx={{
+                    bgcolor: 'rgba(56,189,248,0.06)',
+                    color: '#38bdf8',
+                    border: '1px solid rgba(56,189,248,0.12)',
+                    fontSize: '0.72rem',
+                    height: '24px',
+                    fontWeight: 500,
+                  }}
+                />
+              ))}
+            </Stack>
+          </Box>
+        </FadeIn>
+
+        {/* Stats row */}
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 2 }}>
+          <StatCard value="2+" label="Years Experience" delay={0.15} />
+          <StatCard value="11" label="Projects Built" delay={0.2} />
+          <StatCard value="4.0" label="GPA" delay={0.25} />
         </Box>
-      </Box>
-
-      <AboutTextSection />
-
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
       </Box>
     </Box>
   );

--- a/next-app/src/components/Awards-Page/Awards.js
+++ b/next-app/src/components/Awards-Page/Awards.js
@@ -1,42 +1,65 @@
-import React from 'react';
-import { Box, Divider } from '@mui/material';
-import AwardCard from './AwardCard';
-import SectionHeading from '@/components/SectionHeading';
+'use client';
 
-export const metadata = {
-  title: 'David Riva | Awards',
-};
+import { useState, useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
+import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
+import SectionHeading from '@/components/SectionHeading';
+import FadeIn from '@/components/FadeIn';
+
+const AwardItem = ({ title, description, date, delay }) => (
+  <FadeIn delay={delay}>
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 2.5,
+        p: 3,
+        background: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: '16px',
+        transition: 'border-color 0.3s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.1)' },
+      }}
+    >
+      <Box
+        sx={{
+          width: 36,
+          height: 36,
+          borderRadius: '10px',
+          backgroundColor: 'rgba(250, 204, 21, 0.08)',
+          border: '1px solid rgba(250, 204, 21, 0.15)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <EmojiEventsOutlinedIcon sx={{ fontSize: '1rem', color: '#facc15' }} />
+      </Box>
+      <Box>
+        <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', color: '#fafafa', lineHeight: 1.3 }}>{title}</Typography>
+        <Typography sx={{ fontSize: '0.72rem', color: '#52525b', mt: 0.25 }}>{date}</Typography>
+        <Typography sx={{ fontSize: '0.82rem', color: '#a1a1aa', mt: 1, lineHeight: 1.5 }}>{description}</Typography>
+      </Box>
+    </Box>
+  </FadeIn>
+);
 
 const Awards = () => {
-  const [awardsData, setAwardsData] = useState([]);
+  const [awards, setAwards] = useState([]);
 
   useEffect(() => {
     fetch('/data/awards.json')
       .then((res) => res.json())
-      .then((data) => setAwardsData(data));
+      .then(setAwards);
   }, []);
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '5rem',
-        position: 'relative',
-        borderTop: '8px solid rgba(0,0,0,0.1)',
-        boxShadow: '0px 1px 0px rgba(255,255,255,0.2)',
-      }}
-    >
-      <SectionHeading sectionName="Awards" />
+    <Box sx={{ maxWidth: '700px', mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Awards" subtitle="Recognition" />
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', lineHeight: 1.6 }}>
-        {awardsData.map((award, index) => (
-          <React.Fragment key={award.title}>
-            <AwardCard {...award} />
-            {index < awardsData.length - 1 && <Divider sx={{ backgroundColor: 'lightgray' }} />}
-          </React.Fragment>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {awards.map((award, i) => (
+          <AwardItem key={award.title} {...award} delay={i * 0.08} />
         ))}
       </Box>
     </Box>

--- a/next-app/src/components/Chat-Page/BouncingDotsLoadingAnimation.jsx
+++ b/next-app/src/components/Chat-Page/BouncingDotsLoadingAnimation.jsx
@@ -1,40 +1,25 @@
-import React from 'react';
 import { Box } from '@mui/material';
 
-const BouncingDotsLoadingAnimation = ({
-  dotSize = 4,
-  dotColor = '#a3a1a1',
-  spacing = 4,
-  animationDuration = 0.6,
-  jumpHeight = 4,
-}) => {
-  const dotStyle = (delay) => ({
+const BouncingDotsLoadingAnimation = ({ dotSize = 5, dotColor = '#38bdf8', spacing = 3 }) => {
+  const dot = (delay) => ({
     width: dotSize,
     height: dotSize,
-    margin: `2px ${spacing}px`,
+    margin: `0 ${spacing}px`,
     borderRadius: '50%',
     backgroundColor: dotColor,
-    opacity: 1,
-    animation: `bouncing-loader ${animationDuration}s infinite alternate`,
+    animation: `pulse 1.2s ease-in-out infinite`,
     animationDelay: `${delay}s`,
+    '@keyframes pulse': {
+      '0%, 100%': { opacity: 0.3, transform: 'scale(0.8)' },
+      '50%': { opacity: 1, transform: 'scale(1)' },
+    },
   });
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="center">
-      <Box sx={dotStyle(0)} />
-      <Box sx={dotStyle(0.2)} />
-      <Box sx={dotStyle(0.4)} />
-
-      <style>
-        {`
-          @keyframes bouncing-loader {
-            to {
-              opacity: 0.1;
-              transform: translateY(-${jumpHeight}px);
-            }
-          }
-        `}
-      </style>
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={dot(0)} />
+      <Box sx={dot(0.2)} />
+      <Box sx={dot(0.4)} />
     </Box>
   );
 };

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -12,14 +12,15 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
-        borderRadius: '999px',
+        p: '6px 6px 6px 16px',
+        borderRadius: '14px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        border: '1px solid rgba(255,255,255,0.08)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.15)' },
+        '&:focus-within': { borderColor: 'rgba(56,189,248,0.4)' },
       }}
     >
       <InputBase
@@ -34,24 +35,27 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontSize: '0.9rem',
+          '& input::placeholder': { color: '#52525b', opacity: 1 },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          background: 'rgba(56,189,248,0.15)',
+          border: '1px solid rgba(56,189,248,0.25)',
+          transition: 'all 0.2s ease',
+          '&:hover': { background: 'rgba(56,189,248,0.25)' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <ArrowUpwardIcon sx={{ color: '#38bdf8', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,58 +7,53 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
-    marginBottom: '4px',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#e4e4e7',
+    mb: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
-          px: 2.5,
+          px: 2,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(56,189,248,0.08)' : 'rgba(255,255,255,0.03)',
+          border: isUser ? '1px solid rgba(56,189,248,0.15)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={6} dotColor="#38bdf8" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
-                li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
-                em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                li: (props) => (
+                  <li style={{ lineHeight: 1.65, fontSize: '0.9rem', color: '#e4e4e7', marginBottom: '4px' }} {...props} />
+                ),
+                strong: (props) => <strong style={{ fontWeight: 600, color: '#fafafa' }} {...props} />,
+                em: (props) => <em style={{ color: '#e4e4e7' }} {...props} />,
+                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />,
+                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.1rem', mt: 1.5, mb: 0.8 }} {...props} />,
+                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1rem', mt: 1, mb: 0.5 }} {...props} />,
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#38bdf8',
+                      backgroundColor: 'rgba(56,189,248,0.08)',
+                      px: '4px',
+                      py: '1px',
+                      borderRadius: '4px',
+                      fontSize: '0.85rem',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +62,32 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.3)',
+                      color: '#e4e4e7',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.85rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{ color: '#38bdf8', textDecoration: 'none', fontWeight: 500 }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { Box } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
@@ -10,30 +9,14 @@ const Contact = () => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '600px',
+        mx: 'auto',
+        px: { xs: 2, md: 4 },
+        py: { xs: 8, md: 12 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
-        <ContactForm />
-      </Box>
+      <SectionHeading sectionName="Contact" subtitle="Get in touch" />
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,19 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': { color: '#52525b', fontSize: '0.88rem' },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    borderRadius: '12px',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.12)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(56, 189, 248, 0.4)', borderWidth: '1px' },
   },
 };
 
@@ -49,21 +52,36 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        background: 'rgba(255, 255, 255, 0.02)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        p: { xs: 3, md: 4 },
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +96,27 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.9rem' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            py: 1.5,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            background: 'rgba(56, 189, 248, 0.12)',
+            border: '1px solid rgba(56, 189, 248, 0.2)',
+            color: '#38bdf8',
+            borderRadius: '12px',
+            textTransform: 'none',
+            boxShadow: 'none',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'rgba(56, 189, 248, 0.18)',
+              borderColor: 'rgba(56, 189, 248, 0.35)',
+              boxShadow: 'none',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.03)',
+              border: '1px solid rgba(255, 255, 255, 0.06)',
+              color: '#3f3f46',
             },
           }}
         >
@@ -103,9 +128,10 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.82rem',
+            color: status.includes('success') ? '#4ade80' : '#f87171',
           }}
         >
           {status}

--- a/next-app/src/components/Experience-Page/Experience.js
+++ b/next-app/src/components/Experience-Page/Experience.js
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack, Collapse, IconButton } from '@mui/material';
+import Image from 'next/image';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import SectionHeading from '@/components/SectionHeading';
+import FadeIn from '@/components/FadeIn';
+
+const ExperienceCard = ({ experience, index }) => {
+  const [expanded, setExpanded] = useState(false);
+  const isCurrent = experience.endDate === 'Present' || experience.endDate === 'April 2026';
+  const isGraduation = experience.title.startsWith('Graduated');
+
+  return (
+    <FadeIn delay={index * 0.08}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: { xs: 2, md: 3 },
+          position: 'relative',
+        }}
+      >
+        {/* Timeline line */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            flexShrink: 0,
+            width: 40,
+          }}
+        >
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: '12px',
+              backgroundColor: 'rgba(255,255,255,0.03)',
+              border: isCurrent ? '1px solid rgba(56,189,248,0.25)' : '1px solid rgba(255,255,255,0.06)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              overflow: 'hidden',
+              flexShrink: 0,
+            }}
+          >
+            <Image
+              src={`/images/${experience.logoImage}`}
+              alt={`${experience.company} logo`}
+              width={24}
+              height={24}
+              style={{ objectFit: 'contain' }}
+            />
+          </Box>
+          <Box
+            sx={{
+              width: '1px',
+              flex: 1,
+              background: 'linear-gradient(to bottom, rgba(255,255,255,0.08), transparent)',
+              mt: 1,
+            }}
+          />
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ pb: 5, flex: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1 }}>
+            <Box>
+              <Typography sx={{ fontWeight: 600, fontSize: '0.95rem', color: '#fafafa', lineHeight: 1.3 }}>
+                {isGraduation ? 'B.S. Computer Science — Summa Cum Laude' : experience.title}
+              </Typography>
+              <Typography
+                component="a"
+                href={experience.companyWebsiteLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  fontSize: '0.82rem',
+                  color: '#38bdf8',
+                  textDecoration: 'none',
+                  fontWeight: 500,
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {experience.company}
+              </Typography>
+              <Typography sx={{ fontSize: '0.75rem', color: '#52525b', mt: 0.5 }}>
+                {experience.startDate} — {experience.endDate}
+                {experience.location && ` · ${experience.location}`}
+              </Typography>
+            </Box>
+
+            {experience.bulletPoints && experience.bulletPoints.length > 0 && (
+              <IconButton
+                size="small"
+                onClick={() => setExpanded(!expanded)}
+                sx={{
+                  color: '#52525b',
+                  transform: expanded ? 'rotate(180deg)' : 'rotate(0)',
+                  transition: 'transform 0.2s ease',
+                  '&:hover': { color: '#a1a1aa' },
+                }}
+              >
+                <ExpandMoreIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Box>
+
+          <Collapse in={expanded} timeout={300}>
+            {experience.bulletPoints && (
+              <Box component="ul" sx={{ mt: 1.5, pl: 2, mb: 0 }}>
+                {experience.bulletPoints.map((point, i) => (
+                  <Box
+                    component="li"
+                    key={i}
+                    sx={{
+                      color: '#a1a1aa',
+                      fontSize: '0.82rem',
+                      lineHeight: 1.6,
+                      mb: 0.75,
+                      '&::marker': { color: '#3f3f46' },
+                    }}
+                  >
+                    {point}
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Collapse>
+        </Box>
+      </Box>
+    </FadeIn>
+  );
+};
+
+const Experience = () => {
+  const [experiences, setExperiences] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setExperiences(sorted);
+      });
+  }, []);
+
+  return (
+    <Box sx={{ maxWidth: '700px', mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Experience" subtitle="Where I've worked" />
+
+      <Box>
+        {experiences.map((exp, i) => (
+          <ExperienceCard key={exp.title} experience={exp} index={i} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/FadeIn.jsx
+++ b/next-app/src/components/FadeIn.jsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { useInView } from 'react-intersection-observer';
+
+const FadeIn = ({ children, delay = 0, direction = 'up', sx, ...props }) => {
+  const { ref, inView } = useInView({ triggerOnce: true, threshold: 0.1 });
+
+  const translateMap = {
+    up: 'translateY(24px)',
+    down: 'translateY(-24px)',
+    left: 'translateX(24px)',
+    right: 'translateX(-24px)',
+    none: 'none',
+  };
+
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        opacity: inView ? 1 : 0,
+        transform: inView ? 'none' : translateMap[direction],
+        transition: `opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s`,
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default FadeIn;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,41 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
+        borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        py: 4,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        gap: 2,
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <IconButton
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          width: 36,
+          height: 36,
+          borderRadius: '10px',
+          border: '1px solid rgba(255,255,255,0.06)',
+          color: '#52525b',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            borderColor: 'rgba(255,255,255,0.12)',
+            color: '#a1a1aa',
+            transform: 'translateY(-2px)',
+          },
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        <KeyboardArrowUpIcon fontSize="small" />
+      </IconButton>
+
+      <Typography sx={{ fontSize: '0.75rem', color: '#3f3f46' }}>
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -3,81 +3,63 @@
 import { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
-  const getArticle = (role) => {
-    const vowels = ['a', 'e', 'i', 'o', 'u'];
-    return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
-  };
-
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = ROLES[roleIndex];
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
-      timer = setTimeout(() => {
-        setText((prev) => prev + currentRole[index]);
-        setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev + currentRole[index]);
+          setIndex((prev) => prev + 1);
+        },
+        80 + Math.random() * 40
+      );
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 2000);
     } else if (deleting && index > 0) {
-      // Deleting logic
-      timer = setTimeout(() => {
-        setText((prev) => prev.slice(0, -1));
-        setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev.slice(0, -1));
+          setIndex((prev) => prev - 1);
+        },
+        35 + Math.random() * 20
+      );
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
-    return () => clearInterval(blinkCursor);
+    const blink = setInterval(() => setCursorVisible((prev) => !prev), 500);
+    return () => clearInterval(blink);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.3rem', md: '1.5rem' },
+        fontWeight: 400,
+        color: '#a1a1aa',
+        fontFamily: 'var(--font-inter), system-ui, sans-serif',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {text}
+      <span style={{ color: '#38bdf8', opacity: cursorVisible ? 1 : 0, transition: 'opacity 0.1s' }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -36,38 +36,35 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 
 **[Agentic AI News Summary Service](https://github.com/davidjriva/Agentic_AI_News_Summary_Service)** *(Feb – Mar 2025)* — an automated newsletter pipeline that fetches from 10+ RSS feeds, scores articles with Claude (using prompt caching), and emails a ranked daily digest. Runs on a launchd schedule with a FastAPI dashboard — no infrastructure needed.
 
-**[This portfolio](https://github.com/davidjriva/Personal-Portfolio)** *(Nov 2024 – Apr 2025)* — the site you're on now. It has an embedded GPT-4o-mini RAG agent, streaming SSE responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval automated eval suite. Built with Next.js, React, and MUI.`,
+**[This portfolio](https://github.com/davidjriva/Personal-Portfolio)** *(Nov 2024 – Apr 2025)* — the site you're on now. It has an embedded GPT-4o-mini RAG agent, streaming responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval automated eval suite. Built with Next.js, React, and MUI.`,
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', variant: 'primary' },
+  { label: 'Tell me about your experience', variant: 'secondary' },
+  { label: 'Featured projects', variant: 'ghost' },
 ];
+
+const chipStyles = {
+  primary: {
+    bg: 'rgba(56, 189, 248, 0.08)',
+    border: 'rgba(56, 189, 248, 0.2)',
+    color: '#38bdf8',
+    hover: { bg: 'rgba(56, 189, 248, 0.14)', border: 'rgba(56, 189, 248, 0.4)' },
+  },
+  secondary: {
+    bg: 'rgba(167, 139, 250, 0.08)',
+    border: 'rgba(167, 139, 250, 0.2)',
+    color: '#a78bfa',
+    hover: { bg: 'rgba(167, 139, 250, 0.14)', border: 'rgba(167, 139, 250, 0.4)' },
+  },
+  ghost: {
+    bg: 'rgba(255, 255, 255, 0.04)',
+    border: 'rgba(255, 255, 255, 0.1)',
+    color: '#a1a1aa',
+    hover: { bg: 'rgba(255, 255, 255, 0.08)', border: 'rgba(255, 255, 255, 0.2)' },
+  },
+};
 
 const HeroChat = () => {
   const [input, setInput] = useState('');
@@ -78,8 +75,8 @@ const HeroChat = () => {
   const scrollToAbout = () => {
     const section = document.getElementById('about');
     if (!section) return;
-    const elementPosition = section.getBoundingClientRect().top + window.scrollY;
-    window.scrollTo({ top: elementPosition - 70, behavior: 'smooth' });
+    const y = section.getBoundingClientRect().top + window.scrollY;
+    window.scrollTo({ top: y - 80, behavior: 'smooth' });
   };
 
   const handleSend = () => {
@@ -89,8 +86,8 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#fafafa', zIndex: 1 }}>
+      {/* Pre-chat: hero greeting */}
       <Box
         sx={{
           position: 'absolute',
@@ -99,84 +96,82 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 0.4s ease, transform 0.4s ease',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
+            fontSize: { xs: '2.5rem', sm: '3.5rem', md: '4.5rem' },
             textAlign: 'center',
+            mb: -1,
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          David Riva
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 2 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask me anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: '#f87171' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
-          {CHIPS.map((chip) => (
-            <Chip
-              key={chip.label}
-              label={chip.label}
-              disabled={!hasToken}
-              onClick={() => {
-                const cached = CHIP_CACHE[chip.label];
-                if (cached) addCachedExchange(chip.label, cached);
-                else sendMessage(chip.label);
-                setInput('');
-              }}
-              sx={{
-                height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
-                },
-                '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
-                },
-                '&.Mui-disabled': { opacity: 0.4 },
-              }}
-            />
-          ))}
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ mt: 0.5 }}>
+          {CHIPS.map((chip) => {
+            const s = chipStyles[chip.variant];
+            return (
+              <Chip
+                key={chip.label}
+                label={chip.label}
+                disabled={!hasToken}
+                onClick={() => {
+                  const cached = CHIP_CACHE[chip.label];
+                  if (cached) addCachedExchange(chip.label, cached);
+                  else sendMessage(chip.label);
+                  setInput('');
+                }}
+                sx={{
+                  height: 'auto',
+                  background: s.bg,
+                  border: `1px solid ${s.border}`,
+                  borderRadius: '10px',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                  '& .MuiChip-label': {
+                    color: s.color,
+                    fontSize: '0.82rem',
+                    fontWeight: 500,
+                    px: 1.5,
+                    py: 0.75,
+                  },
+                  '&:hover': {
+                    background: s.hover.bg,
+                    borderColor: s.hover.border,
+                  },
+                  '&.Mui-disabled': { opacity: 0.35 },
+                }}
+              />
+            );
+          })}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +184,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -200,28 +198,33 @@ const HeroChat = () => {
         <Box
           component="button"
           onClick={scrollToAbout}
+          aria-label="Scroll to about section"
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: { xs: 24, md: 40 },
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.5,
+            px: 2.5,
+            py: 1,
+            borderRadius: '12px',
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: '1px solid rgba(255,255,255,0.1)',
+            color: '#a1a1aa',
+            fontSize: '0.82rem',
+            fontWeight: 500,
             cursor: 'pointer',
-            transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            transition: 'all 0.2s ease',
+            fontFamily: 'var(--font-inter), system-ui, sans-serif',
+            '&:hover': {
+              borderColor: 'rgba(255,255,255,0.2)',
+              color: '#fafafa',
+              background: 'rgba(255,255,255,0.03)',
+            },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Explore
+          <KeyboardArrowDownIcon sx={{ fontSize: '1rem' }} />
         </Box>
       </Box>
 
@@ -233,11 +236,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 0.4s ease 0.1s',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +248,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #38bdf8, #a78bfa)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.85rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +269,27 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.88rem', lineHeight: 1.2, color: '#fafafa' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
-              Knows David&apos;s experience, projects &amp; skills
+            <Typography sx={{ fontSize: '0.72rem', color: '#71717a', lineHeight: 1.2 }}>
+              Ask about experience, projects, or skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
-          </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+            background: 'rgba(9,9,11,0.5)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +297,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -2,87 +2,99 @@
 
 import { Link as ScrollLink } from 'react-scroll';
 import { Toolbar, Box, AppBar, Typography } from '@mui/material';
-import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
+import { useState, useEffect } from 'react';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const pages = ['About', 'Experience', 'Projects', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+const NavLink = ({ page, active, setActivePage }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-80}
+    duration={500}
+    onSetActive={() => setActivePage(page)}
+    style={{ textDecoration: 'none', cursor: 'pointer' }}
+  >
+    <Typography
+      component="span"
+      sx={{
+        px: 2,
+        py: 0.75,
+        fontSize: '0.82rem',
+        fontWeight: active ? 600 : 400,
+        color: active ? '#fafafa' : '#a1a1aa',
+        borderRadius: '8px',
+        backgroundColor: active ? 'rgba(255,255,255,0.06)' : 'transparent',
+        transition: 'all 0.2s ease',
+        '&:hover': {
+          color: '#fafafa',
+          backgroundColor: 'rgba(255,255,255,0.04)',
+        },
       }}
     >
       {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+    </Typography>
+  </ScrollLink>
+);
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [activePage, setActivePage] = useState('');
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <AppBar
       position="fixed"
       sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
+        top: 16,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: 'auto',
+        maxWidth: '600px',
+        borderRadius: '16px',
+        bgcolor: scrolled ? 'rgba(9, 9, 11, 0.85)' : 'rgba(9, 9, 11, 0.6)',
+        backdropFilter: 'blur(20px)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        boxShadow: scrolled ? '0 4px 30px rgba(0,0,0,0.4)' : 'none',
         transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
+        zIndex: 1100,
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 0.5,
+          minHeight: '48px !important',
+          px: 2,
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', mr: 2 }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
-          <Logo />
           <Typography
-            variant="h6"
-            component="div"
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              fontWeight: 700,
+              fontSize: '0.9rem',
+              letterSpacing: '-0.02em',
+              color: '#fafafa',
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            DR
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
+        <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', gap: 0.5 }}>
           {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
           ))}
         </Box>
       </Toolbar>

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,168 +2,140 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Card, CardContent, Chip, Stack, IconButton } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
-        id={id}
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+          border: '1px solid rgba(255,255,255,0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: featured ? 'rgba(56,189,248,0.2)' : 'rgba(255,255,255,0.12)',
+            boxShadow: '0 8px 30px rgba(0,0,0,0.25)',
+            '& .project-image': { transform: 'scale(1.03)' },
+            '& .project-link': { opacity: 1 },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        {/* Image */}
+        <Box sx={{ position: 'relative', height: featured ? 200 : 170, width: '100%', overflow: 'hidden' }}>
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 40%, rgba(9,9,11,0.9) 100%)',
+            }}
+          />
+          <IconButton
+            component="a"
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="project-link"
+            sx={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              opacity: 0,
+              backgroundColor: 'rgba(9,9,11,0.6)',
+              backdropFilter: 'blur(8px)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              color: '#fafafa',
+              transition: 'opacity 0.2s ease',
+              width: 32,
+              height: 32,
+              '&:hover': { backgroundColor: 'rgba(9,9,11,0.8)' },
+            }}
+          >
+            <LaunchIcon sx={{ fontSize: '0.85rem' }} />
+          </IconButton>
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 2.5, pt: 2 }}>
+          <Box sx={{ mb: 1.5 }}>
+            <Typography
+              component="h3"
+              sx={{
+                fontWeight: 600,
+                fontSize: '0.95rem',
+                color: '#fafafa',
+                lineHeight: 1.3,
+                mb: 0.5,
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography sx={{ fontSize: '0.72rem', color: '#52525b', mb: 1.5 }}>
+              {dateStarted} — {dateCompleted}
+            </Typography>
+            <Typography
+              sx={{
+                color: '#a1a1aa',
+                fontSize: '0.82rem',
+                lineHeight: 1.6,
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {short_description}
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 'auto' }}>
+            {allTools.slice(0, 5).map((tool) => (
+              <Chip
+                key={tool}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  color: '#71717a',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 5 && (
+              <Chip
+                label={`+${allTools.length - 5}`}
+                size="small"
+                sx={{
+                  bgcolor: 'transparent',
+                  color: '#52525b',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  fontWeight: 500,
+                }}
+              />
+            )}
+          </Stack>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,10 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
-    <Box
-      sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
-      }}
-    >
-      <SectionHeading sectionName="Projects" />
-
+    <Box sx={{ py: { xs: 8, md: 12 }, textAlign: 'center' }}>
+      <SectionHeading sectionName="Projects" subtitle="What I've built" />
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -1,76 +1,11 @@
 'use client';
 
 import { Box, Skeleton, Grid, Collapse, Button } from '@mui/material';
-import { useState, useEffect, useRef, useMemo, memo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import ProjectCard from './ProjectCard';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import gsap from 'gsap';
-import { ScrollTrigger } from 'gsap/ScrollTrigger';
-
-gsap.registerPlugin(ScrollTrigger);
-
-const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.featured-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 40, opacity: 0 },
-      {
-        y: 0,
-        opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
-      }
-    );
-    ScrollTrigger.refresh();
-    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
-  }, [projects]);
-
-  return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
-            <ProjectCard {...project} featured />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-});
-FeaturedProjects.displayName = 'FeaturedProjects';
-
-const AllProjects = ({ projects }) => {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
-  }, [projects]);
-
-  return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
-            <ProjectCard {...project} />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-};
+import FadeIn from '@/components/FadeIn';
 
 const ProjectsContainer = () => {
   const [projectData, setProjectData] = useState([]);
@@ -92,45 +27,53 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%', maxWidth: '1100px', margin: '0 auto', px: { xs: 2, md: 4 } }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box sx={{ bgcolor: 'rgba(255,255,255,0.02)', borderRadius: '16px', overflow: 'hidden' }}>
+                <Skeleton variant="rectangular" height={200} sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Box sx={{ p: 2.5 }}>
+                  <Skeleton variant="text" sx={{ bgcolor: 'rgba(255,255,255,0.04)', fontSize: '1rem' }} />
+                  <Skeleton variant="text" width="40%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+                  <Skeleton variant="text" sx={{ bgcolor: 'rgba(255,255,255,0.04)', mt: 1 }} height={50} />
+                </Box>
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
-          <FeaturedProjects projects={featuredProjects} />
+        <>
+          <Grid container spacing={2.5}>
+            {featuredProjects.map((project, i) => (
+              <Grid key={project.title} size={{ xs: 12, sm: 6, md: 4 }}>
+                <FadeIn delay={i * 0.08}>
+                  <ProjectCard {...project} featured />
+                </FadeIn>
+              </Grid>
+            ))}
+          </Grid>
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <Box sx={{ mt: 5, textAlign: 'center' }}>
             <Button
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
+                color: '#71717a',
+                borderColor: 'rgba(255,255,255,0.08)',
                 border: '1px solid',
-                borderRadius: '50px',
+                borderRadius: '12px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.82rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
+                transition: 'all 0.2s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.03)',
+                  borderColor: 'rgba(255,255,255,0.15)',
+                  color: '#a1a1aa',
                 },
               }}
             >
@@ -139,11 +82,17 @@ const ProjectsContainer = () => {
           </Box>
 
           <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
-            </Box>
+            <Grid container spacing={2.5} sx={{ mt: 1 }}>
+              {otherProjects.map((project, i) => (
+                <Grid key={project.title} size={{ xs: 12, sm: 6, lg: 4 }}>
+                  <FadeIn delay={i * 0.06}>
+                    <ProjectCard {...project} />
+                  </FadeIn>
+                </Grid>
+              ))}
+            </Grid>
           </Collapse>
-        </Box>
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,42 +1,38 @@
-import { Box, Typography } from '@mui/material';
+'use client';
 
-const SectionHeading = ({ sectionName }) => {
+import { Box, Typography } from '@mui/material';
+import FadeIn from './FadeIn';
+
+const SectionHeading = ({ sectionName, subtitle }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
-      <Typography
-        variant="h2"
-        sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
-        }}
-      >
-        {sectionName}
-      </Typography>
-    </Box>
+    <FadeIn>
+      <Box sx={{ mb: { xs: 6, md: 8 }, textAlign: 'center' }}>
+        <Typography
+          variant="overline"
+          sx={{
+            color: '#38bdf8',
+            fontSize: '0.8rem',
+            fontWeight: 600,
+            letterSpacing: '0.2em',
+            mb: 1.5,
+            display: 'block',
+          }}
+        >
+          {sectionName}
+        </Typography>
+        {subtitle && (
+          <Typography
+            variant="h2"
+            sx={{
+              fontSize: { xs: '2rem', md: '3rem' },
+              color: '#fafafa',
+            }}
+          >
+            {subtitle}
+          </Typography>
+        )}
+      </Box>
+    </FadeIn>
   );
 };
 

--- a/next-app/src/components/Skills-Page/Skills.js
+++ b/next-app/src/components/Skills-Page/Skills.js
@@ -1,45 +1,83 @@
-import React from 'react';
-import { Box, Divider } from '@mui/material';
-import SkillCard from './SkillCard';
-import SkillCardContainer from '@/components/Skills-Page/SkillCardContainer';
-import SectionHeading from '@/components/SectionHeading';
+'use client';
 
-export const metadata = {
-  title: 'David Riva | Skills',
-};
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import SectionHeading from '@/components/SectionHeading';
+import FadeIn from '@/components/FadeIn';
+
+const SkillCategory = ({ title, items, delay }) => (
+  <FadeIn delay={delay}>
+    <Box
+      sx={{
+        background: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: '16px',
+        p: 3,
+        transition: 'border-color 0.3s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.1)' },
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.78rem',
+          fontWeight: 600,
+          color: '#52525b',
+          mb: 2,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+      </Typography>
+      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+        {items.map((item) => (
+          <Chip
+            key={item}
+            label={item}
+            size="small"
+            sx={{
+              bgcolor: 'rgba(255,255,255,0.04)',
+              color: '#d4d4d8',
+              border: '1px solid rgba(255,255,255,0.06)',
+              fontSize: '0.78rem',
+              height: '28px',
+              fontWeight: 400,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                bgcolor: 'rgba(56,189,248,0.08)',
+                borderColor: 'rgba(56,189,248,0.15)',
+                color: '#38bdf8',
+              },
+            }}
+          />
+        ))}
+      </Stack>
+    </Box>
+  </FadeIn>
+);
 
 const Skills = () => {
-  const [skillsData, setSkillsData] = useState([]);
+  const [skills, setSkills] = useState([]);
 
   useEffect(() => {
     fetch('/data/skills.json')
       .then((res) => res.json())
-      .then((data) => setSkillsData(data));
+      .then(setSkills);
   }, []);
 
   return (
-    <Box
-      sx={{
-        marginTop: 10,
-        padding: '5rem',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        backgroundColor: '#565859',
-        borderTop: '8px solid rgba(0,0,0,0.1)',
-        boxShadow: '0px 1px 0px rgba(255,255,255,0.2)',
-      }}
-    >
-      <SectionHeading sectionName="Skills" />
+    <Box sx={{ maxWidth: '1100px', mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Skills" subtitle="What I work with" />
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', marginTop: 10 }}>
-        {skillsData.map((skill, index) => (
-          <React.Fragment key={skill.title}>
-            <SkillCardContainer {...skill} />
-            {index < skillsData.length - 1 && <Divider sx={{ margin: '1rem 0', backgroundColor: 'lightgray' }} />}
-          </React.Fragment>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+          gap: 2,
+        }}
+      >
+        {skills.map((category, i) => (
+          <SkillCategory key={category.title} title={category.title} items={category.items} delay={i * 0.06} />
         ))}
       </Box>
     </Box>

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,35 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: '#a1a1aa',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#38bdf8',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#a78bfa',
     },
+    divider: 'rgba(255, 255, 255, 0.06)',
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.04em', lineHeight: 1.05 },
+    h2: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.02em' },
+    h4: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7 },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+    caption: { fontWeight: 400, lineHeight: 1.5 },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual redesign of the portfolio with a refined minimal dark aesthetic following 2026 UI/UX trends.

- **New theme & color palette** — Near-black background (#09090b), sky-blue primary (#38bdf8), violet secondary (#a78bfa), Inter font replacing Montserrat
- **Floating pill navbar** — Centered glassmorphic navigation bar with backdrop blur, replacing the full-width app bar
- **Redesigned hero** — Clean dot-grid background replacing tsparticles, larger typography, refined chat input and suggestion chips
- **Bento grid About section** — Headshot card, bio card, and stat cards (years experience, projects, GPA) in a modular grid layout with social links and resume button
- **New Experience section** — Standalone section with company logo timeline and expandable bullet points (previously hidden in About sidebar)
- **Skills & Awards sections** — Now integrated into the main page flow with category-based chip groups and trophy-icon achievement cards
- **Refined project cards** — Cleaner card design with image hover reveals, external link overlay, and muted tech chips
- **Scroll-driven animations** — Lightweight FadeIn component using Intersection Observer, replacing heavy GSAP ScrollTrigger usage
- **Redesigned contact form, chat UI, and footer** — Consistent glassmorphic styling throughout
- **All backend preserved** — API routes (chat, token, contact, health), chat hooks, RAG search, embeddings, and data files are untouched

## Test plan

- [ ] Verify the page loads and all 7 sections render (Hero, About, Experience, Projects, Skills, Awards, Contact)
- [ ] Test hero chat: suggestion chips load cached responses, free-text input streams from AI agent
- [ ] Verify nav links scroll to correct sections and highlight active section
- [ ] Test project cards: featured vs non-featured, "View all" expand/collapse, hover effects, external links
- [ ] Test experience cards: expand/collapse bullet points for each role
- [ ] Test contact form submission with Turnstile CAPTCHA
- [ ] Verify responsive layout on mobile (xs), tablet (sm), and desktop (md/lg)
- [ ] Confirm `npm run build` passes successfully
- [ ] Confirm `npm run lint` passes with no warnings or errors

https://claude.ai/code/session_01MEqaWQYajejrLSPhVQZ4wc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEqaWQYajejrLSPhVQZ4wc)_