### PR TITLE
redesign: complete portfolio UI overhaul

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,38 +4,48 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['300', '400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | AI & Full Stack Engineer',
+  description:
+    'Portfolio of David Riva — AI engineer and full-stack developer specializing in agentic systems, RAG pipelines, and production ML. Based in the Bay Area.',
+  keywords: [
+    'David Riva',
+    'AI Engineer',
+    'Full Stack Developer',
+    'RAG Pipeline',
+    'LangChain',
+    'React',
+    'Next.js',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — AI & Full Stack Engineer',
+    description: 'AI engineer building production-grade agentic systems and full-stack applications.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: 'David Riva Portfolio',
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — AI & Full Stack Engineer',
+    description: 'AI engineer building production-grade agentic systems and full-stack applications.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,84 +2,49 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
-
-const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
-const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
-const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
-import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
+import Hero from '@/components/Hero/Hero';
 import Footer from '@/components/Footer/Footer';
+
+const About = dynamic(() => import('@/components/About/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
+const Projects = dynamic(() => import('@/components/Projects/Projects'), { ssr: false });
+const Contact = dynamic(() => import('@/components/Contact/Contact'), { ssr: false });
 
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         position: 'relative',
         minHeight: '100vh',
+        overflowX: 'hidden',
       }}
     >
       <NavBar />
 
-      <Box
-        sx={{
-          position: 'relative',
-          height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
-        }}
-      >
-        <ParticleBackground backgroundColor="transparent" />
-        <HeroChat />
+      <Hero />
+
+      <Box id="about">
+        <About />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
+      <Box id="experience">
+        <Experience />
+      </Box>
 
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
+      <Box id="projects">
+        <Projects />
+      </Box>
 
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+      <Box id="contact">
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About/About.jsx
+++ b/next-app/src/components/About/About.jsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, IconButton, Chip, Stack } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+import DescriptionIcon from '@mui/icons-material/Description';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import SectionWrapper from '@/components/shared/SectionWrapper';
+import FadeInView from '@/components/shared/FadeInView';
+
+const GlassCard = ({ children, sx = {}, ...props }) => (
+  <Box
+    sx={{
+      bgcolor: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.06)',
+      borderRadius: '16px',
+      p: { xs: 2.5, md: 3 },
+      transition: 'border-color 0.3s ease',
+      '&:hover': { borderColor: 'rgba(255,255,255,0.12)' },
+      ...sx,
+    }}
+    {...props}
+  >
+    {children}
+  </Box>
+);
+
+const About = () => {
+  const [skills, setSkills] = useState([]);
+  const [awards, setAwards] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/skills.json')
+      .then((r) => r.json())
+      .then(setSkills)
+      .catch(() => {});
+    fetch('/data/awards.json')
+      .then((r) => r.json())
+      .then(setAwards)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <SectionWrapper label="About" title="A bit about me" maxWidth="1200px">
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 1fr' },
+          gridTemplateRows: 'auto',
+          gap: 2,
+        }}
+      >
+        {/* Bio card - spans 2 cols */}
+        <FadeInView delay={0.05} sx={{ gridColumn: { xs: '1', md: '1 / 3' } }}>
+          <GlassCard sx={{ display: 'flex', gap: 3, alignItems: 'flex-start', flexDirection: { xs: 'column', sm: 'row' }, height: '100%' }}>
+            <Box
+              sx={{
+                width: { xs: 80, sm: 100 },
+                height: { xs: 80, sm: 100 },
+                borderRadius: '16px',
+                overflow: 'hidden',
+                flexShrink: 0,
+                border: '2px solid rgba(167, 139, 250, 0.2)',
+              }}
+            >
+              <Image
+                src="/images/headshot.webp"
+                alt="David Riva"
+                width={100}
+                height={100}
+                style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+                priority
+              />
+            </Box>
+            <Box>
+              <Typography variant="h5" sx={{ fontSize: '1.2rem', mb: 1, color: '#fafafa' }}>
+                David Riva
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.45)', mb: 1.5, lineHeight: 1.7 }}>
+                Software engineer based in the Bay Area with a B.S. in Computer Science from Colorado State University
+                (Summa Cum Laude). I build production AI systems — RAG pipelines, agentic workflows, and full-stack
+                applications — with a focus on measurable quality and clean architecture.
+              </Typography>
+              <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                <IconButton
+                  component="a"
+                  href="https://github.com/davidjriva"
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="GitHub"
+                  sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#fafafa' }, p: 0.75 }}
+                >
+                  <GitHubIcon sx={{ fontSize: '1.2rem' }} />
+                </IconButton>
+                <IconButton
+                  component="a"
+                  href="https://www.linkedin.com/in/david-j-riva"
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="LinkedIn"
+                  sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#38bdf8' }, p: 0.75 }}
+                >
+                  <LinkedInIcon sx={{ fontSize: '1.2rem' }} />
+                </IconButton>
+                <IconButton
+                  component="a"
+                  href="mailto:davidjriva@gmail.com"
+                  aria-label="Email"
+                  sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#a78bfa' }, p: 0.75 }}
+                >
+                  <EmailIcon sx={{ fontSize: '1.2rem' }} />
+                </IconButton>
+                <IconButton
+                  component="a"
+                  href="/documents/resume.pdf"
+                  target="_blank"
+                  aria-label="Resume"
+                  sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#fafafa' }, p: 0.75 }}
+                >
+                  <DescriptionIcon sx={{ fontSize: '1.2rem' }} />
+                </IconButton>
+              </Stack>
+            </Box>
+          </GlassCard>
+        </FadeInView>
+
+        {/* Awards card */}
+        <FadeInView delay={0.15}>
+          <GlassCard sx={{ height: '100%' }}>
+            <Typography
+              variant="overline"
+              sx={{ color: 'rgba(255,255,255,0.35)', fontSize: '0.7rem', letterSpacing: '0.12em', mb: 2, display: 'block' }}
+            >
+              Recognition
+            </Typography>
+            <Stack spacing={2}>
+              {awards.slice(0, 3).map((award) => (
+                <Box key={award.title} sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start' }}>
+                  <EmojiEventsIcon sx={{ color: '#fbbf24', fontSize: '1rem', mt: '3px', flexShrink: 0 }} />
+                  <Box>
+                    <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, color: '#fafafa', lineHeight: 1.3 }}>
+                      {award.title}
+                    </Typography>
+                    <Typography sx={{ fontSize: '0.7rem', color: 'rgba(255,255,255,0.3)', mt: 0.25 }}>
+                      {award.date}
+                    </Typography>
+                  </Box>
+                </Box>
+              ))}
+            </Stack>
+          </GlassCard>
+        </FadeInView>
+
+        {/* Skills grid - spans full width */}
+        <FadeInView delay={0.2} sx={{ gridColumn: { xs: '1', md: '1 / -1' } }}>
+          <GlassCard>
+            <Typography
+              variant="overline"
+              sx={{ color: 'rgba(255,255,255,0.35)', fontSize: '0.7rem', letterSpacing: '0.12em', mb: 2.5, display: 'block' }}
+            >
+              Technical Skills
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(4, 1fr)' },
+                gap: 2.5,
+              }}
+            >
+              {skills.slice(0, 4).map((category) => (
+                <Box key={category.title}>
+                  <Typography
+                    sx={{
+                      fontSize: '0.75rem',
+                      fontWeight: 600,
+                      color: '#a78bfa',
+                      mb: 1,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    {category.title}
+                  </Typography>
+                  <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5}>
+                    {category.items.map((item) => (
+                      <Chip
+                        key={item}
+                        label={item}
+                        size="small"
+                        sx={{
+                          bgcolor: 'rgba(255,255,255,0.04)',
+                          color: 'rgba(255,255,255,0.55)',
+                          border: '1px solid rgba(255,255,255,0.06)',
+                          fontSize: '0.7rem',
+                          height: '24px',
+                        }}
+                      />
+                    ))}
+                  </Stack>
+                </Box>
+              ))}
+            </Box>
+            {skills.length > 4 && (
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+                  gap: 2.5,
+                  mt: 2.5,
+                }}
+              >
+                {skills.slice(4).map((category) => (
+                  <Box key={category.title}>
+                    <Typography
+                      sx={{
+                        fontSize: '0.75rem',
+                        fontWeight: 600,
+                        color: '#a78bfa',
+                        mb: 1,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                      }}
+                    >
+                      {category.title}
+                    </Typography>
+                    <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5}>
+                      {category.items.map((item) => (
+                        <Chip
+                          key={item}
+                          label={item}
+                          size="small"
+                          sx={{
+                            bgcolor: 'rgba(255,255,255,0.04)',
+                            color: 'rgba(255,255,255,0.55)',
+                            border: '1px solid rgba(255,255,255,0.06)',
+                            fontSize: '0.7rem',
+                            height: '24px',
+                          }}
+                        />
+                      ))}
+                    </Stack>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </GlassCard>
+        </FadeInView>
+      </Box>
+    </SectionWrapper>
+  );
+};
+
+export default About;

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -13,13 +13,13 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         display: 'flex',
         alignItems: 'center',
         p: '4px 8px',
-        borderRadius: '999px',
+        borderRadius: '14px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        border: '1px solid rgba(255,255,255,0.08)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.15)' },
+        '&:focus-within': { borderColor: 'rgba(167,139,250,0.5)' },
       }}
     >
       <InputBase
