### PR TITLE
Redesign: Complete portfolio UI overhaul

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,10 +4,10 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['300', '400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
@@ -15,8 +15,18 @@ const montserrat = Montserrat({
 
 export const metadata = {
   title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'UI/UX Design',
+    'React Developer',
+    'Node.js',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
     title: 'David Riva - Personal Portfolio',
     description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
@@ -43,7 +53,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={montserrat.variable} style={{ margin: 0, overflowX: 'hidden' }}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -4,10 +4,10 @@ import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
 
@@ -15,8 +15,8 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#06060a',
+        color: '#e8e8ed',
         position: 'relative',
         minHeight: '100vh',
       }}
@@ -27,59 +27,100 @@ const MainPage = () => {
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          overflow: 'hidden',
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(96,165,250,0.08) 0%, transparent 60%), radial-gradient(ellipse 60% 50% at 20% 60%, rgba(167,139,250,0.06) 0%, transparent 50%), radial-gradient(ellipse 50% 40% at 80% 30%, rgba(96,165,250,0.04) 0%, transparent 50%)',
+            animation: 'meshDrift 20s ease-in-out infinite',
+            '@keyframes meshDrift': {
+              '0%, 100%': {
+                background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(96,165,250,0.08) 0%, transparent 60%), radial-gradient(ellipse 60% 50% at 20% 60%, rgba(167,139,250,0.06) 0%, transparent 50%), radial-gradient(ellipse 50% 40% at 80% 30%, rgba(96,165,250,0.04) 0%, transparent 50%)',
+              },
+              '33%': {
+                background: 'radial-gradient(ellipse 70% 50% at 60% 50%, rgba(167,139,250,0.08) 0%, transparent 60%), radial-gradient(ellipse 50% 60% at 30% 40%, rgba(96,165,250,0.06) 0%, transparent 50%), radial-gradient(ellipse 60% 40% at 70% 70%, rgba(167,139,250,0.04) 0%, transparent 50%)',
+              },
+              '66%': {
+                background: 'radial-gradient(ellipse 60% 70% at 40% 30%, rgba(96,165,250,0.07) 0%, transparent 60%), radial-gradient(ellipse 70% 40% at 70% 60%, rgba(167,139,250,0.05) 0%, transparent 50%), radial-gradient(ellipse 40% 50% at 30% 50%, rgba(96,165,250,0.05) 0%, transparent 50%)',
+              },
+            },
+          }}
+        />
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage:
+              'radial-gradient(rgba(255,255,255,0.03) 1px, transparent 1px)',
+            backgroundSize: '32px 32px',
+            opacity: 0.5,
+          }}
+        />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box id="about" sx={{ position: 'relative' }}>
         <Box
-          id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(96,165,250,0.2), rgba(167,139,250,0.2), transparent)',
           }}
-        >
-          <About />
-        </Box>
+        />
+        <About />
+      </Box>
 
+      <Box id="experience" sx={{ position: 'relative' }}>
         <Box
-          id="projects"
           sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)',
           }}
-        >
-          <Projects />
-        </Box>
+        />
+        <Experience />
+      </Box>
 
+      <Box id="projects" sx={{ position: 'relative' }}>
         <Box
-          id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(96,165,250,0.2), rgba(167,139,250,0.2), transparent)',
           }}
-        >
-          <Contact />
-        </Box>
+        />
+        <Projects />
+      </Box>
+
+      <Box id="contact" sx={{ position: 'relative' }}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)',
+          }}
+        />
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,279 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
-};
+import { useEffect, useState, useRef } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+import SectionHeading from '@/components/SectionHeading';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const GlassCard = ({ children, sx = {}, ...props }) => (
+  <Box
+    {...props}
+    sx={{
+      bgcolor: 'rgba(255, 255, 255, 0.02)',
+      border: '1px solid rgba(255, 255, 255, 0.05)',
+      borderRadius: '16px',
+      p: 3,
+      transition: 'all 0.3s ease',
+      '&:hover': {
+        bgcolor: 'rgba(255, 255, 255, 0.035)',
+        borderColor: 'rgba(255, 255, 255, 0.08)',
+      },
+      ...sx,
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const StatItem = ({ value, label }) => (
+  <Box sx={{ textAlign: 'center' }}>
+    <Typography sx={{ fontSize: '1.75rem', fontWeight: 700, color: '#e8e8ed', lineHeight: 1.1 }}>{value}</Typography>
+    <Typography sx={{ fontSize: '0.72rem', color: '#6b6b80', mt: 0.5, fontWeight: 500 }}>{label}</Typography>
+  </Box>
+);
+
+const SocialLink = ({ href, icon, label }) => (
+  <Box
+    component="a"
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1,
+      px: 2,
+      py: 1,
+      borderRadius: '10px',
+      bgcolor: 'rgba(255, 255, 255, 0.03)',
+      border: '1px solid rgba(255, 255, 255, 0.05)',
+      color: '#8888a0',
+      textDecoration: 'none',
+      fontSize: '0.82rem',
+      fontWeight: 500,
+      transition: 'all 0.2s ease',
+      '&:hover': {
+        bgcolor: 'rgba(255, 255, 255, 0.06)',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        color: '#e8e8ed',
+      },
+    }}
+  >
+    {icon}
+    {label}
+  </Box>
+);
 
 const About = () => {
+  const [skills, setSkills] = useState([]);
+  const [awards, setAwards] = useState([]);
+  const gridRef = useRef(null);
+
+  useEffect(() => {
+    fetch('/data/skills.json')
+      .then((res) => res.json())
+      .then(setSkills);
+    fetch('/data/awards.json')
+      .then((res) => res.json())
+      .then(setAwards);
+  }, []);
+
+  useEffect(() => {
+    if (!gridRef.current) return;
+    const cards = gridRef.current.querySelectorAll('.bento-card');
+    gsap.fromTo(
+      cards,
+      { y: 40, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.7,
+        stagger: 0.08,
+        ease: 'power3.out',
+        scrollTrigger: { trigger: gridRef.current, start: 'top 80%' },
+      },
+    );
+    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
+  }, [skills, awards]);
+
+  const allSkillItems = skills.flatMap((cat) => cat.items);
+
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        py: { xs: 8, md: 12 },
       }}
     >
-      <Box
-        sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
-        </Box>
-      </Box>
-
-      <AboutTextSection />
+      <SectionHeading label="About" title="Get to know me" />
 
       <Box
+        ref={gridRef}
         sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' },
+          gridTemplateRows: 'auto',
+          gap: 2,
         }}
       >
-        <SimpleTimeline />
+        {/* Main bio card - spans 2 columns */}
+        <GlassCard
+          className="bento-card"
+          sx={{
+            gridColumn: { xs: '1', md: '1 / 3' },
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { xs: 'center', sm: 'flex-start' },
+            gap: 3,
+            p: { xs: 3, md: 4 },
+          }}
+        >
+          <Box
+            sx={{
+              width: 130,
+              height: 130,
+              borderRadius: '16px',
+              overflow: 'hidden',
+              flexShrink: 0,
+              border: '2px solid rgba(96, 165, 250, 0.15)',
+            }}
+          >
+            <Image
+              alt="Photo of David Riva"
+              src="/images/headshot.webp"
+              width={130}
+              height={130}
+              style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+              priority
+            />
+          </Box>
+          <Box>
+            <Typography variant="h3" sx={{ color: '#e8e8ed', mb: 0.5 }}>
+              David Riva
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.9rem',
+                fontWeight: 500,
+                background: 'linear-gradient(135deg, #60a5fa, #a78bfa)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                mb: 2,
+              }}
+            >
+              Software Engineer &bull; Bay Area, CA
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 1.5 }}>
+              Software engineer with a strong background in full-stack development, applied AI, and data engineering.
+              Colorado State University graduate (B.S. Computer Science, Summa Cum Laude). Passionate about building
+              production-grade systems that solve real problems.
+            </Typography>
+            <Typography variant="body1">
+              Experienced in building data-intensive applications, agentic AI pipelines, and developer tooling. I
+              pride myself on clean architecture and delivering under tight deadlines.
+            </Typography>
+          </Box>
+        </GlassCard>
+
+        {/* Stats card */}
+        <GlassCard className="bento-card" sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <Typography variant="overline" sx={{ mb: 2.5, fontSize: '0.7rem' }}>
+            At a glance
+          </Typography>
+          <Stack spacing={2.5}>
+            <StatItem value="4.0" label="GPA — Summa Cum Laude" />
+            <StatItem value="8,000+" label="Learners trained at C3 AI" />
+            <StatItem value="1st" label="C3 AI Hackathon 2025" />
+          </Stack>
+        </GlassCard>
+
+        {/* Skills card - spans 2 columns */}
+        <GlassCard className="bento-card" sx={{ gridColumn: { xs: '1', md: '1 / 3' } }}>
+          <Typography variant="overline" sx={{ mb: 2, display: 'block', fontSize: '0.7rem' }}>
+            Technical Skills
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" gap={0.75}>
+            {allSkillItems.map((skill) => (
+              <Chip
+                key={skill}
+                label={skill}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(96, 165, 250, 0.06)',
+                  color: '#8888a0',
+                  border: '1px solid rgba(96, 165, 250, 0.1)',
+                  fontSize: '0.72rem',
+                  height: '28px',
+                  fontWeight: 500,
+                  '&:hover': {
+                    bgcolor: 'rgba(96, 165, 250, 0.12)',
+                    color: '#60a5fa',
+                  },
+                  transition: 'all 0.2s ease',
+                }}
+              />
+            ))}
+          </Stack>
+        </GlassCard>
+
+        {/* Awards card */}
+        <GlassCard className="bento-card">
+          <Typography variant="overline" sx={{ mb: 2, display: 'block', fontSize: '0.7rem' }}>
+            Awards
+          </Typography>
+          <Stack spacing={2}>
+            {awards.map((award) => (
+              <Box key={award.title}>
+                <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: '#e8e8ed', lineHeight: 1.3, mb: 0.25 }}>
+                  {award.title}
+                </Typography>
+                <Typography sx={{ fontSize: '0.72rem', color: '#6b6b80' }}>{award.date}</Typography>
+              </Box>
+            ))}
+          </Stack>
+        </GlassCard>
+
+        {/* Social links */}
+        <GlassCard
+          className="bento-card"
+          sx={{
+            gridColumn: { xs: '1', md: '2 / 4' },
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { xs: 'stretch', sm: 'center' },
+            gap: 1.5,
+          }}
+        >
+          <Typography variant="overline" sx={{ fontSize: '0.7rem', mr: 2, whiteSpace: 'nowrap' }}>
+            Connect
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ flex: 1 }}>
+            <SocialLink
+              href="https://github.com/davidjriva"
+              icon={<GitHubIcon sx={{ fontSize: '1rem' }} />}
+              label="GitHub"
+            />
+            <SocialLink
+              href="https://www.linkedin.com/in/david-j-riva"
+              icon={<LinkedInIcon sx={{ fontSize: '1rem' }} />}
+              label="LinkedIn"
+            />
+            <SocialLink
+              href="mailto:davidjriva@gmail.com"
+              icon={<EmailIcon sx={{ fontSize: '1rem' }} />}
+              label="davidjriva@gmail.com"
+            />
+          </Stack>
+        </GlassCard>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,37 +1,100 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography, Stack } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
+import EmailIcon from '@mui/icons-material/Email';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import GitHubIcon from '@mui/icons-material/GitHub';
+
+const InfoItem = ({ icon, label, value, href }) => (
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+    <Box
+      sx={{
+        width: 40,
+        height: 40,
+        borderRadius: '10px',
+        bgcolor: 'rgba(96, 165, 250, 0.06)',
+        border: '1px solid rgba(96, 165, 250, 0.1)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      {icon}
+    </Box>
+    <Box>
+      <Typography sx={{ fontSize: '0.72rem', color: '#6b6b80', fontWeight: 500 }}>{label}</Typography>
+      {href ? (
+        <Typography
+          component="a"
+          href={href}
+          target={href.startsWith('http') ? '_blank' : undefined}
+          rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+          sx={{
+            fontSize: '0.88rem',
+            color: '#a0a0b0',
+            textDecoration: 'none',
+            '&:hover': { color: '#60a5fa' },
+            transition: 'color 0.2s',
+          }}
+        >
+          {value}
+        </Typography>
+      ) : (
+        <Typography sx={{ fontSize: '0.88rem', color: '#a0a0b0' }}>{value}</Typography>
+      )}
+    </Box>
+  </Box>
+);
 
 const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        py: { xs: 8, md: 12 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      <SectionHeading label="Contact" title="Get in touch" />
 
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1.5fr' },
+          gap: { xs: 4, md: 5 },
+          alignItems: 'start',
         }}
       >
+        {/* Info side */}
+        <Box>
+          <Typography variant="body1" sx={{ mb: 4, maxWidth: 400 }}>
+            Have a project in mind or want to connect? I&apos;d love to hear from you. Send me a message and
+            I&apos;ll get back to you as soon as possible.
+          </Typography>
+          <Stack spacing={2.5}>
+            <InfoItem
+              icon={<EmailIcon sx={{ fontSize: '1.1rem', color: '#60a5fa' }} />}
+              label="Email"
+              value="davidjriva@gmail.com"
+              href="mailto:davidjriva@gmail.com"
+            />
+            <InfoItem
+              icon={<LocationOnIcon sx={{ fontSize: '1.1rem', color: '#60a5fa' }} />}
+              label="Location"
+              value="Bay Area, CA"
+            />
+            <InfoItem
+              icon={<GitHubIcon sx={{ fontSize: '1.1rem', color: '#60a5fa' }} />}
+              label="GitHub"
+              value="github.com/davidjriva"
+              href="https://github.com/davidjriva"
+            />
+          </Stack>
+        </Box>
+
+        {/* Form side */}
         <ContactForm />
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -2,17 +2,24 @@
 
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
 import { Turnstile } from '@marsidev/react-turnstile';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': {
+    color: '#6b6b80',
+    fontSize: '0.88rem',
+    '&.Mui-focused': { color: '#60a5fa' },
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#e8e8ed',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.12)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(96, 165, 250, 0.4)', borderWidth: '1px' },
   },
 };
 