@@ -36,22 +36,26 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         sx={{
           ml: 1,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontSize: '0.85rem',
+          fontFamily: 'inherit',
+          '& input::placeholder': { color: 'rgba(255,255,255,0.3)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          ml: 0.5,
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#09090b', fontSize: '0.9rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,59 +7,58 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'inherit',
     fontWeight: 400,
     lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    fontSize: '0.85rem',
+    color: '#fafafa',
     marginBottom: '4px',
   };
 
   return (
     <Box
       sx={{
-        mb: 2,
+        mb: 1.5,
         display: 'flex',
         justifyContent: isUser ? 'flex-end' : 'flex-start',
       }}
     >
       <Box
         sx={{
-          maxWidth: '80%',
-          px: 2.5,
-          py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          maxWidth: '85%',
+          px: 2,
+          py: 1.25,
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(167,139,250,0.12)' : 'rgba(255,255,255,0.04)',
+          border: isUser ? '1px solid rgba(167,139,250,0.2)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={6} dotColor="#a78bfa" spacing={3} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
-                li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
+                li: (props) => <li style={{ ...mdStyles, marginBottom: '4px' }} {...props} />,
                 strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.5 }} {...props} />,
+                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1, mb: 0.5 }} {...props} />,
+                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '0.95rem', mt: 0.8, mb: 0.4 }} {...props} />,
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
+                      color: '#a78bfa',
+                      backgroundColor: 'rgba(167,139,250,0.08)',
                       p: '0 4px',
-                      borderRadius: 1,
+                      borderRadius: '4px',
                       display: 'inline',
+                      fontSize: '0.8rem',
                     }}
                     {...props}
                   />
@@ -67,18 +66,18 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fafafa', p: 1.5, borderRadius: '8px', overflowX: 'auto', fontSize: '0.8rem' }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => <a style={{ color: '#a78bfa', textDecoration: 'none' }} target="_blank" rel="noopener" {...props} />,
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact/Contact.jsx
+++ b/next-app/src/components/Contact/Contact.jsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, TextField, Button, Typography, Stack } from '@mui/material';
+import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
+import SectionWrapper from '@/components/shared/SectionWrapper';
+import FadeInView from '@/components/shared/FadeInView';
+
+const inputSx = {
+  mb: 2,
+  '& .MuiInputLabel-root': { color: 'rgba(255,255,255,0.35)', fontSize: '0.85rem' },
+  '& .MuiOutlinedInput-root': {
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255,255,255,0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.15)' },
+    '&.Mui-focused fieldset': { borderColor: '#a78bfa' },
+  },
+};
+
+const Contact = () => {
+  const [formData, setFormData] = useState({ name: '', email: '', subject: '', message: '' });
+  const [status, setStatus] = useState('');
+  const [captchaToken, setCaptchaToken] = useState(null);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...formData, captchaToken }),
+      });
+      if (res.ok) {
+        setStatus('Message sent successfully!');
+        setFormData({ name: '', email: '', subject: '', message: '' });
+      } else {
+        setStatus('Failed to send message.');
+      }
+    } catch {
+      setStatus('Error sending message.');
+    }
+  };
+
+  return (
+    <SectionWrapper
+      label="Contact"
+      title="Get in touch"
+      subtitle="Have a question or want to work together? Drop me a message."
+      maxWidth="600px"
+      sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+    >
+      <FadeInView delay={0.1}>
+        <Box
+          sx={{
+            bgcolor: 'rgba(255,255,255,0.02)',
+            border: '1px solid rgba(255,255,255,0.06)',
+            borderRadius: '20px',
+            p: { xs: 3, md: 4 },
+          }}
+        >
+          <form onSubmit={handleSubmit}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 0 }}>
+              <TextField
+                fullWidth
+                label="Name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+                sx={inputSx}
+              />
+              <TextField
+                fullWidth
+                label="Email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                required
+                sx={inputSx}
+              />
+            </Stack>
+            <TextField
+              fullWidth
+              label="Subject"
+              name="subject"
+              value={formData.subject}
+              onChange={handleChange}
+              required
+              sx={inputSx}
+            />
+            <TextField
+              fullWidth
+              label="Message"
+              name="message"
+              multiline
+              rows={4}
+              value={formData.message}
+              onChange={handleChange}
+              required
+              sx={inputSx}
+            />
+
+            {!captchaToken && (
+              <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+                <Turnstile
+                  siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
+                  onSuccess={(token) => setCaptchaToken(token)}
+                />
+              </Box>
+            )}
+
+            <Button
+              type="submit"
+              fullWidth
+              disabled={!captchaToken}
+              endIcon={<SendIcon sx={{ fontSize: '0.9rem !important' }} />}
+              sx={{
+                py: 1.5,
+                borderRadius: '12px',
+                textTransform: 'none',
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
+                color: '#09090b',
+                '&:hover': {
+                  background: 'linear-gradient(135deg, #b59cfc, #5dcdfb)',
+                },
+                '&.Mui-disabled': {
+                  background: 'rgba(255,255,255,0.06)',
+                  color: 'rgba(255,255,255,0.2)',
+                },
+              }}
+            >
+              Send Message
+            </Button>
+          </form>
+
+          {status && (
+            <Typography
+              variant="body2"
+              sx={{
+                mt: 2,
+                textAlign: 'center',
+                fontSize: '0.8rem',
+                color: status.includes('success') ? '#4ade80' : '#f87171',
+              }}
+            >
+              {status}
+            </Typography>
+          )}
+        </Box>
+      </FadeInView>
+    </SectionWrapper>
+  );
+};
+
+export default Contact;