@@ -48,22 +55,38 @@ const ContactForm = () => {
   return (
     <Box
       sx={{
-        width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        bgcolor: 'rgba(255, 255, 255, 0.02)',
+        border: '1px solid rgba(255, 255, 255, 0.05)',
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        p: { xs: 3, md: 4 },
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2, mb: 0 }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={5}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +101,22 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.9rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            py: 1.5,
+            fontSize: '0.88rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #60a5fa, #a78bfa)',
+            borderRadius: '12px',
+            boxShadow: 'none',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #93c5fd, #c4b5fd)',
+              boxShadow: '0 4px 20px rgba(96, 165, 250, 0.2)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.04)',
+              color: 'rgba(255, 255, 255, 0.2)',
             },
           }}
         >
@@ -101,11 +126,11 @@ const ContactForm = () => {
 
       {status && (
         <Typography
-          variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.85rem',
+            color: status.includes('success') ? '#34d399' : '#f87171',
           }}
         >
           {status}

--- a/next-app/src/components/Experience/Experience.js
+++ b/next-app/src/components/Experience/Experience.js
@@ -1,0 +1,207 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { Box, Typography, Stack } from '@mui/material';
+import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, location, startDate, endDate, bulletPoints }) => {
+  const isCurrent = endDate === 'Present';
+  const isGraduation = title.startsWith('Graduated');
+
+  return (
+    <Box
+      className="exp-card"
+      sx={{
+        display: 'flex',
+        gap: { xs: 2, md: 3 },
+        position: 'relative',
+      }}
+    >
+      {/* Timeline line */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column',
+          alignItems: 'center',
+          pt: 0.5,
+          flexShrink: 0,
+          width: 40,
+        }}
+      >
+        <Box
+          sx={{
+            width: 12,
+            height: 12,
+            borderRadius: '50%',
+            bgcolor: isCurrent ? '#60a5fa' : 'rgba(255, 255, 255, 0.1)',
+            border: isCurrent ? '2px solid rgba(96, 165, 250, 0.3)' : '2px solid rgba(255, 255, 255, 0.06)',
+            boxShadow: isCurrent ? '0 0 12px rgba(96, 165, 250, 0.3)' : 'none',
+            flexShrink: 0,
+            zIndex: 1,
+          }}
+        />
+        <Box
+          sx={{
+            width: '1px',
+            flex: 1,
+            background: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.08), transparent)',
+            mt: 1,
+          }}
+        />
+      </Box>
+
+      {/* Content */}
+      <Box
+        sx={{
+          flex: 1,
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+          border: '1px solid rgba(255, 255, 255, 0.05)',
+          borderRadius: '16px',
+          p: { xs: 2.5, md: 3 },
+          mb: 2,
+          transition: 'all 0.3s ease',
+          '&:hover': {
+            bgcolor: 'rgba(255, 255, 255, 0.035)',
+            borderColor: 'rgba(255, 255, 255, 0.08)',
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: bulletPoints ? 2 : 0 }}>
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: '10px',
+              overflow: 'hidden',
+              bgcolor: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              p: 0.5,
+            }}
+          >
+            <Image
+              src={`/images/${logoImage}`}
+              alt={`${company} logo`}
+              width={32}
+              height={32}
+              style={{ objectFit: 'contain' }}
+            />
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            <Typography sx={{ fontSize: '0.95rem', fontWeight: 600, color: '#e8e8ed', lineHeight: 1.3 }}>
+              {title}
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
+              <Typography
+                component="a"
+                href={companyWebsiteLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  fontSize: '0.82rem',
+                  color: '#60a5fa',
+                  textDecoration: 'none',
+                  fontWeight: 500,
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {company}
+              </Typography>
+              <Typography sx={{ fontSize: '0.75rem', color: '#6b6b80' }}>&bull;</Typography>
+              <Typography sx={{ fontSize: '0.75rem', color: '#6b6b80' }}>{location}</Typography>
+            </Box>
+            <Typography
+              sx={{
+                fontSize: '0.72rem',
+                color: isCurrent ? '#60a5fa' : '#6b6b80',
+                fontWeight: isCurrent ? 500 : 400,
+                mt: 0.5,
+              }}
+            >
+              {isGraduation ? startDate : `${startDate} — ${endDate}`}
+            </Typography>
+          </Box>
+        </Box>
+
+        {bulletPoints && (
+          <Stack spacing={1} sx={{ pl: { xs: 0, md: 6.5 } }}>
+            {bulletPoints.map((point, i) => (
+              <Box key={i} sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start' }}>
+                <Box
+                  sx={{
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(96, 165, 250, 0.4)',
+                    mt: '8px',
+                    flexShrink: 0,
+                  }}
+                />
+                <Typography sx={{ fontSize: '0.82rem', color: '#8888a0', lineHeight: 1.6 }}>{point}</Typography>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const Experience = () => {
+  const [data, setData] = useState([]);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((d) => {
+        const sorted = [...d].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setData(sorted);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current || data.length === 0) return;
+    const cards = containerRef.current.querySelectorAll('.exp-card');
+    gsap.fromTo(
+      cards,
+      { y: 30, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.6,
+        stagger: 0.1,
+        ease: 'power3.out',
+        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+      },
+    );
+    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
+  }, [data]);
+
+  return (
+    <Box
+      sx={{
+        maxWidth: '900px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        py: { xs: 8, md: 12 },
+      }}
+    >
+      <SectionHeading label="Experience" title="Where I've worked" />
+      <Box ref={containerRef}>
+        {data.map((exp) => (
+          <ExperienceCard key={exp.title} {...exp} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,39 +1,96 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, Stack } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+
+const FooterLink = ({ href, icon }) => (
+  <Box
+    component="a"
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    sx={{
+      width: 36,
+      height: 36,
+      borderRadius: '10px',
+      bgcolor: 'rgba(255, 255, 255, 0.03)',
+      border: '1px solid rgba(255, 255, 255, 0.05)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: '#6b6b80',
+      textDecoration: 'none',
+      transition: 'all 0.2s ease',
+      '&:hover': {
+        bgcolor: 'rgba(255, 255, 255, 0.06)',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        color: '#a0a0b0',
+      },
+    }}
+  >
+    {icon}
+  </Box>
+);
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        bgcolor: '#06060a',
+        borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        py: 5,
+        px: { xs: 3, md: 5 },
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <Box
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          maxWidth: '1200px',
+          mx: 'auto',
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 3,
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
-      </Typography>
+        <Typography sx={{ fontSize: '0.82rem', color: '#6b6b80', fontWeight: 400 }}>
+          {new Date().getFullYear()} David Riva. All rights reserved.
+        </Typography>
+
+        <Stack direction="row" spacing={1}>
+          <FooterLink href="https://github.com/davidjriva" icon={<GitHubIcon sx={{ fontSize: '1rem' }} />} />
+          <FooterLink
+            href="https://www.linkedin.com/in/david-j-riva"
+            icon={<LinkedInIcon sx={{ fontSize: '1rem' }} />}
+          />
+          <FooterLink href="mailto:davidjriva@gmail.com" icon={<EmailIcon sx={{ fontSize: '1rem' }} />} />
+        </Stack>
+
+        <Box
+          component="button"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            background: 'none',
+            border: 'none',
+            color: '#6b6b80',
+            cursor: 'pointer',
+            fontSize: '0.82rem',
+            fontFamily: 'inherit',
+            fontWeight: 500,
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#a0a0b0' },
+          }}
+        >
+          Back to top
+          <KeyboardArrowUpIcon sx={{ fontSize: '1rem' }} />
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -1,83 +1,76 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 
 const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
     const currentRole = `${ROLES[roleIndex]}.`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
-      timer = setTimeout(() => {
-        setText((prev) => prev + currentRole[index]);
-        setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev + currentRole[index]);
+          setIndex((prev) => prev + 1);
+        },
+        90 + Math.random() * 40,
+      );
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 1400);
     } else if (deleting && index > 0) {
-      // Deleting logic
-      timer = setTimeout(() => {
-        setText((prev) => prev.slice(0, -1));
-        setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev.slice(0, -1));
+          setIndex((prev) => prev - 1);
+        },
+        40 + Math.random() * 30,
+      );
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
+    const blinkCursor = setInterval(() => setCursorVisible((prev) => !prev), 400);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.3rem', md: '1.5rem' },
+        fontWeight: 300,
+        color: '#6b6b80',
+        textAlign: 'center',
+        minHeight: '2em',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      I&apos;m {getArticle(ROLES[roleIndex])}{' '}
+      <Box component="span" sx={{ color: '#a0a0b0', fontWeight: 400 }}>
+        {text}
+      </Box>
+      <Box component="span" sx={{ color: '#60a5fa', opacity: cursorVisible ? 1 : 0, transition: 'opacity 0.1s' }}>
+        |
+      </Box>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -40,33 +40,9 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', color: '#60a5fa' },
+  { label: 'Tell me about your experience', color: '#a78bfa' },
+  { label: 'Featured projects', color: '#8888a0' },
 ];
 
 const HeroChat = () => {
@@ -89,8 +65,8 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#e8e8ed', zIndex: 1 }}>
+      {/* Pre-chat hero view */}
       <Box
         sx={{
           position: 'absolute',
@@ -99,46 +75,70 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 3,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease-out, transform 400ms ease-out',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
         <Typography
-          variant="h1"
+          variant="overline"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
-            textAlign: 'center',
+            color: '#60a5fa',
+            fontSize: '0.8rem',
+            letterSpacing: '0.2em',
+            mb: -1,
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          Software Engineer
+        </Typography>
+
+        <Typography
+          variant="h1"
+          sx={{
+            textAlign: 'center',
+            fontWeight: 800,
+            lineHeight: 1.0,
+          }}
+        >
+          <Box component="span" sx={{ color: '#e8e8ed' }}>
+            David{' '}
+          </Box>
+          <Box
+            component="span"
+            sx={{
+              background: 'linear-gradient(135deg, #60a5fa, #a78bfa)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
+            Riva
+          </Box>
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={
+              turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask my AI agent anything...'
+            }
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: 'rgba(248,113,113,0.85)', minHeight: '1.2em' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ mt: -0.5 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -152,31 +152,29 @@ const HeroChat = () => {
               }}
               sx={{
                 height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                background: 'rgba(255, 255, 255, 0.03)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
+                borderRadius: '10px',
                 cursor: 'pointer',
-                transition: 'all 0.2s ease',
+                transition: 'all 0.25s ease',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.85,
                 },
                 '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
+                  background: 'rgba(255, 255, 255, 0.06)',
+                  borderColor: 'rgba(255, 255, 255, 0.15)',
+                  transform: 'translateY(-1px)',
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +187,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +203,35 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.75,
+            px: 0,
+            py: 0,
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: 'none',
+            color: '#6b6b80',
+            fontFamily: 'var(--font-montserrat), sans-serif',
+            fontWeight: 500,
+            fontSize: '0.82rem',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            flexDirection: 'column',
+            '&:hover': { color: '#a0a0b0' },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Scroll to explore
+          <KeyboardArrowDownIcon
+            sx={{
+              fontSize: '1.2rem',
+              animation: 'floatDown 2s ease-in-out infinite',
+              '@keyframes floatDown': {
+                '0%, 100%': { transform: 'translateY(0)' },
+                '50%': { transform: 'translateY(4px)' },
+              },
+            }}
+          />
         </Box>
       </Box>
 
@@ -233,11 +243,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease-out 120ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +255,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.04)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #60a5fa, #a78bfa)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.85rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +276,42 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2, color: '#e8e8ed' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.72rem', color: '#6b6b80', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
+          <Typography
+            component="button"
+            onClick={scrollToAbout}
+            sx={{
+              fontSize: '0.72rem',
+              color: '#6b6b80',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              '&:hover': { color: '#a0a0b0' },
+            }}
+          >
             ↓ scroll for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.04)',
+            background: 'rgba(6, 6, 10, 0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +319,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -1,122 +1,23 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useState, useRef } from 'react';
-import { useGSAP } from '@gsap/react';
-import gsap from 'gsap';
 
 const Logo = () => {
-  const container = useRef();
-  const [hovered, setHovered] = useState(false);
-
-  useGSAP(() => {
-    if (hovered) {
-      // Brackets expand outward and disappear
-      gsap.to(".bracket-left", { x: -20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      gsap.to(".bracket-right", { x: 20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      
-      // Slash disappears as it "transforms" into the stand
-      gsap.to(".code-slash", { opacity: 0, scale: 0, duration: 0.3 });
-
-      // Monitor Screen assembles
-      gsap.fromTo(".monitor-screen", 
-        { opacity: 0, scale: 0.5 },
-        { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.5)" }
-      );
-
-      // Code appearance on screen
-      gsap.to(".monitor-code", { opacity: 1, duration: 0.3, delay: 0.4 });
-      gsap.fromTo(".code-line", 
-        { scaleX: 0 },
-        { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: "left center", ease: "power1.out" }
-      );
-      
-      // Monitor Stand slides up
-      gsap.fromTo(".monitor-stand-all",
-        { opacity: 0, y: 5 },
-        { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: "power2.out" }
-      );
-    } else {
-      // Restore to initial state
-      gsap.to(".bracket-left", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".bracket-right", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".code-slash", { opacity: 1, scale: 1, duration: 0.4 });
-      
-      gsap.to(".monitor-screen", { opacity: 0, scale: 0.5, duration: 0.3 });
-      gsap.to(".monitor-code", { opacity: 0, duration: 0.2 });
-      gsap.to(".monitor-stand-all", { opacity: 0, y: 5, duration: 0.3 });
-    }
-  }, { scope: container, dependencies: [hovered] });
-
   return (
     <Box
-      ref={container}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
       sx={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        mr: 2,
-        cursor: 'pointer',
-        width: 40,
-        height: 40,
+        width: 28,
+        height: 28,
       }}
     >
-      <svg width="40" height="40" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-        {/* Left Bracket */}
-        <path
-          className="bracket-left"
-          d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
-          strokeWidth="6"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {/* Right Bracket */}
-        <path
-          className="bracket-right"
-          d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
-          strokeWidth="6"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {/* The Slash */}
-        <path
-          className="code-slash"
-          d="M56 35L44 65"
-          stroke="currentColor"
-          strokeWidth="5"
-          strokeLinecap="round"
-        />
-        
-        {/* Monitor Screen Frame - Higher and More Compact */}
-        <rect
-          className="monitor-screen"
-          x="30"
-          y="32"
-          width="40"
-          height="26"
-          rx="2"
-          stroke="#38c0f2"
-          strokeWidth="4"
-          opacity="0"
-          style={{ transformOrigin: 'center' }}
-        />
-
-        {/* Code Content on Screen - Adjusted for new rectangle position */}
-        <g className="monitor-code" opacity="0">
-          <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-        </g>
-        
-        {/* Monitor Stand Group - More Compact Stand */}
-        <g className="monitor-stand-all" opacity="0">
-          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Shortened Stem */}
-          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Sized Base */}
-        </g>
+      <svg width="28" height="28" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="8" y="8" width="84" height="84" rx="20" stroke="#60a5fa" strokeWidth="6" opacity="0.3" />
+        <path d="M32 38L22 50L32 62" stroke="#60a5fa" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M68 38L78 50L68 62" stroke="#60a5fa" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M56 32L44 68" stroke="#a78bfa" strokeWidth="4.5" strokeLinecap="round" />
       </svg>
     </Box>
   );

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -4,41 +4,47 @@ import { Link as ScrollLink } from 'react-scroll';
 import { Toolbar, Box, AppBar, Typography } from '@mui/material';
 import { useState } from 'react';
 import Logo from './Logo';
-import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const pages = ['About', 'Experience', 'Projects', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+const NavLink = ({ page, active, setActivePage }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-80}
+    duration={600}
+    onSetActive={() => setActivePage(page)}
+    style={{ textDecoration: 'none', cursor: 'pointer' }}
+  >
+    <Box
+      sx={{
+        position: 'relative',
+        px: 2,
+        py: 0.75,
+        borderRadius: '8px',
+        transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        bgcolor: active ? 'rgba(96, 165, 250, 0.08)' : 'transparent',
+        '&:hover': {
+          bgcolor: active ? 'rgba(96, 165, 250, 0.12)' : 'rgba(255, 255, 255, 0.04)',
+        },
       }}
     >
-      {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+      <Typography
+        sx={{
+          fontSize: '0.82rem',
+          fontWeight: active ? 600 : 400,
+          color: active ? '#60a5fa' : '#6b6b80',
+          transition: 'color 0.3s ease',
+          letterSpacing: '0.02em',
+          '&:hover': { color: active ? '#60a5fa' : '#a0a0b0' },
+        }}
+      >
+        {page}
+      </Typography>
+    </Box>
+  </ScrollLink>
+);
 
 const NavBar = () => {
   const [activePage, setActivePage] = useState('About');
@@ -46,44 +52,97 @@ const NavBar = () => {
   return (
     <AppBar
       position="fixed"
+      elevation={0}
       sx={{
         top: 0,
         zIndex: 1100,
         width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
+        bgcolor: 'rgba(6, 6, 10, 0.6)',
+        backdropFilter: 'blur(20px) saturate(1.5)',
+        height: '60px',
+        color: '#e8e8ed',
+        borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
         boxShadow: 'none',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: { xs: 2, md: 5 },
+          minHeight: '60px !important',
+          height: '60px',
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+            gap: 1.5,
+            '&:hover': { opacity: 0.8 },
+            transition: 'opacity 0.2s ease',
+          }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
           <Logo />
           <Typography
-            variant="h6"
-            component="div"
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              fontWeight: 700,
+              letterSpacing: '-0.02em',
+              fontSize: '1.05rem',
+              color: '#e8e8ed',
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            david
+            <Box component="span" sx={{ color: '#60a5fa' }}>
+              riva
+            </Box>
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'flex' },
+            alignItems: 'center',
+            gap: 0.5,
+            bgcolor: 'rgba(255, 255, 255, 0.02)',
+            border: '1px solid rgba(255, 255, 255, 0.04)',
+            borderRadius: '12px',
+            p: 0.5,
+          }}
+        >
           {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
           ))}
+        </Box>
+
+        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
+          <Box
+            component="a"
+            href="/documents/resume.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              px: 2.5,
+              py: 0.75,
+              borderRadius: '8px',
+              border: '1px solid rgba(96, 165, 250, 0.25)',
+              bgcolor: 'rgba(96, 165, 250, 0.06)',
+              color: '#60a5fa',
+              fontSize: '0.82rem',
+              fontWeight: 600,
+              textDecoration: 'none',
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                bgcolor: 'rgba(96, 165, 250, 0.12)',
+                borderColor: 'rgba(96, 165, 250, 0.4)',
+              },
+            }}
+          >
+            Resume
+          </Box>
         </Box>
       </Toolbar>
     </AppBar>

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,172 +2,153 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Chip, Stack } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
-      <Card
+      <Box
         ref={ref}
         id={id}
+        component="a"
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
         sx={{
-          height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          height: '100%',
+          bgcolor: featured ? 'rgba(96, 165, 250, 0.02)' : 'rgba(255, 255, 255, 0.02)',
+          border: featured ? '1px solid rgba(96, 165, 250, 0.1)' : '1px solid rgba(255, 255, 255, 0.05)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          textDecoration: 'none',
+          color: 'inherit',
+          transition: 'all 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
+          cursor: 'pointer',
           '&:hover': {
-            transform: 'translateY(-6px)',
+            transform: 'translateY(-4px)',
+            bgcolor: featured ? 'rgba(96, 165, 250, 0.04)' : 'rgba(255, 255, 255, 0.035)',
+            borderColor: featured ? 'rgba(96, 165, 250, 0.2)' : 'rgba(255, 255, 255, 0.1)',
             boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+              ? '0 16px 40px rgba(96, 165, 250, 0.08)'
+              : '0 12px 32px rgba(0, 0, 0, 0.2)',
+            '& .project-cover': { transform: 'scale(1.03)' },
+            '& .launch-icon': { opacity: 1, transform: 'translate(0, 0)' },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        {/* Cover image */}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? 200 : 170,
+            width: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            className="project-cover"
+            style={{
+              objectFit: 'cover',
+              transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+            }}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
-        </CardContent>
-      </Card>
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 40%, rgba(6, 6, 10, 0.8) 100%)',
+            }}
+          />
+          <Box
+            className="launch-icon"
+            sx={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              width: 28,
+              height: 28,
+              borderRadius: '8px',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              backdropFilter: 'blur(8px)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: 0,
+              transform: 'translate(4px, -4px)',
+              transition: 'all 0.3s ease',
+            }}
+          >
+            <LaunchIcon sx={{ fontSize: '0.85rem', color: '#e8e8ed' }} />
+          </Box>
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ p: 2.5, flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <Typography sx={{ fontSize: '0.95rem', fontWeight: 600, color: '#e8e8ed', lineHeight: 1.3, mb: 0.5 }}>
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: '0.72rem', color: '#6b6b80', mb: 1.5 }}>
+            {dateStarted} — {dateCompleted}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.82rem',
+              color: '#8888a0',
+              lineHeight: 1.6,
+              mb: 2,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              flex: 1,
+            }}
+          >
+            {short_description}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" gap={0.5}>
+            {allTools.slice(0, 5).map((tool, i) => (
+              <Chip
+                key={i}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(96, 165, 250, 0.06)',
+                  color: '#6b6b80',
+                  border: '1px solid rgba(96, 165, 250, 0.08)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  fontWeight: 500,
+                }}
+              />
+            ))}
+            {allTools.length > 5 && (
+              <Chip
+                label={`+${allTools.length - 5}`}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.03)',
+                  color: '#6b6b80',
+                  border: '1px solid rgba(255, 255, 255, 0.05)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  fontWeight: 500,
+                }}
+              />
+            )}
+          </Stack>
+        </Box>
+      </Box>
     );
-  }
+  },
 );
 
 ProjectCard.displayName = 'ProjectCard';

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,17 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        py: { xs: 8, md: 12 },
       }}
     >
-      <SectionHeading sectionName="Projects" />
-
+      <SectionHeading label="Projects" title="What I've built" />
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -26,7 +26,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
         stagger: 0.12,
         ease: 'power3.out',
         scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
-      }
+      },
     );
     ScrollTrigger.refresh();
     return () => ScrollTrigger.getAll().forEach((t) => t.kill());
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -55,13 +55,13 @@ const AllProjects = ({ projects }) => {
     gsap.fromTo(
       cards,
       { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
+      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' },
     );
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,22 +92,28 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: 'rgba(255,255,255,0.02)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(255,255,255,0.05)',
+                }}
+              >
+                <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.2rem', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <>
           <FeaturedProjects projects={featuredProjects} />
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
@@ -115,22 +121,19 @@ const ProjectsContainer = () => {
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
+                color: '#6b6b80',
+                border: '1px solid rgba(255,255,255,0.06)',
+                borderRadius: '10px',
                 px: 3,
-                py: 0.85,
-                textTransform: 'none',
-                fontSize: '0.85rem',
+                py: 1,
+                fontSize: '0.82rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
+                bgcolor: 'rgba(255,255,255,0.02)',
                 transition: 'all 0.25s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  borderColor: 'rgba(255,255,255,0.1)',
+                  color: '#a0a0b0',
                 },
               }}
             >