--- a/next-app/src/components/Experience/Experience.jsx
+++ b/next-app/src/components/Experience/Experience.jsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Stack } from '@mui/material';
+import Image from 'next/image';
+import SectionWrapper from '@/components/shared/SectionWrapper';
+import FadeInView from '@/components/shared/FadeInView';
+
+const ExperienceCard = ({ experience, index }) => {
+  const isCurrent = experience.endDate === 'Present' || new Date(experience.endDate) > new Date();
+  const isGraduation = experience.title.startsWith('Graduated');
+
+  return (
+    <FadeInView delay={index * 0.08}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: { xs: 2, md: 3 },
+          position: 'relative',
+        }}
+      >
+        {/* Timeline line */}
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'flex' },
+            flexDirection: 'column',
+            alignItems: 'center',
+            pt: '6px',
+            flexShrink: 0,
+            width: 40,
+          }}
+        >
+          <Box
+            sx={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              bgcolor: isCurrent ? '#a78bfa' : 'rgba(255,255,255,0.15)',
+              boxShadow: isCurrent ? '0 0 12px rgba(167,139,250,0.4)' : 'none',
+              flexShrink: 0,
+            }}
+          />
+          <Box
+            sx={{
+              width: '1px',
+              flex: 1,
+              background: 'linear-gradient(to bottom, rgba(255,255,255,0.1), transparent)',
+              mt: 0.5,
+            }}
+          />
+        </Box>
+
+        {/* Content */}
+        <Box
+          sx={{
+            flex: 1,
+            bgcolor: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.06)',
+            borderRadius: '16px',
+            p: { xs: 2.5, md: 3 },
+            mb: 2,
+            transition: 'border-color 0.3s ease',
+            '&:hover': { borderColor: 'rgba(255,255,255,0.12)' },
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
+            <Box
+              sx={{
+                width: 36,
+                height: 36,
+                borderRadius: '10px',
+                bgcolor: 'rgba(255,255,255,0.06)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                overflow: 'hidden',
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}
+            >
+              <Image
+                src={`/images/${experience.logoImage}`}
+                alt={`${experience.company} logo`}
+                width={22}
+                height={22}
+                style={{ objectFit: 'contain' }}
+              />
+            </Box>
+            <Box sx={{ flex: 1 }}>
+              <Typography sx={{ fontWeight: 600, fontSize: '0.95rem', color: '#fafafa', lineHeight: 1.3 }}>
+                {isGraduation ? 'B.S. Computer Science, Summa Cum Laude' : experience.title}
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
+                <Typography
+                  component="a"
+                  href={experience.companyWebsiteLink}
+                  target="_blank"
+                  rel="noopener"
+                  sx={{
+                    color: '#a78bfa',
+                    textDecoration: 'none',
+                    fontSize: '0.8rem',
+                    fontWeight: 500,
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  {experience.company}
+                </Typography>
+                <Typography sx={{ color: 'rgba(255,255,255,0.2)', fontSize: '0.75rem' }}>
+                  {experience.location}
+                </Typography>
+              </Box>
+              <Typography
+                sx={{
+                  color: isCurrent ? '#a78bfa' : 'rgba(255,255,255,0.35)',
+                  fontSize: '0.75rem',
+                  fontWeight: isCurrent ? 500 : 400,
+                  mt: 0.5,
+                }}
+              >
+                {isGraduation ? experience.startDate : `${experience.startDate} – ${experience.endDate}`}
+              </Typography>
+            </Box>
+          </Box>
+
+          {experience.bulletPoints && (
+            <Stack spacing={1} sx={{ mt: 2 }}>
+              {experience.bulletPoints.slice(0, 3).map((point, i) => (
+                <Box key={i} sx={{ display: 'flex', gap: 1.5 }}>
+                  <Box
+                    sx={{
+                      width: 4,
+                      height: 4,
+                      borderRadius: '50%',
+                      bgcolor: 'rgba(255,255,255,0.2)',
+                      mt: '8px',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Typography sx={{ color: 'rgba(255,255,255,0.45)', fontSize: '0.8rem', lineHeight: 1.6 }}>
+                    {point}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </Box>
+    </FadeInView>
+  );
+};
+
+const Experience = () => {
+  const [experiences, setExperiences] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((r) => r.json())
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setExperiences(sorted);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <SectionWrapper
+      label="Experience"
+      title="Where I've worked"
+      subtitle="From AI engineering to full-stack development and machine learning."
+      maxWidth="800px"
+      sx={{
+        borderTop: '1px solid rgba(255,255,255,0.04)',
+      }}
+    >
+      <Box>
+        {experiences.map((exp, i) => (
+          <ExperienceCard key={exp.title} experience={exp} index={i} />
+        ))}
+      </Box>
+    </SectionWrapper>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,73 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
+        borderTop: '1px solid rgba(255,255,255,0.04)',
+        px: { xs: 3, md: 6 },
+        py: 5,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        gap: 2,
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <Box
+        component="button"
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          width: 40,
+          height: 40,
+          borderRadius: '12px',
+          bgcolor: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          color: 'rgba(255,255,255,0.4)',
+          transition: 'all 0.25s ease',
+          '&:hover': {
+            bgcolor: 'rgba(255,255,255,0.08)',
+            color: '#fafafa',
+            borderColor: 'rgba(255,255,255,0.15)',
+          },
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        <KeyboardArrowUpIcon sx={{ fontSize: '1.2rem' }} />
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <IconButton
+          component="a"
+          href="https://github.com/davidjriva"
+          target="_blank"
+          rel="noopener"
+          aria-label="GitHub"
+          sx={{ color: 'rgba(255,255,255,0.3)', '&:hover': { color: '#fafafa' } }}
+        >
+          <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+        </IconButton>
+        <IconButton
+          component="a"
+          href="https://www.linkedin.com/in/david-j-riva"
+          target="_blank"
+          rel="noopener"
+          aria-label="LinkedIn"
+          sx={{ color: 'rgba(255,255,255,0.3)', '&:hover': { color: '#38bdf8' } }}
+        >
+          <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+        </IconButton>
+      </Box>
+
+      <Typography sx={{ color: 'rgba(255,255,255,0.2)', fontSize: '0.75rem' }}>
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Hero/AnimatedRole.jsx
+++ b/next-app/src/components/Hero/AnimatedRole.jsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Typography, Box } from '@mui/material';
+
+const ROLES = ['AI engineer', 'full-stack developer', 'builder'];
+
+const AnimatedRole = () => {
+  const [text, setText] = useState('');
+  const [roleIdx, setRoleIdx] = useState(0);
+  const [charIdx, setCharIdx] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    const currentRole = ROLES[roleIdx];
+    let timer;
+
+    if (!deleting && charIdx < currentRole.length) {
+      timer = setTimeout(() => {
+        setText(currentRole.slice(0, charIdx + 1));
+        setCharIdx(charIdx + 1);
+      }, 80 + Math.random() * 40);
+    } else if (!deleting && charIdx === currentRole.length) {
+      timer = setTimeout(() => setDeleting(true), 1800);
+    } else if (deleting && charIdx > 0) {
+      timer = setTimeout(() => {
+        setText(currentRole.slice(0, charIdx - 1));
+        setCharIdx(charIdx - 1);
+      }, 40 + Math.random() * 20);
+    } else if (deleting && charIdx === 0) {
+      timer = setTimeout(() => {
+        setDeleting(false);
+        setRoleIdx((prev) => (prev + 1) % ROLES.length);
+      }, 400);
+    }
+
+    return () => clearTimeout(timer);
+  }, [charIdx, deleting, roleIdx]);
+
+  return (
+    <Typography
+      variant="h2"
+      sx={{
+        fontSize: { xs: 'clamp(1.5rem, 5vw, 2.5rem)', md: '2.5rem' },
+        color: 'rgba(255,255,255,0.35)',
+        fontWeight: 500,
+        minHeight: '1.3em',
+      }}
+    >
+      {text}
+      <Box
+        component="span"
+        sx={{
+          color: '#a78bfa',
+          ml: '2px',
+          '@keyframes blink': {
+            '0%, 100%': { opacity: 1 },
+            '50%': { opacity: 0 },
+          },
+          animation: 'blink 1s step-end infinite',
+        }}
+      >
+        |
+      </Box>
+    </Typography>
+  );
+};
+
+export default AnimatedRole;

--- a/next-app/src/components/Hero/ChatWidget.jsx
+++ b/next-app/src/components/Hero/ChatWidget.jsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import CloseIcon from '@mui/icons-material/Close';
+import ChatInput from '@/components/Chat-Page/ChatInput';
+import MessagesList from '@/components/Chat-Page/MessagesList';
+
+const ChatWidget = ({ open, onToggle, messages, started, sendMessage, hasToken, turnstileError }) => {
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    sendMessage(input);
+    setInput('');
+  };
+
+  return (
+    <>
+      {/* Floating toggle button */}
+      <Box
+        component="button"
+        onClick={onToggle}
+        sx={{
+          position: 'fixed',
+          bottom: 24,
+          right: 24,
+          zIndex: 1300,
+          width: 52,
+          height: 52,
+          borderRadius: '16px',
+          background: open ? 'rgba(255,255,255,0.1)' : 'linear-gradient(135deg, #a78bfa, #38bdf8)',
+          border: open ? '1px solid rgba(255,255,255,0.15)' : 'none',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          transition: 'all 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
+          boxShadow: open ? 'none' : '0 8px 32px rgba(167, 139, 250, 0.25)',
+          '&:hover': {
+            transform: 'scale(1.05)',
+          },
+        }}
+      >
+        {open ? (
+          <CloseIcon sx={{ color: '#fafafa', fontSize: '1.2rem' }} />
+        ) : (
+          <ChatBubbleOutlineIcon sx={{ color: '#09090b', fontSize: '1.3rem' }} />
+        )}
+      </Box>
+
+      {/* Chat panel */}
+      <Box
+        sx={{
+          position: 'fixed',
+          bottom: 88,
+          right: 24,
+          zIndex: 1200,
+          width: { xs: 'calc(100vw - 48px)', sm: '400px' },
+          maxWidth: '400px',
+          height: '500px',
+          maxHeight: 'calc(100vh - 140px)',
+          borderRadius: '20px',
+          bgcolor: 'rgba(15, 15, 20, 0.95)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          backdropFilter: 'blur(24px)',
+          boxShadow: '0 24px 80px rgba(0,0,0,0.5)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          opacity: open ? 1 : 0,
+          transform: open ? 'translateY(0) scale(1)' : 'translateY(16px) scale(0.95)',
+          pointerEvents: open ? 'auto' : 'none',
+          transition: 'all 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            px: 2.5,
+            py: 2,
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontWeight: 800,
+              fontSize: '0.75rem',
+              color: '#09090b',
+              flexShrink: 0,
+            }}
+          >
+            AI
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', lineHeight: 1.2, color: '#fafafa' }}>
+              Ask about David
+            </Typography>
+            <Typography sx={{ fontSize: '0.7rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+              Powered by GPT-4o-mini with RAG
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Messages */}
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 1.5, pt: 1 }}>
+          {messages.length === 0 ? (
+            <Box
+              sx={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography
+                sx={{
+                  color: 'rgba(255,255,255,0.2)',
+                  fontSize: '0.85rem',
+                  textAlign: 'center',
+                  px: 3,
+                }}
+              >
+                Ask me anything about David&apos;s experience, projects, or skills.
+              </Typography>
+            </Box>
+          ) : (
+            <MessagesList messages={messages} />
+          )}
+        </Box>
+
+        {/* Input */}
+        <Box
+          sx={{
+            flexShrink: 0,
+            px: 2,
+            py: 1.5,
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
+          <ChatInput
+            input={input}
+            setInput={setInput}
+            sendMessage={handleSend}
+            disabled={!hasToken}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything...'}
+          />
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default ChatWidget;

--- a/next-app/src/components/Hero/Hero.jsx
+++ b/next-app/src/components/Hero/Hero.jsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import { Turnstile } from '@marsidev/react-turnstile';
+import AnimatedRole from './AnimatedRole';
+import ChatWidget from './ChatWidget';
+import useChat from '@/components/Chat-Page/hooks/useChat';
+
+const CHIP_CACHE = {
+  'What AI have you built?': `David has built several impressive AI projects.
+
+**[Production RAG Pipeline](https://github.com/davidjriva/Production_RAG_Pipeline)** is a production-grade system for answering natural language questions over PDFs. It uses hybrid retrieval (Pinecone + BM25), cross-encoder reranking, and automated RAGAS quality gates to ensure faithfulness and relevancy. The pipeline is orchestrated with a LangGraph state machine and traced via LangSmith.
+
+**[Agentic AI News Summary Service](https://github.com/davidjriva/Agentic_AI_News_Summary_Service)** is a fully automated newsletter that runs twice daily. It fetches from 10+ RSS feeds, scores each article with Claude using ephemeral prompt caching, and emails a ranked digest — all with zero manual intervention.
+
+**[This portfolio's chat agent](https://github.com/davidjriva/Personal-Portfolio)** is the one you're talking to right now — a RAG agent built with Next.js and GPT-4o-mini, with streaming responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval eval suite.
+
+David also took **1st place at C3 AI's Agentic AI Hackathon 2025**, building agentic developer tooling with React, TypeScript, and an in-house LLM.`,
+
+  'Tell me about your experience': `Here's a quick overview of David's background.
+
+Most recently he was a **Training Engineer, Generative AI at C3 AI** (Sept 2024 – Apr 2026), where he built and maintained their core training platform serving 8,000+ learners, created internal automation tools that cut feedback turnaround time by 80%, and won 1st place at the C3 Agentic AI Hackathon 2025.
+
+Before that, he was a **Full-Stack Developer on a university research team at Colorado State University** (Dec 2022 – Jan 2024), building an accessible interface to 20TB+ environmental datasets using React, TypeScript, Python/Flask, and MongoDB. That project won the Excellence in Data Science Award at CSU's Celebrating Undergraduate Research Competition.
+
+In between, he interned as a **Machine Learning Engineer at Hewlett Packard Inc.** (May – Aug 2023), building ETL pipelines on AWS and developing ML forecasting models with Scikit-Learn and Facebook Prophet.
+
+David graduated from Colorado State University in May 2024 with a B.S. in Computer Science, *Summa Cum Laude*.`,
+
+  'Featured projects': `Here are three of David's featured projects.
+
+**[Production RAG Pipeline](https://github.com/davidjriva/Production_RAG_Pipeline)** *(Mar – Apr 2025)* — a production-grade RAG system for answering natural language questions over PDFs. It combines dense and BM25 retrieval, cross-encoder reranking, and RAGAS quality gates to keep responses accurate and grounded. Built with LangChain, LangGraph, Pinecone, and FastAPI.
+
+**[Agentic AI News Summary Service](https://github.com/davidjriva/Agentic_AI_News_Summary_Service)** *(Feb – Mar 2025)* — an automated newsletter pipeline that fetches from 10+ RSS feeds, scores articles with Claude (using prompt caching), and emails a ranked daily digest. Runs on a launchd schedule with a FastAPI dashboard — no infrastructure needed.
+
+**[This portfolio](https://github.com/davidjriva/Personal-Portfolio)** *(Nov 2024 – Apr 2025)* — the site you're on now. It has an embedded GPT-4o-mini RAG agent, streaming SSE responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval automated eval suite. Built with Next.js, React, and MUI.`,
+};
+
+const QUICK_ACTIONS = [
+  { label: 'What AI have you built?', color: '#a78bfa' },
+  { label: 'Tell me about your experience', color: '#38bdf8' },
+  { label: 'Featured projects', color: '#fafafa' },
+];
+
+const Hero = () => {
+  const [chatOpen, setChatOpen] = useState(false);
+  const [turnstileError, setTurnstileError] = useState(false);
+  const [needsChallenge, setNeedsChallenge] = useState(false);
+  const { messages, started, sendMessage, addCachedExchange, fetchToken, hasToken } = useChat();
+
+  const scrollToAbout = () => {
+    const el = document.getElementById('about');
+    if (el) {
+      const y = el.getBoundingClientRect().top + window.scrollY - 80;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }
+  };
+
+  const handleChipClick = (label) => {
+    if (!chatOpen) setChatOpen(true);
+    const cached = CHIP_CACHE[label];
+    if (cached) addCachedExchange(label, cached);
+    else sendMessage(label);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        px: { xs: 2.5, sm: 4, md: 6 },
+        pt: { xs: 12, md: 0 },
+        pb: { xs: 8, md: 0 },
+        overflow: 'hidden',
+      }}
+    >
+      {/* Ambient gradient orbs */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '-20%',
+          right: '-10%',
+          width: '60vw',
+          height: '60vw',
+          maxWidth: '800px',
+          maxHeight: '800px',
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(167,139,250,0.08) 0%, transparent 70%)',
+          pointerEvents: 'none',
+          filter: 'blur(60px)',
+        }}
+      />
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: '-10%',
+          left: '-15%',
+          width: '50vw',
+          height: '50vw',
+          maxWidth: '700px',
+          maxHeight: '700px',
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(56,189,248,0.06) 0%, transparent 70%)',
+          pointerEvents: 'none',
+          filter: 'blur(60px)',
+        }}
+      />
+
+      {/* Noise texture overlay */}
+      <Box
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          opacity: 0.03,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+          backgroundSize: '128px 128px',
+          pointerEvents: 'none',
+        }}
+      />
+
+      <Box sx={{ position: 'relative', maxWidth: '1200px', mx: 'auto', width: '100%' }}>
+        <Box sx={{ maxWidth: '720px' }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'rgba(255,255,255,0.4)',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              mb: 3,
+              letterSpacing: '0.04em',
+            }}
+          >
+            Bay Area, CA
+          </Typography>
+
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: { xs: 'clamp(2.5rem, 8vw, 4.5rem)', md: '4.5rem' },
+              mb: 2,
+            }}
+          >
+            David Riva
+          </Typography>
+
+          <AnimatedRole />
+
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'rgba(255,255,255,0.45)',
+              maxWidth: '520px',
+              mt: 3,
+              mb: 4,
+              fontSize: { xs: '0.95rem', md: '1.05rem' },
+            }}
+          >
+            Building production AI systems and full-stack applications. Previously at C3 AI, HP, and Colorado State
+            University.
+          </Typography>
+
+          <Stack
+            direction="row"
+            spacing={1}
+            flexWrap="wrap"
+            useFlexGap
+            sx={{ mb: 4 }}
+          >
+            {QUICK_ACTIONS.map((action) => (
+              <Chip
+                key={action.label}
+                label={action.label}
+                disabled={!hasToken}
+                onClick={() => handleChipClick(action.label)}
+                sx={{
+                  height: 'auto',
+                  background: 'rgba(255,255,255,0.04)',
+                  border: `1px solid rgba(255,255,255,0.1)`,
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                  '& .MuiChip-label': {
+                    color: action.color,
+                    fontFamily: 'inherit',
+                    fontSize: '0.82rem',
+                    fontWeight: 500,
+                    px: 1.5,
+                    py: 0.85,
+                  },
+                  '&:hover': {
+                    background: 'rgba(255,255,255,0.08)',
+                    borderColor: 'rgba(255,255,255,0.2)',
+                  },
+                  '&.Mui-disabled': { opacity: 0.3 },
+                }}
+              />
+            ))}
+          </Stack>
+
+          <Box
+            component="button"
+            onClick={scrollToAbout}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 2.5,
+              py: 1,
+              borderRadius: '999px',
+              background: 'transparent',
+              border: '1px solid rgba(255,255,255,0.15)',
+              color: 'rgba(255,255,255,0.6)',
+              fontFamily: 'inherit',
+              fontWeight: 500,
+              fontSize: '0.8rem',
+              cursor: 'pointer',
+              transition: 'all 0.25s ease',
+              '&:hover': {
+                borderColor: 'rgba(255,255,255,0.3)',
+                color: '#fafafa',
+                background: 'rgba(255,255,255,0.04)',
+              },
+            }}
+          >
+            <ArrowDownwardIcon sx={{ fontSize: '0.9rem' }} />
+            Explore my work
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Turnstile */}
+      {!hasToken && !turnstileError && (
+        <Box
+          sx={{
+            position: 'fixed',
+            bottom: 100,
+            right: 24,
+            zIndex: 1200,
+            visibility: needsChallenge ? 'visible' : 'hidden',
+            height: needsChallenge ? 'auto' : 0,
+            overflow: 'hidden',
+          }}
+        >
+          <Turnstile
+            siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
+            onSuccess={(captchaToken) => {
+              fetchToken(captchaToken);
+              setNeedsChallenge(false);
+            }}
+            onError={() => setTurnstileError(true)}
+            onBeforeInteractive={() => setNeedsChallenge(true)}
+            options={{ appearance: 'interaction-only' }}
+          />
+        </Box>
+      )}
+
+      {/* Chat Widget */}
+      <ChatWidget
+        open={chatOpen}
+        onToggle={() => setChatOpen((prev) => !prev)}
+        messages={messages}
+        started={started}
+        sendMessage={sendMessage}
+        hasToken={hasToken}
+        turnstileError={turnstileError}
+      />
+    </Box>
+  );
+};
+
+export default Hero;

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,144 @@
 'use client';
 