@@ -139,11 +142,11 @@ const ProjectsContainer = () => {
           </Box>
 
           <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
+            <Box sx={{ mt: 3 }}>
               <AllProjects projects={otherProjects} />
             </Box>
           </Collapse>
-        </Box>
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,40 +1,30 @@
 import { Box, Typography } from '@mui/material';
 
-const SectionHeading = ({ sectionName }) => {
+const SectionHeading = ({ label, title }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: { xs: 5, md: 7 } }}>
+      <Typography variant="overline" sx={{ display: 'block', mb: 1, fontSize: '0.75rem' }}>
+        {label}
+      </Typography>
       <Typography
         variant="h2"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
+          color: '#e8e8ed',
           position: 'relative',
+          display: 'inline-block',
           '&::after': {
             content: '""',
             position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+            bottom: '-8px',
+            left: 0,
+            width: '40px',
+            height: '3px',
+            background: 'linear-gradient(90deg, #60a5fa, #a78bfa)',
+            borderRadius: '4px',
+          },
         }}
       >
-        {sectionName}
+        {title}
       </Typography>
     </Box>
   );

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,72 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#06060a',
+      paper: '#0f0f16',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#e8e8ed',
+      secondary: '#6b6b80',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#60a5fa',
+      light: '#93c5fd',
+      dark: '#3b82f6',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#a78bfa',
+      light: '#c4b5fd',
+      dark: '#8b5cf6',
     },