-import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
-import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
+import { useState, useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+const NAV_ITEMS = ['About', 'Experience', 'Projects', 'Contact'];
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [active, setActive] = useState('');
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled(window.scrollY > 50);
+
+      const sections = NAV_ITEMS.map((id) => document.getElementById(id.toLowerCase()));
+      const scrollPos = window.scrollY + 120;
+
+      for (let i = sections.length - 1; i >= 0; i--) {
+        if (sections[i] && sections[i].offsetTop <= scrollPos) {
+          setActive(NAV_ITEMS[i]);
+          return;
+        }
+      }
+      setActive('');
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollTo = (id) => {
+    if (!id) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    const el = document.getElementById(id.toLowerCase());
+    if (el) {
+      const y = el.getBoundingClientRect().top + window.scrollY - 80;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }
+  };
 
   return (
-    <AppBar
-      position="fixed"
+    <Box
+      component="nav"
       sx={{
+        position: 'fixed',
         top: 0,
+        left: 0,
+        right: 0,
         zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        px: { xs: 2.5, md: 4 },
         height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
+        bgcolor: scrolled ? 'rgba(9, 9, 11, 0.85)' : 'transparent',
+        backdropFilter: scrolled ? 'blur(20px) saturate(1.5)' : 'none',
+        borderBottom: scrolled ? '1px solid rgba(255,255,255,0.06)' : '1px solid transparent',
+        transition: 'all 0.35s ease',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Box
+        onClick={() => scrollTo(null)}
+        sx={{
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          sx={{
+            width: 32,
+            height: 32,
+            borderRadius: '8px',
+            background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 800,
+            fontSize: '0.85rem',
+            color: '#09090b',
+          }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
+          DR
+        </Box>
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '1rem',
+            letterSpacing: '-0.01em',
+            color: '#fafafa',
+            display: { xs: 'none', sm: 'block' },
+          }}
+        >
+          David Riva
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: { xs: 0.5, sm: 1 },
+          bgcolor: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: '999px',
+          px: 1,
+          py: 0.5,
+        }}
+      >
+        {NAV_ITEMS.map((item) => (
+          <Box
+            key={item}
+            component="button"
+            onClick={() => scrollTo(item)}
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              background: active === item ? 'rgba(167, 139, 250, 0.15)' : 'transparent',
+              border: 'none',
+              borderRadius: '999px',
+              px: { xs: 1.5, sm: 2 },
+              py: 0.75,
+              color: active === item ? '#a78bfa' : 'rgba(255,255,255,0.5)',
+              fontSize: { xs: '0.75rem', sm: '0.8rem' },
+              fontWeight: 500,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              transition: 'all 0.25s ease',
+              '&:hover': {
+                color: '#fafafa',
+                background: 'rgba(255,255,255,0.06)',
+              },
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
-
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
-        </Box>
-      </Toolbar>
-    </AppBar>
+            {item}
+          </Box>
+        ))}
+      </Box>
+    </Box>
   );
 };
 

--- a/next-app/src/components/Projects/Projects.jsx
+++ b/next-app/src/components/Projects/Projects.jsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack, Button, Collapse, Skeleton, Grid } from '@mui/material';
+import Image from 'next/image';
+import LaunchIcon from '@mui/icons-material/Launch';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import SectionWrapper from '@/components/shared/SectionWrapper';
+import FadeInView from '@/components/shared/FadeInView';
+
+const FeaturedProject = ({ project, index, isReversed }) => {
+  return (
+    <FadeInView delay={index * 0.1}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: isReversed ? 'row-reverse' : 'row' },
+          gap: { xs: 0, md: 4 },
+          mb: { xs: 4, md: 6 },
+          bgcolor: 'rgba(255,255,255,0.02)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          borderRadius: '20px',
+          overflow: 'hidden',
+          transition: 'all 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+          '&:hover': {
+            borderColor: 'rgba(167, 139, 250, 0.2)',
+            transform: 'translateY(-4px)',
+            boxShadow: '0 16px 48px rgba(0,0,0,0.3)',
+            '& .project-img': { transform: 'scale(1.03)' },
+          },
+        }}
+      >
+        {/* Image */}
+        <Box
+          sx={{
+            position: 'relative',
+            width: { xs: '100%', md: '50%' },
+            minHeight: { xs: 200, md: 280 },
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${project.coverImage}`}
+            alt={project.title}
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            style={{ objectFit: 'cover', transition: 'transform 0.6s ease' }}
+            className="project-img"
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: { xs: 'linear-gradient(to bottom, transparent 50%, rgba(9,9,11,0.8) 100%)', md: 'none' },
+            }}
+          />
+        </Box>
+
+        {/* Content */}
+        <Box
+          sx={{
+            flex: 1,
+            p: { xs: 2.5, md: 4 },
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+          }}
+        >
+          <Typography
+            variant="overline"
+            sx={{ color: 'rgba(255,255,255,0.3)', fontSize: '0.7rem', letterSpacing: '0.1em', mb: 1 }}
+          >
+            {project.dateStarted} – {project.dateCompleted}
+          </Typography>
+          <Typography variant="h4" sx={{ fontSize: { xs: '1.25rem', md: '1.5rem' }, mb: 1.5, color: '#fafafa' }}>
+            {project.title}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{ color: 'rgba(255,255,255,0.45)', mb: 2.5, lineHeight: 1.7, fontSize: '0.85rem' }}
+          >
+            {project.short_description}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5} sx={{ mb: 2.5 }}>
+            {project.technologies.flatMap((t) => t.tools).map((tool) => (
+              <Chip
+                key={tool}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(167,139,250,0.08)',
+                  color: '#a78bfa',
+                  border: '1px solid rgba(167,139,250,0.15)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                }}
+              />
+            ))}
+          </Stack>
+          <Box>
+            <Button
+              href={project.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              endIcon={<LaunchIcon sx={{ fontSize: '0.85rem !important' }} />}
+              sx={{
+                color: 'rgba(255,255,255,0.6)',
+                borderColor: 'rgba(255,255,255,0.12)',
+                border: '1px solid',
+                borderRadius: '999px',
+                px: 2.5,
+                py: 0.6,
+                textTransform: 'none',
+                fontSize: '0.8rem',
+                fontWeight: 500,
+                '&:hover': {
+                  borderColor: 'rgba(255,255,255,0.3)',
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  color: '#fafafa',
+                },
+              }}
+            >
+              View Project
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </FadeInView>
+  );
+};
+
+const SmallProjectCard = ({ project, index }) => {
+  return (
+    <FadeInView delay={index * 0.06}>
+      <Box
+        sx={{
+          bgcolor: 'rgba(255,255,255,0.02)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          borderRadius: '16px',
+          overflow: 'hidden',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          transition: 'all 0.3s ease',
+          '&:hover': {
+            borderColor: 'rgba(255,255,255,0.12)',
+            transform: 'translateY(-3px)',
+            '& .sm-project-img': { transform: 'scale(1.03)' },
+          },
+        }}
+      >
+        <Box sx={{ position: 'relative', height: 160, overflow: 'hidden' }}>
+          <Image
+            src={`/images/${project.coverImage}`}
+            alt={project.title}
+            fill
+            sizes="(max-width: 768px) 100vw, 33vw"
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="sm-project-img"
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 40%, rgba(9,9,11,0.9) 100%)',
+            }}
+          />
+        </Box>
+        <Box sx={{ p: 2.5, flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)', mb: 0.5 }}>
+            {project.dateStarted} – {project.dateCompleted}
+          </Typography>
+          <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', color: '#fafafa', mb: 1, lineHeight: 1.3 }}>
+            {project.title}
+          </Typography>
+          <Typography
+            sx={{
+              color: 'rgba(255,255,255,0.4)',
+              fontSize: '0.78rem',
+              lineHeight: 1.6,
+              mb: 2,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {project.short_description}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5} sx={{ mb: 2, mt: 'auto' }}>
+            {project.technologies
+              .flatMap((t) => t.tools)
+              .slice(0, 4)
+              .map((tool) => (
+                <Chip
+                  key={tool}
+                  label={tool}
+                  size="small"
+                  sx={{
+                    bgcolor: 'rgba(255,255,255,0.04)',
+                    color: 'rgba(255,255,255,0.45)',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    fontSize: '0.65rem',
+                    height: '20px',
+                  }}
+                />
+              ))}
+          </Stack>
+          <Button
+            href={project.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={<LaunchIcon sx={{ fontSize: '0.8rem !important' }} />}
+            fullWidth
+            sx={{
+              color: 'rgba(255,255,255,0.5)',
+              borderColor: 'rgba(255,255,255,0.08)',
+              border: '1px solid',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '0.75rem',
+              py: 0.6,
+              '&:hover': {
+                borderColor: 'rgba(255,255,255,0.2)',
+                bgcolor: 'rgba(255,255,255,0.04)',
+                color: '#fafafa',
+              },
+            }}
+          >
+            View
+          </Button>
+        </Box>
+      </Box>
+    </FadeInView>
+  );
+};
+
+const Projects = () => {
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    fetch('/data/projects.json')
+      .then((r) => r.json())
+      .then((data) => {
+        setProjects([...data].sort((a, b) => new Date(b.dateStarted) - new Date(a.dateStarted)));
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const featured = projects.filter((p) => p.featured);
+  const others = projects.filter((p) => !p.featured);
+
+  return (
+    <SectionWrapper
+      label="Projects"
+      title="Things I've built"
+      subtitle="From production RAG pipelines to agentic AI systems and full-stack applications."
+      maxWidth="1100px"
+      sx={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
+    >
+      {loading ? (
+        <Stack spacing={3}>
+          {[1, 2].map((i) => (
+            <Skeleton key={i} variant="rectangular" height={280} sx={{ borderRadius: '20px', bgcolor: 'rgba(255,255,255,0.04)' }} />
+          ))}
+        </Stack>
+      ) : (
+        <>
+          {featured.map((project, i) => (
+            <FeaturedProject key={project.title} project={project} index={i} isReversed={i % 2 === 1} />
+          ))}
+
+          <FadeInView delay={0.1}>
+            <Box sx={{ textAlign: 'center', mt: 2, mb: 3 }}>
+              <Button
+                onClick={() => setShowAll((prev) => !prev)}
+                endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                sx={{
+                  color: 'rgba(255,255,255,0.45)',
+                  borderColor: 'rgba(255,255,255,0.1)',
+                  border: '1px solid',
+                  borderRadius: '999px',
+                  px: 3,
+                  py: 0.75,
+                  textTransform: 'none',
+                  fontSize: '0.8rem',
+                  fontWeight: 500,
+                  '&:hover': {
+                    bgcolor: 'rgba(255,255,255,0.04)',
+                    borderColor: 'rgba(255,255,255,0.2)',
+                    color: '#fafafa',
+                  },
+                }}
+              >
+                {showAll ? 'Show less' : `View all ${projects.length} projects`}
+              </Button>
+            </Box>
+          </FadeInView>
+
+          <Collapse in={showAll} timeout={400}>
+            <Grid container spacing={2}>
+              {others.map((project, i) => (
+                <Grid key={project.title} size={{ xs: 12, sm: 6, md: 4 }}>
+                  <SmallProjectCard project={project} index={i} />
+                </Grid>
+              ))}
+            </Grid>
+          </Collapse>
+        </>
+      )}
+    </SectionWrapper>
+  );
+};
+
+export default Projects;

--- a/next-app/src/components/shared/FadeInView.jsx
+++ b/next-app/src/components/shared/FadeInView.jsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRef } from 'react';
+import { Box } from '@mui/material';
+import { useInView } from 'react-intersection-observer';
+
+const FadeInView = ({ children, delay = 0, direction = 'up', sx = {}, ...props }) => {
+  const { ref, inView } = useInView({ triggerOnce: true, threshold: 0.1 });
+
+  const transforms = {
+    up: 'translateY(32px)',
+    down: 'translateY(-32px)',
+    left: 'translateX(32px)',
+    right: 'translateX(-32px)',
+    none: 'none',
+  };
+
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        opacity: inView ? 1 : 0,
+        transform: inView ? 'none' : transforms[direction],
+        transition: `opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s, transform 0.7s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s`,
+        willChange: 'opacity, transform',
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default FadeInView;

--- a/next-app/src/components/shared/SectionWrapper.jsx
+++ b/next-app/src/components/shared/SectionWrapper.jsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import FadeInView from './FadeInView';
+
+const SectionWrapper = ({ children, label, title, subtitle, maxWidth = '1200px', sx = {} }) => {
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        py: { xs: 10, md: 14 },
+        px: { xs: 2.5, sm: 4, md: 6 },
+        ...sx,
+      }}
+    >
+      <Box sx={{ maxWidth, mx: 'auto' }}>
+        <FadeInView>
+          <Box sx={{ mb: { xs: 6, md: 8 } }}>
+            {label && (
+              <Typography
+                variant="overline"
+                sx={{
+                  color: '#a78bfa',
+                  fontSize: '0.8rem',
+                  fontWeight: 600,
+                  letterSpacing: '0.15em',
+                  mb: 1.5,
+                  display: 'block',
+                }}
+              >
+                {label}
+              </Typography>
+            )}
+            {title && (
+              <Typography
+                variant="h2"
+                sx={{
+                  fontSize: { xs: '2rem', md: '2.75rem' },
+                  color: '#fafafa',
+                  mb: subtitle ? 1.5 : 0,
+                }}
+              >
+                {title}
+              </Typography>
+            )}
+            {subtitle && (
+              <Typography
+                variant="body1"
+                sx={{
+                  color: 'rgba(255,255,255,0.45)',
+                  maxWidth: '600px',
+                  fontSize: { xs: '0.95rem', md: '1.05rem' },
+                }}
+              >
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+        </FadeInView>
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default SectionWrapper;

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,33 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: 'rgba(255, 255, 255, 0.5)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#a78bfa',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#38bdf8',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.03em', lineHeight: 1.05 },
+    h2: { fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.015em' },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7 },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete redesign of the portfolio with a modern 2026 design system — moving from the current particle-heavy, cyan/purple MUI dark theme to a refined, typography-driven layout with scroll-triggered animations and bento grid compositions.

### What changed

- **New design system**: Dark zinc palette (`#09090b`), violet (`#a78bfa`) and sky (`#38bdf8`) accents, subtle grain texture, ambient gradient orbs — replacing the particle background and animated gradient hero
- **Hero section**: Bold typographic intro with animated role cycling ("AI engineer", "full-stack developer", "builder"). AI chat moved from full-screen takeover to a floating widget in the bottom-right corner, always accessible without disrupting the portfolio flow
- **About section**: Bento grid layout combining bio card (with headshot, social links, resume), awards card, and a full-width categorized skills grid — replacing the old headshot + text + hidden timeline layout
- **Experience section** (new): Dedicated timeline section with company logos, bullet points, location, and active-state indicators — previously hidden on screens below 1250px
- **Projects section**: Featured projects displayed as alternating large image+content cards, remaining projects in a compact grid — replacing the uniform card grid
- **Contact section**: Cleaner glass-morphism form with side-by-side name/email fields and gradient submit button
- **Navigation**: Pill-style nav bar with scroll-aware active state indicator — replacing the underline-based nav
- **Footer**: Compact layout with back-to-top button and social links
- **Shared components**: `FadeInView` (IntersectionObserver-based scroll reveals) and `SectionWrapper` (consistent section layout with label/title/subtitle pattern)
- **Chat components**: Updated `ChatInput` and `MessageItem` styling to match new palette

### Architecture notes

- Old component directories (`Greeting-Page/`, `About-Page/`, `Skills-Page/`, `Awards-Page/`, `Projects-Page/`, `Contact-Page/`) are still present but no longer imported — they can be cleaned up in a follow-up
- Skills and Awards data are now integrated into the About bento grid instead of standalone sections
- Experience data gets its own dedicated section, visible at all screen sizes
- `tsparticles` is no longer used on the main page (dependency still installed)
- GSAP scroll animations replaced with lighter IntersectionObserver-based `FadeInView`
- All existing API routes, chat hooks, auth flow, and data files are unchanged

## Test plan

- [ ] Verify hero section renders with animated role text and "Explore my work" scroll button
- [ ] Verify chat widget opens/closes via floating button, sends messages, and displays streamed responses
- [ ] Verify quick-action chips in hero trigger cached chat responses
- [ ] Verify About bento grid loads skills from `/data/skills.json` and awards from `/data/awards.json`
- [ ] Verify Experience section loads and sorts data from `/data/experiences.json`
- [ ] Verify Projects section loads from `/data/projects.json`, shows featured projects prominently, and "View all" expands the remaining grid
- [ ] Verify Contact form submits with Turnstile CAPTCHA
- [ ] Verify nav pill highlights correct section on scroll
- [ ] Verify responsive layout on mobile (xs), tablet (sm/md), and desktop (lg)
- [ ] Verify `npm run build` passes cleanly
- [ ] Verify `npm run lint` passes cleanly

https://claude.ai/code/session_014zLbKdB5FRVyb7eriaRF1i

---
_Generated by [Claude Code](https://claude.ai/code/session_014zLbKdB5FRVyb7eriaRF1i)_