+    divider: 'rgba(255, 255, 255, 0.06)',
+  },
+  shape: {
+    borderRadius: 12,
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-montserrat), system-ui, -apple-system, sans-serif',
+    h1: {
+      fontWeight: 800,
+      fontSize: 'clamp(2.5rem, 6vw, 5rem)',
+      lineHeight: 1.05,
+      letterSpacing: '-0.03em',
+    },
+    h2: {
+      fontWeight: 700,
+      fontSize: 'clamp(2rem, 4vw, 3rem)',
+      lineHeight: 1.1,
+      letterSpacing: '-0.02em',
+    },
+    h3: {
+      fontWeight: 700,
+      fontSize: 'clamp(1.25rem, 2vw, 1.5rem)',
+      lineHeight: 1.2,
+      letterSpacing: '-0.01em',
+    },
+    h4: { fontWeight: 600, fontSize: '1.25rem', lineHeight: 1.3 },
+    h5: { fontWeight: 600, fontSize: '1.1rem', lineHeight: 1.4 },
+    h6: { fontWeight: 600, fontSize: '0.95rem', lineHeight: 1.4 },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '1rem', color: '#a0a0b0' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.875rem', color: '#8888a0' },
+    caption: { fontSize: '0.75rem', color: '#6b6b80', lineHeight: 1.5 },
+    overline: {
+      fontWeight: 600,
+      fontSize: '0.75rem',
+      letterSpacing: '0.12em',
+      textTransform: 'uppercase',
+      color: '#60a5fa',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          fontWeight: 600,
+          borderRadius: 10,
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

Complete redesign of the portfolio with a modern 2026 aesthetic, replacing the previous dark-purple/cyan theme with a refined editorial design system.

### What changed

- **New color palette** — soft blue (`#60a5fa`), violet (`#a78bfa`), near-black (`#06060a`) replacing the old cyan/purple scheme
- **Hero section** — animated CSS gradient mesh background replacing the tsparticles library; dramatic typography with gradient text; AI chat agent preserved with updated styling
- **Bento grid About section** — headshot + bio card, stats card, skills tag cloud, awards list, and social links all in an asymmetric grid layout
- **New Experience section** — dedicated timeline with company logos, bullet points, and scroll-driven GSAP reveal animations (previously a small sidebar timeline in About)
- **Redesigned project cards** — hover-reveal launch icons, cleaner typography, tech chip overflow with `+N` indicator, full card is a clickable link
- **Pill-shaped navbar** — grouped nav links in a bordered container with active state highlighting, resume CTA button, simplified logo
- **Split-layout contact section** — info sidebar (email, location, GitHub) alongside the form
- **Minimal footer** — social icon row, copyright, back-to-top button
- **Consistent glassmorphism** — `rgba(255,255,255,0.02)` cards with `0.05` borders throughout
- **Better typography** — refined sizing with `clamp()`, tighter letter-spacing, muted secondary text colors
- **SectionHeading component** — now takes `label` (overline) + `title` props with left-aligned gradient underline

### What's preserved

- All data files (`projects.json`, `experiences.json`, `skills.json`, `awards.json`) unchanged
- AI chat agent functionality (Turnstile CAPTCHA, JWT auth, cached chip responses, streaming)
- Contact form with Cloudflare Turnstile
- API routes (`/api/chat`, `/api/token`, `/api/contact`, `/api/health`) untouched
- GSAP scroll-driven animations
- `next/dynamic` lazy loading for below-fold sections
- Vercel Analytics + Speed Insights

## Test plan

- [ ] Verify hero section renders with gradient mesh background and typing animation
- [ ] Test AI chat agent — send a message, verify streaming response works
- [ ] Test cached chip responses (click "What AI have you built?", etc.)
- [ ] Scroll through About bento grid — verify skills, awards, stats, social links render
- [ ] Verify Experience section loads timeline cards with company logos
- [ ] Test Projects section — featured cards render, "View all" expands remaining projects
- [ ] Click a project card — should open GitHub link in new tab
- [ ] Test Contact form — fill out and submit (verify Turnstile renders)
- [ ] Verify nav scroll-spy highlights correct section while scrolling
- [ ] Test Resume button in navbar opens PDF in new tab
- [ ] Check mobile responsiveness (bento grid collapses to single column, nav links hide)
- [ ] Verify footer social links and back-to-top button work

https://claude.ai/code/session_01XtWpKV5PUjHRHumwwT2idQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtWpKV5PUjHRHumwwT2idQ)_