### PR TITLE
Complete portfolio redesign with modern 2026 aesthetic

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,38 +4,46 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in applied AI, full-stack development, and data engineering. View projects involving React, Next.js, LangChain, and distributed systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'AI Engineer',
+    'React Developer',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: "David Riva's portfolio",
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,84 +2,147 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
-
-const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
-const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
-const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
 
+const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/About-Page/SimpleTimeline'), { ssr: false });
+const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
+const Skills = dynamic(() => import('@/components/Skills-Page/Skills'), { ssr: false });
+const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
+
 const MainPage = () => {
   return (
-    <Box
-      sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
-        position: 'relative',
-        minHeight: '100vh',
-      }}
-    >
+    <Box sx={{ bgcolor: '#09090b', color: '#f4f4f5', position: 'relative', minHeight: '100vh' }}>
       <NavBar />
 
+      {/* Hero */}
       <Box
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          overflow: 'hidden',
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
+        {/* Ambient gradient orbs */}
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            overflow: 'hidden',
+            pointerEvents: 'none',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: '-30%',
+              left: '-15%',
+              width: '55vw',
+              height: '55vw',
+              borderRadius: '50%',
+              background: 'radial-gradient(circle, rgba(99, 102, 241, 0.12) 0%, transparent 65%)',
+              filter: 'blur(60px)',
+              animation: 'orbFloat1 22s ease-in-out infinite',
+            },
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              bottom: '-25%',
+              right: '-10%',
+              width: '50vw',
+              height: '50vw',
+              borderRadius: '50%',
+              background: 'radial-gradient(circle, rgba(168, 85, 247, 0.08) 0%, transparent 65%)',
+              filter: 'blur(60px)',
+              animation: 'orbFloat2 28s ease-in-out infinite',
+            },
+            '@keyframes orbFloat1': {
+              '0%, 100%': { transform: 'translate(0, 0) scale(1)' },
+              '33%': { transform: 'translate(4vw, 5vh) scale(1.05)' },
+              '66%': { transform: 'translate(-2vw, 2vh) scale(0.95)' },
+            },
+            '@keyframes orbFloat2': {
+              '0%, 100%': { transform: 'translate(0, 0) scale(1)' },
+              '50%': { transform: 'translate(-6vw, -4vh) scale(1.08)' },
+            },
+          }}
+        />
+
+        {/* Subtle dot grid */}
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            opacity: 0.3,
+            backgroundImage: 'radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px)',
+            backgroundSize: '32px 32px',
+            pointerEvents: 'none',
+          }}
+        />
+
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
+      {/* Content sections */}
+      <Box id="about">
+        <About />
+      </Box>
 
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
+      <Box
+        sx={{
+          height: '1px',
+          maxWidth: 1200,
+          mx: 'auto',
+          bgcolor: 'rgba(255, 255, 255, 0.04)',
+        }}
+      />
 
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+      <Box id="experience">
+        <Experience />
+      </Box>
+
+      <Box
+        sx={{
+          height: '1px',
+          maxWidth: 1200,
+          mx: 'auto',
+          bgcolor: 'rgba(255, 255, 255, 0.04)',
+        }}
+      />
+
+      <Box id="projects">
+        <Projects />
+      </Box>
+
+      <Box
+        sx={{
+          height: '1px',
+          maxWidth: 1200,
+          mx: 'auto',
+          bgcolor: 'rgba(255, 255, 255, 0.04)',
+        }}
+      />
+
+      <Box id="skills">
+        <Skills />
+      </Box>
+
+      <Box
+        sx={{
+          height: '1px',
+          maxWidth: 1200,
+          mx: 'auto',
+          bgcolor: 'rgba(255, 255, 255, 0.04)',
+        }}
+      />
+
+      <Box id="contact">
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,232 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
+import { useState, useEffect } from 'react';
+import { Box, Typography, IconButton, Link, Button, Stack } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import PlaceOutlinedIcon from '@mui/icons-material/PlaceOutlined';
+import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import SectionHeading from '@/components/SectionHeading';
+import RevealOnScroll from '@/components/RevealOnScroll';
+
+const cardSx = {
+  bgcolor: '#131316',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '20px',
+  p: { xs: 3, md: 4 },
+  transition: 'border-color 0.3s ease',
+  '&:hover': { borderColor: 'rgba(255, 255, 255, 0.1)' },
 };
 
 const About = () => {
+  const [awards, setAwards] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/awards.json')
+      .then((res) => res.json())
+      .then((data) => setAwards(data));
+  }, []);
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
-      }}
-    >
+    <Box sx={{ py: { xs: 10, md: 14 }, px: { xs: 2, md: 4 } }}>
+      <SectionHeading sectionName="About" />
+
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '320px 1fr 280px' },
+          gap: 2,
+          maxWidth: 1200,
+          mx: 'auto',
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Photo card */}
+        <RevealOnScroll delay={0} sx={{ ...cardSx, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              width: 200,
+              height: 200,
+              borderRadius: '20px',
+              overflow: 'hidden',
+              border: '2px solid rgba(255, 255, 255, 0.08)',
+            }}
+          >
+            <Image
+              alt="Photo of David Riva"
+              src="/images/headshot.webp"
+              width={200}
+              height={200}
+              style={{ objectFit: 'cover', display: 'block' }}
+              priority
+            />
+          </Box>
+
+          <Box sx={{ textAlign: 'center' }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '1.4rem', color: '#f4f4f5', mb: 0.5 }}>
+              David Riva
+            </Typography>
+            <Typography sx={{ fontSize: '0.85rem', color: '#6366f1', fontWeight: 500, mb: 1 }}>
+              Training Engineer, Generative AI
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={1}>
+            <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+              <IconButton
+                aria-label="GitHub"
+                size="small"
+                sx={{
+                  color: '#6b7280',
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  '&:hover': { color: '#f4f4f5', borderColor: 'rgba(255, 255, 255, 0.15)' },
+                }}
+              >
+                <GitHubIcon fontSize="small" />
+              </IconButton>
+            </Link>
+            <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+              <IconButton
+                aria-label="LinkedIn"
+                size="small"
+                sx={{
+                  color: '#6b7280',
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  '&:hover': { color: '#f4f4f5', borderColor: 'rgba(255, 255, 255, 0.15)' },
+                }}
+              >
+                <LinkedInIcon fontSize="small" />
+              </IconButton>
+            </Link>
+            <Link href="mailto:davidjriva@gmail.com">
+              <IconButton
+                aria-label="Email"
+                size="small"
+                sx={{
+                  color: '#6b7280',
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  '&:hover': { color: '#f4f4f5', borderColor: 'rgba(255, 255, 255, 0.15)' },
+                }}
+              >
+                <EmailOutlinedIcon fontSize="small" />
+              </IconButton>
+            </Link>
+          </Stack>
+        </RevealOnScroll>
+
+        {/* Bio card */}
+        <RevealOnScroll delay={0.1} sx={{ ...cardSx, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <Typography sx={{ color: '#a1a1aa', fontSize: '0.95rem', lineHeight: 1.8, mb: 2.5 }}>
+            Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
+            University with a B.S. in Computer Science, Summa Cum Laude. I&apos;m passionate about applied AI
+            engineering and building production-grade software.
+          </Typography>
+          <Typography sx={{ color: '#a1a1aa', fontSize: '0.95rem', lineHeight: 1.8, mb: 2.5 }}>
+            I specialize in full-stack development, AI systems, and data engineering. I have a strong background
+            in data structures, algorithms, and mathematical applications — and I pride myself on elegant
+            problem-solving and high standards of excellence.
+          </Typography>
+
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <PlaceOutlinedIcon sx={{ fontSize: '1rem', color: '#6b7280' }} />
+              <Typography sx={{ fontSize: '0.82rem', color: '#6b7280' }}>Bay Area, CA</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <EmailOutlinedIcon sx={{ fontSize: '1rem', color: '#6b7280' }} />
+              <Typography
+                component="a"
+                href="mailto:davidjriva@gmail.com"
+                sx={{
+                  fontSize: '0.82rem',
+                  color: '#6b7280',
+                  textDecoration: 'none',
+                  '&:hover': { color: '#a1a1aa' },
+                }}
+              >
+                davidjriva@gmail.com
+              </Typography>
+            </Box>
+          </Box>
+
+          <Button
+            onClick={() => window.open('/documents/resume.pdf', '_blank')}
+            startIcon={<DescriptionOutlinedIcon sx={{ fontSize: '1rem' }} />}
+            sx={{
+              mt: 3,
+              alignSelf: 'flex-start',
+              color: '#f4f4f5',
+              bgcolor: 'rgba(99, 102, 241, 0.1)',
+              border: '1px solid rgba(99, 102, 241, 0.2)',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontWeight: 500,
+              fontSize: '0.82rem',
+              px: 2.5,
+              py: 1,
+              '&:hover': {
+                bgcolor: 'rgba(99, 102, 241, 0.18)',
+                borderColor: 'rgba(99, 102, 241, 0.35)',
+              },
+            }}
+          >
+            View Resume
+          </Button>
+        </RevealOnScroll>
+
+        {/* Stats + Awards column */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {/* Stats card */}
+          <RevealOnScroll delay={0.2} sx={cardSx}>
+            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+              {[
+                { value: '2+', label: 'Years Exp.' },
+                { value: '10+', label: 'Projects' },
+                { value: '4.0', label: 'GPA' },
+                { value: '1st', label: 'Hackathon' },
+              ].map((stat) => (
+                <Box key={stat.label} sx={{ textAlign: 'center', py: 1 }}>
+                  <Typography
+                    sx={{
+                      fontSize: '1.8rem',
+                      fontWeight: 800,
+                      letterSpacing: '-0.03em',
+                      background: 'linear-gradient(135deg, #6366f1, #a855f7)',
+                      WebkitBackgroundClip: 'text',
+                      WebkitTextFillColor: 'transparent',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {stat.value}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.72rem', color: '#6b7280', mt: 0.5, fontWeight: 500 }}>
+                    {stat.label}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </RevealOnScroll>
+
+          {/* Awards card */}
+          <RevealOnScroll delay={0.3} sx={{ ...cardSx, flex: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <EmojiEventsOutlinedIcon sx={{ fontSize: '1.1rem', color: '#a855f7' }} />
+              <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: '#f4f4f5', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                Awards
+              </Typography>
+            </Box>
+            {awards.map((award) => (
+              <Box key={award.title} sx={{ mb: 1.5, '&:last-child': { mb: 0 } }}>
+                <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, color: '#e4e4e7', lineHeight: 1.3, mb: 0.25 }}>
+                  {award.title}
+                </Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: '#6b7280' }}>{award.date}</Typography>
+              </Box>
+            ))}
+          </RevealOnScroll>
         </Box>
-      </Box>
-
-      <AboutTextSection />
-
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
       </Box>
     </Box>
   );

--- a/next-app/src/components/About-Page/SimpleTimeline.js
+++ b/next-app/src/components/About-Page/SimpleTimeline.js
@@ -1,153 +1,112 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import {
-  Timeline,
-  TimelineItem,
-  TimelineOppositeContent,
-  TimelineSeparator,
-  TimelineConnector,
-  TimelineDot,
-  TimelineContent,
-} from '@mui/lab';
-import { Typography, Box } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Box, Typography } from '@mui/material';
 import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+import RevealOnScroll from '@/components/RevealOnScroll';
 
-const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate, isEnd }) => {
-  const isCurrent = endDate === 'Present';
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate, index }) => {
+  const isCurrent = endDate === 'Present' || (new Date(endDate) > new Date('2026-01-01'));
   const isGraduation = title.startsWith('Graduated');
 
   return (
-    <TimelineItem>
-      <TimelineOppositeContent sx={{ flex: 'none', width: 130, pr: 1.5, pt: '14px' }}>
-        <Typography
-          variant="caption"
-          sx={{
-            color: isCurrent ? '#38c0f2' : 'rgba(255,255,255,0.45)',
-            fontWeight: isCurrent ? 600 : 400,
-            lineHeight: 1.4,
-            display: 'block',
-          }}
-        >
-          {isGraduation ? startDate : `${startDate} –\u00a0${isCurrent ? 'Present' : endDate}`}
-        </Typography>
-      </TimelineOppositeContent>
+    <RevealOnScroll
+      delay={index * 0.08}
+      sx={{
+        display: 'flex',
+        gap: { xs: 2, md: 3 },
+        p: { xs: 2.5, md: 3 },
+        bgcolor: '#131316',
+        border: isCurrent ? '1px solid rgba(99, 102, 241, 0.2)' : '1px solid rgba(255, 255, 255, 0.06)',
+        borderRadius: '16px',
+        '&:hover': {
+          borderColor: isCurrent ? 'rgba(99, 102, 241, 0.35)' : 'rgba(255, 255, 255, 0.1)',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: '12px',
+          bgcolor: '#1c1c21',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          border: '1px solid rgba(255, 255, 255, 0.06)',
+        }}
+      >
+        <Image
+          src={`/images/${logoImage}`}
+          alt={`${company} logo`}
+          width={24}
+          height={24}
+          style={{ display: 'block', objectFit: 'contain' }}
+        />
+      </Box>
 
-      <TimelineSeparator>
-        <TimelineDot
-          sx={{
-            backgroundColor: '#ffffff',
-            border: isCurrent
-              ? '1.5px solid rgba(56,192,242,0.6)'
-              : '1.5px solid rgba(255,255,255,0.2)',
-            boxShadow: isCurrent ? '0 0 10px 2px rgba(56,192,242,0.25)' : 'none',
-            p: '5px',
-            m: '6px 0',
-          }}
-        >
-          <Image
-            src={`/images/${logoImage}`}
-            alt={`${company} logo`}
-            width={20}
-            height={20}
-            style={{ display: 'block', objectFit: 'contain' }}
-          />
-        </TimelineDot>
-        {!isEnd && (
-          <TimelineConnector
-            sx={{
-              background: 'linear-gradient(to bottom, rgba(56,192,242,0.25), rgba(110,64,201,0.15))',
-              width: '1.5px',
-            }}
-          />
-        )}
-      </TimelineSeparator>
-
-      <TimelineContent sx={{ pl: 1.5, pt: '10px', pb: '16px' }}>
-        <Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 1 }}>
+          <Box>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.95rem', color: '#f4f4f5', lineHeight: 1.3 }}>
+              {isGraduation ? 'Graduated, Summa Cum Laude' : title.split(',')[0]}
+            </Typography>
+            <Typography
+              component="a"
+              href={companyWebsiteLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                fontSize: '0.82rem',
+                color: '#6366f1',
+                textDecoration: 'none',
+                fontWeight: 500,
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              {company}
+            </Typography>
+          </Box>
           <Typography
-            variant="body2"
             sx={{
-              fontWeight: 600,
-              fontSize: '0.8rem',
-              lineHeight: 1.35,
-              color: '#ffffff',
-              mb: 0.25,
+              fontSize: '0.78rem',
+              color: isCurrent ? '#818cf8' : '#6b7280',
+              fontWeight: isCurrent ? 500 : 400,
+              whiteSpace: 'nowrap',
             }}
           >
-            {isGraduation ? 'Graduated' : title.split(',')[0]}
-          </Typography>
-          <Typography
-            component="a"
-            href={companyWebsiteLink}
-            target="_blank"
-            variant="caption"
-            sx={{
-              color: '#38c0f2',
-              textDecoration: 'none',
-              fontSize: '0.72rem',
-              '&:hover': { textDecoration: 'underline' },
-            }}
-          >
-            {company}
+            {isGraduation ? startDate : `${startDate} — ${endDate}`}
           </Typography>
         </Box>
-      </TimelineContent>
-    </TimelineItem>
+      </Box>
+    </RevealOnScroll>
   );
 };
 
-const SimpleTimeline = () => {
-  const [experienceData, setExperienceData] = useState([]);
+const Experience = () => {
+  const [data, setData] = useState([]);
 
   useEffect(() => {
     fetch('/data/experiences.json')
       .then((res) => res.json())
-      .then((data) => setExperienceData(data));
+      .then((d) => setData(d));
   }, []);
 
-  const sortedExperienceData = [...experienceData].sort((a, b) => {
-    return new Date(b.startDate) - new Date(a.startDate);
-  });
+  const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        background: 'rgba(255,255,255,0.03)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        px: 1,
-        py: 2,
-      }}
-    >
-      <Typography
-        variant="overline"
-        sx={{
-          color: 'rgba(255,255,255,0.55)',
-          fontSize: '0.85rem',
-          letterSpacing: '0.18em',
-          fontWeight: 600,
-          mb: 0.5,
-        }}
-      >
-        Experience
-      </Typography>
-      <Timeline sx={{ maxWidth: '22vw', p: 0, m: 0 }}>
-        {sortedExperienceData.map((experience, index) => (
-          <React.Fragment key={experience.title}>
-            <SimpleTimelineItem
-              {...experience}
-              isEnd={index === sortedExperienceData.length - 1}
-            />
-          </React.Fragment>
+    <Box sx={{ py: { xs: 10, md: 14 }, px: { xs: 2, md: 4 } }}>
+      <SectionHeading sectionName="Experience" />
+
+      <Box sx={{ maxWidth: 800, mx: 'auto', display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        {sorted.map((exp, i) => (
+          <ExperienceCard key={exp.title} {...exp} index={i} />
         ))}
-      </Timeline>
+      </Box>
     </Box>
   );
 };
 
-export default SimpleTimeline;
+export default Experience;

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -12,14 +12,15 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
+        p: '5px 8px',
         borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        backgroundColor: 'rgba(255, 255, 255, 0.03)',
+        border: '1px solid rgba(255, 255, 255, 0.08)',
+        backdropFilter: 'blur(16px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255, 255, 255, 0.14)' },
+        '&:focus-within': { borderColor: 'rgba(99, 102, 241, 0.5)' },
       }}
     >
       <InputBase
@@ -34,24 +35,28 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
+          color: '#f4f4f5',
+          fontSize: '0.9rem',
           fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          '& input::placeholder': { color: 'rgba(255, 255, 255, 0.3)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          ml: 0.5,
+          width: 36,
+          height: 36,
+          background: 'linear-gradient(135deg, #6366f1, #a855f7)',
+          transition: 'opacity 0.2s',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255, 255, 255, 0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#fff', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -9,36 +9,28 @@ const MessageItem = ({ msg }) => {
   const mdStyles = {
     fontFamily: 'var(--font-montserrat), Arial, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#e4e4e7',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
           px: 2.5,
           py: 1.5,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          background: isUser ? 'rgba(99, 102, 241, 0.1)' : 'rgba(255, 255, 255, 0.04)',
+          border: isUser ? '1px solid rgba(99, 102, 241, 0.2)' : '1px solid rgba(255, 255, 255, 0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={7} dotColor="#6366f1" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -47,19 +39,26 @@ const MessageItem = ({ msg }) => {
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
                 strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#818cf8',
+                      backgroundColor: 'rgba(99, 102, 241, 0.08)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
                       display: 'inline',
+                      fontSize: '0.85em',
                     }}
                     {...props}
                   />
@@ -67,18 +66,32 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                      color: '#e4e4e7',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.85rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{ color: '#818cf8', textDecoration: 'none' }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#f4f4f5' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,39 +1,22 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+'use client';
+
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
+import RevealOnScroll from '@/components/RevealOnScroll';
 
 const Contact = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
-      }}
-    >
-      <SectionHeading sectionName="Contact Me" />
+    <Box sx={{ py: { xs: 10, md: 14 }, px: { xs: 2, md: 4 } }}>
+      <SectionHeading sectionName="Contact" />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
+      <Typography sx={{ textAlign: 'center', color: '#6b7280', fontSize: '0.95rem', mb: 6, maxWidth: 500, mx: 'auto' }}>
+        Have a project in mind or want to chat? Send me a message and I&apos;ll get back to you.
+      </Typography>
+
+      <RevealOnScroll sx={{ maxWidth: 640, mx: 'auto' }}>
         <ContactForm />
-      </Box>
+      </RevealOnScroll>
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,23 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': {
+    color: '#6b7280',
+    fontSize: '0.85rem',
+    '&.Mui-focused': { color: '#818cf8' },
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#f4f4f5',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.07)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.15)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(99, 102, 241, 0.5)', borderWidth: '1px' },
   },
 };
 
@@ -48,22 +55,38 @@ const ContactForm = () => {
   return (
     <Box
       sx={{
-        width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        bgcolor: '#131316',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        borderRadius: '20px',
+        p: { xs: 3, sm: 4 },
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2, mb: 0 }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +101,26 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.9rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
+            py: 1.5,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #6366f1, #a855f7)',
+            color: '#fff',
+            borderRadius: '12px',
             border: 'none',
+            textTransform: 'none',
+            boxShadow: 'none',
+            transition: 'opacity 0.2s',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #818cf8, #c084fc)',
+              boxShadow: '0 4px 20px rgba(99, 102, 241, 0.3)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(255, 255, 255, 0.2)',
             },
           }}
         >
@@ -101,11 +130,11 @@ const ContactForm = () => {
 
       {status && (
         <Typography
-          variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.85rem',
+            color: status.includes('success') ? '#4ade80' : '#f87171',
           }}
         >
           {status}

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,39 +1,56 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton, Link } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
+        borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+        py: 4,
+        px: { xs: 3, md: 6 },
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: { xs: 'column', sm: 'row' },
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        justifyContent: 'space-between',
+        gap: 2,
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
-        }}
-      >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+      <Typography sx={{ color: '#4b5563', fontSize: '0.8rem' }}>
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+          <IconButton size="small" sx={{ color: '#4b5563', '&:hover': { color: '#9ca3af' } }}>
+            <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+          </IconButton>
+        </Link>
+        <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+          <IconButton size="small" sx={{ color: '#4b5563', '&:hover': { color: '#9ca3af' } }}>
+            <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+          </IconButton>
+        </Link>
+
+        <Box sx={{ width: '1px', height: 16, bgcolor: 'rgba(255,255,255,0.06)', mx: 1 }} />
+
+        <IconButton
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          size="small"
+          sx={{
+            color: '#4b5563',
+            border: '1px solid rgba(255, 255, 255, 0.06)',
+            width: 32,
+            height: 32,
+            '&:hover': { color: '#9ca3af', borderColor: 'rgba(255, 255, 255, 0.12)' },
+          }}
+        >
+          <KeyboardArrowUpIcon sx={{ fontSize: '1rem' }} />
+        </IconButton>
+      </Box>
     </Box>
   );
 };

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -3,81 +3,67 @@
 import { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
-  const getArticle = (role) => {
-    const vowels = ['a', 'e', 'i', 'o', 'u'];
-    return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
-  };
-
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = `${ROLES[roleIndex]}`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, 80 + Math.random() * 40);
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 1500);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, 40 + Math.random() * 20);
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
-    return () => clearInterval(blinkCursor);
+    const blink = setInterval(() => setCursorVisible((prev) => !prev), 400);
+    return () => clearInterval(blink);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.3rem', md: '1.5rem' },
+        fontWeight: 400,
+        color: '#a1a1aa',
+        fontFamily: 'var(--font-montserrat), sans-serif',
+        minHeight: '2rem',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {text}
+      <span
+        style={{
+          color: '#6366f1',
+          opacity: cursorVisible ? 1 : 0,
+          transition: 'opacity 0.1s',
+          marginLeft: '1px',
+        }}
+      >
+        |
+      </span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -40,33 +40,9 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', accent: true },
+  { label: 'Tell me about your experience', accent: false },
+  { label: 'Featured projects', accent: false },
 ];
 
 const HeroChat = () => {
@@ -89,7 +65,7 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#f4f4f5', zIndex: 1 }}>
       {/* Pre-chat view */}
       <Box
         sx={{
@@ -99,46 +75,62 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-20px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease, transform 400ms ease',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
         <Typography
-          variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
-            textAlign: 'center',
+            fontSize: '0.8rem',
+            fontWeight: 600,
+            color: '#6366f1',
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          Software Engineer
+        </Typography>
+
+        <Typography
+          variant="h1"
+          sx={{
+            fontSize: 'clamp(3rem, 9vw, 6.5rem)',
+            fontWeight: 800,
+            lineHeight: 0.95,
+            textAlign: 'center',
+            background: 'linear-gradient(180deg, #f4f4f5 0%, #71717a 100%)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+          }}
+        >
+          David Riva
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 540, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={
+              turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask my AI agent anything…'
+            }
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: '#ef4444', fontSize: '0.8rem' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" useFlexGap>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -152,31 +144,30 @@ const HeroChat = () => {
               }}
               sx={{
                 height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                background: chip.accent ? 'rgba(99, 102, 241, 0.1)' : 'rgba(255, 255, 255, 0.04)',
+                border: chip.accent
+                  ? '1px solid rgba(99, 102, 241, 0.25)'
+                  : '1px solid rgba(255, 255, 255, 0.08)',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  color: chip.accent ? '#818cf8' : '#a1a1aa',
+                  fontFamily: 'var(--font-montserrat), sans-serif',
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.8,
                 },
                 '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
+                  background: chip.accent ? 'rgba(99, 102, 241, 0.18)' : 'rgba(255, 255, 255, 0.07)',
+                  borderColor: chip.accent ? 'rgba(99, 102, 241, 0.4)' : 'rgba(255, 255, 255, 0.15)',
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +180,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +196,40 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
-            display: 'inline-flex',
+            bottom: { xs: 24, md: 40 },
+            display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
-            background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            gap: 0.5,
+            background: 'none',
+            border: 'none',
             cursor: 'pointer',
-            transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            color: '#6b7280',
+            transition: 'color 0.3s',
+            '&:hover': { color: '#a1a1aa' },
+            '@keyframes gentleBounce': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(4px)' },
+            },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          <Typography
+            sx={{
+              fontSize: '0.7rem',
+              fontWeight: 500,
+              letterSpacing: '0.2em',
+              textTransform: 'uppercase',
+              fontFamily: 'var(--font-montserrat), sans-serif',
+            }}
+          >
+            Scroll
+          </Typography>
+          <KeyboardArrowDownIcon
+            sx={{
+              fontSize: '1.2rem',
+              animation: 'gentleBounce 2s ease-in-out infinite',
+            }}
+          />
         </Box>
       </Box>
 
@@ -233,11 +241,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease 150ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +253,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #6366f1, #a855f7)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
               fontWeight: 800,
-              fontSize: '1rem',
+              fontSize: '0.85rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +274,30 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2, color: '#f4f4f5' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.72rem', color: '#6b7280', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography sx={{ fontSize: '0.72rem', color: '#4b5563' }}>
+            &#8595; scroll for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+            background: 'rgba(9, 9, 11, 0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,100 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
-import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
+import { Box, Typography } from '@mui/material';
+import { useState, useEffect } from 'react';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+const pages = ['About', 'Experience', 'Projects', 'Contact'];
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [activePage, setActivePage] = useState('');
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 100);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
-    <AppBar
-      position="fixed"
+    <Box
       sx={{
-        top: 0,
+        position: 'fixed',
+        top: 16,
+        left: '50%',
+        transform: `translateX(-50%) translateY(${scrolled ? 0 : -80}px)`,
         zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
+        opacity: scrolled ? 1 : 0,
+        transition: 'all 0.5s cubic-bezier(0.16, 1, 0.3, 1)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        px: 1,
+        py: 0.5,
+        borderRadius: '999px',
+        bgcolor: 'rgba(9, 9, 11, 0.85)',
+        backdropFilter: 'blur(24px)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      <Box
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        sx={{
+          px: 2,
+          py: 1,
+          cursor: 'pointer',
+          borderRight: '1px solid rgba(255, 255, 255, 0.08)',
+          mr: 0.5,
+        }}
+      >
+        <Typography
+          sx={{
+            fontWeight: 800,
+            fontSize: '0.85rem',
+            letterSpacing: '-0.02em',
+            fontFamily: 'var(--font-montserrat), sans-serif',
+            color: '#f4f4f5',
+          }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
+          DR
+        </Typography>
+      </Box>
+
+      {pages.map((page) => (
+        <ScrollLink
+          key={page}
+          to={page.toLowerCase()}
+          spy={true}
+          smooth={true}
+          offset={-80}
+          duration={600}
+          onSetActive={() => setActivePage(page)}
+        >
+          <Box
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              px: { xs: 1.5, sm: 2.5 },
+              py: 1,
+              borderRadius: '999px',
+              cursor: 'pointer',
+              fontSize: { xs: '0.78rem', sm: '0.85rem' },
+              fontWeight: 500,
+              fontFamily: 'var(--font-montserrat), sans-serif',
+              color: activePage === page ? '#f4f4f5' : '#6b7280',
+              bgcolor: activePage === page ? 'rgba(99, 102, 241, 0.12)' : 'transparent',
+              transition: 'all 0.25s ease',
+              whiteSpace: 'nowrap',
+              '&:hover': {
+                color: '#f4f4f5',
+                bgcolor: activePage === page ? 'rgba(99, 102, 241, 0.12)' : 'rgba(255, 255, 255, 0.04)',
+              },
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
-
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
-        </Box>
-      </Toolbar>
-    </AppBar>
+            {page}
+          </Box>
+        </ScrollLink>
+      ))}
+    </Box>
   );
 };
 

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,129 +2,13 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Card, CardContent, Chip, Stack, Button } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
@@ -133,37 +17,132 @@ const ProjectCard = forwardRef(
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
-          borderRadius: '16px',
+          bgcolor: '#131316',
+          color: '#f4f4f5',
+          border: featured ? '1px solid rgba(99, 102, 241, 0.15)' : '1px solid rgba(255, 255, 255, 0.06)',
+          borderRadius: '20px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: featured ? 'rgba(99, 102, 241, 0.3)' : 'rgba(255, 255, 255, 0.12)',
+            boxShadow: '0 20px 40px rgba(0, 0, 0, 0.3)',
+            '& .project-image': { transform: 'scale(1.04)' },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? 200 : 170,
+            width: '100%',
+            bgcolor: '#0e0e0e',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 30%, rgba(19, 19, 22, 0.9) 100%)',
+            }}
+          />
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 3 }}>
+          <Typography
+            component="h3"
+            sx={{ fontWeight: 700, mb: 0.5, color: '#f4f4f5', lineHeight: 1.3, fontSize: featured ? '1.05rem' : '0.95rem' }}
+          >
+            {title}
+          </Typography>
+
+          <Typography sx={{ color: '#6b7280', fontSize: '0.75rem', mb: 1.5 }}>
+            {dateStarted} – {dateCompleted}
+          </Typography>
+
+          <Typography
+            sx={{
+              color: '#9ca3af',
+              lineHeight: 1.65,
+              mb: 2.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              fontSize: '0.82rem',
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mb: 3 }}>
+            {allTools.slice(0, 6).map((tool) => (
+              <Chip
+                key={tool}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(99, 102, 241, 0.08)',
+                  color: '#818cf8',
+                  border: '1px solid rgba(99, 102, 241, 0.12)',
+                  fontSize: '0.68rem',
+                  height: '24px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 6 && (
+              <Chip
+                label={`+${allTools.length - 6}`}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.04)',
+                  color: '#6b7280',
+                  fontSize: '0.68rem',
+                  height: '24px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            )}
+          </Stack>
+
+          <Button
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={<LaunchIcon sx={{ fontSize: '0.85rem !important' }} />}
+            fullWidth
+            sx={{
+              mt: 'auto',
+              color: '#f4f4f5',
+              bgcolor: 'rgba(255, 255, 255, 0.04)',
+              border: '1px solid rgba(255, 255, 255, 0.08)',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '0.8rem',
+              fontWeight: 500,
+              py: 0.85,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                bgcolor: 'rgba(255, 255, 255, 0.07)',
+                borderColor: 'rgba(255, 255, 255, 0.15)',
+              },
+            }}
+          >
+            View Project
+          </Button>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,10 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
-    <Box
-      sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
-      }}
-    >
+    <Box sx={{ py: { xs: 10, md: 14 }, px: { xs: 0, md: 0 } }}>
       <SectionHeading sectionName="Projects" />
-
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -1,70 +1,38 @@
 'use client';
 
-import { Box, Skeleton, Grid, Collapse, Button } from '@mui/material';
-import { useState, useEffect, useRef, useMemo, memo } from 'react';
+import { Box, Grid, Collapse, Button } from '@mui/material';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import ProjectCard from './ProjectCard';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import gsap from 'gsap';
-import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
-gsap.registerPlugin(ScrollTrigger);
-
-const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
+const AnimatedCards = ({ projects, className }) => {
   const containerRef = useRef(null);
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.featured-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 40, opacity: 0 },
-      {
-        y: 0,
-        opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
-      }
-    );
-    ScrollTrigger.refresh();
-    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
-  }, [projects]);
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(([entry]) => { if (entry.isIntersecting) setVisible(true); }, { threshold: 0.05 });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
-            <ProjectCard {...project} featured />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-});
-FeaturedProjects.displayName = 'FeaturedProjects';
-
-const AllProjects = ({ projects }) => {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
-  }, [projects]);
-
-  return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
-            <ProjectCard {...project} />
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
+        {projects.map((project, i) => (
+          <Grid
+            size={{ xs: 12, sm: 6, md: 4 }}
+            key={project.title}
+            className={className}
+            sx={{
+              opacity: visible ? 1 : 0,
+              transform: visible ? 'translateY(0)' : 'translateY(30px)',
+              transition: `opacity 0.5s ease ${i * 0.08}s, transform 0.5s ease ${i * 0.08}s`,
+            }}
+          >
+            <ProjectCard {...project} featured={project.featured} />
           </Grid>
         ))}
       </Grid>
@@ -91,60 +59,68 @@ const ProjectsContainer = () => {
   const featuredProjects = useMemo(() => projectData.filter((p) => p.featured), [projectData]);
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
-  return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
-      {loading ? (
-        <Grid container spacing={3}>
+  if (loading) {
+    return (
+      <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 } }}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
-              </Box>
+              <Box
+                sx={{
+                  bgcolor: '#131316',
+                  border: '1px solid rgba(255, 255, 255, 0.06)',
+                  borderRadius: '20px',
+                  height: 380,
+                  '@keyframes shimmer': {
+                    '0%': { opacity: 0.5 },
+                    '50%': { opacity: 0.8 },
+                    '100%': { opacity: 0.5 },
+                  },
+                  animation: 'shimmer 2s ease-in-out infinite',
+                }}
+              />
             </Grid>
           ))}
         </Grid>
-      ) : (
-        <Box sx={{ py: 3 }}>
-          <FeaturedProjects projects={featuredProjects} />
+      </Box>
+    );
+  }
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
-            <Button
-              onClick={() => setShowAll((prev) => !prev)}
-              endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-              sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
-                px: 3,
-                py: 0.85,
-                textTransform: 'none',
-                fontSize: '0.85rem',
-                fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
-                },
-              }}
-            >
-              {showAll ? 'Show less' : `View all ${projectData.length} projects`}
-            </Button>
-          </Box>
+  return (
+    <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 } }}>
+      <AnimatedCards projects={featuredProjects} className="featured-card" />
 
-          <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
-            </Box>
-          </Collapse>
+      <Box sx={{ mt: 5, textAlign: 'center' }}>
+        <Button
+          onClick={() => setShowAll((prev) => !prev)}
+          endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          sx={{
+            color: '#9ca3af',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            borderRadius: '999px',
+            px: 3.5,
+            py: 1,
+            textTransform: 'none',
+            fontSize: '0.85rem',
+            fontWeight: 500,
+            bgcolor: 'rgba(255, 255, 255, 0.02)',
+            transition: 'all 0.25s ease',
+            '&:hover': {
+              bgcolor: 'rgba(255, 255, 255, 0.05)',
+              borderColor: 'rgba(255, 255, 255, 0.15)',
+              color: '#f4f4f5',
+            },
+          }}
+        >
+          {showAll ? 'Show less' : `View all ${projectData.length} projects`}
+        </Button>
+      </Box>
+
+      <Collapse in={showAll} timeout={400}>
+        <Box sx={{ mt: 4 }}>
+          <AnimatedCards projects={otherProjects} className="all-card" />
         </Box>
-      )}
+      </Collapse>
     </Box>
   );
 };

--- a/next-app/src/components/RevealOnScroll.js
+++ b/next-app/src/components/RevealOnScroll.js
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+import { Box } from '@mui/material';
+
+const RevealOnScroll = ({ children, delay = 0, sx = {}, ...props }) => {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          obs.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(24px)',
+        transition: `opacity 0.6s ease ${delay}s, transform 0.6s ease ${delay}s`,
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default RevealOnScroll;

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -2,36 +2,14 @@ import { Box, Typography } from '@mui/material';
 
 const SectionHeading = ({ sectionName }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: { xs: 6, md: 8 }, textAlign: 'center' }}>
       <Typography
         variant="h2"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          fontSize: { xs: '2.25rem', sm: '3rem', md: '3.5rem' },
+          fontWeight: 700,
+          color: '#f4f4f5',
+          letterSpacing: '-0.03em',
         }}
       >
         {sectionName}

--- a/next-app/src/components/Skills-Page/Skills.js
+++ b/next-app/src/components/Skills-Page/Skills.js
@@ -1,11 +1,61 @@
-import React from 'react';
-import { Box, Divider } from '@mui/material';
-import SkillCard from './SkillCard';
-import SkillCardContainer from '@/components/Skills-Page/SkillCardContainer';
-import SectionHeading from '@/components/SectionHeading';
+'use client';
 
-export const metadata = {
-  title: 'David Riva | Skills',
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import SectionHeading from '@/components/SectionHeading';
+import RevealOnScroll from '@/components/RevealOnScroll';
+
+const categoryColors = {
+  Languages: { bg: 'rgba(99, 102, 241, 0.08)', border: 'rgba(99, 102, 241, 0.15)', text: '#818cf8' },
+  'AI Orchestration & Machine Learning': { bg: 'rgba(168, 85, 247, 0.08)', border: 'rgba(168, 85, 247, 0.15)', text: '#c084fc' },
+  'Web Development': { bg: 'rgba(59, 130, 246, 0.08)', border: 'rgba(59, 130, 246, 0.15)', text: '#60a5fa' },
+  'Big Data & Cloud': { bg: 'rgba(20, 184, 166, 0.08)', border: 'rgba(20, 184, 166, 0.15)', text: '#5eead4' },
+  'Databases & Tools': { bg: 'rgba(251, 146, 60, 0.08)', border: 'rgba(251, 146, 60, 0.15)', text: '#fdba74' },
+  'Testing & Validation': { bg: 'rgba(52, 211, 153, 0.08)', border: 'rgba(52, 211, 153, 0.15)', text: '#6ee7b7' },
+  'Data Science Libraries': { bg: 'rgba(244, 114, 182, 0.08)', border: 'rgba(244, 114, 182, 0.15)', text: '#f9a8d4' },
+};
+
+const fallbackColor = { bg: 'rgba(255, 255, 255, 0.04)', border: 'rgba(255, 255, 255, 0.08)', text: '#a1a1aa' };
+
+const SkillCategory = ({ title, items, index }) => {
+  const colors = categoryColors[title] || fallbackColor;
+
+  return (
+    <RevealOnScroll
+      delay={index * 0.06}
+      sx={{
+        bgcolor: '#131316',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        borderRadius: '16px',
+        p: 3,
+        '&:hover': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+      }}
+    >
+      <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: colors.text, mb: 2, letterSpacing: '0.02em' }}>
+        {title}
+      </Typography>
+      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+        {items.map((item) => (
+          <Chip
+            key={item}
+            label={item}
+            size="small"
+            sx={{
+              bgcolor: colors.bg,
+              color: colors.text,
+              border: `1px solid ${colors.border}`,
+              fontSize: '0.75rem',
+              fontWeight: 500,
+              height: '28px',
+              '& .MuiChip-label': { px: 1.5 },
+              transition: 'all 0.2s ease',
+              '&:hover': { opacity: 0.8 },
+            }}
+          />
+        ))}
+      </Stack>
+    </RevealOnScroll>
+  );
 };
 
 const Skills = () => {
@@ -18,28 +68,20 @@ const Skills = () => {
   }, []);
 
   return (
-    <Box
-      sx={{
-        marginTop: 10,
-        padding: '5rem',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        backgroundColor: '#565859',
-        borderTop: '8px solid rgba(0,0,0,0.1)',
-        boxShadow: '0px 1px 0px rgba(255,255,255,0.2)',
-      }}
-    >
+    <Box sx={{ py: { xs: 10, md: 14 }, px: { xs: 2, md: 4 } }}>
       <SectionHeading sectionName="Skills" />
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', marginTop: 10 }}>
+      <Box
+        sx={{
+          maxWidth: 1000,
+          mx: 'auto',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: '1fr 1fr 1fr' },
+          gap: 2,
+        }}
+      >
         {skillsData.map((skill, index) => (
-          <React.Fragment key={skill.title}>
-            <SkillCardContainer {...skill} />
-            {index < skillsData.length - 1 && <Divider sx={{ margin: '1rem 0', backgroundColor: 'lightgray' }} />}
-          </React.Fragment>
+          <SkillCategory key={skill.title} {...skill} index={index} />
         ))}
       </Box>
     </Box>

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,35 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: '#131316',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#f4f4f5',
+      secondary: '#a1a1aa',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#6366f1',
+      light: '#818cf8',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#a855f7',
+      light: '#c084fc',
     },
   },
   typography: {
     fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    h1: { fontWeight: 800, letterSpacing: '-0.04em', lineHeight: 1.0 },
+    h2: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.02em' },
+    h4: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7 },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

- **Complete visual overhaul** replacing the cyan/purple gradient theme with a refined dark editorial design using an indigo (#6366f1) / violet (#a855f7) accent palette on a zinc-based near-black background
- **New layout patterns**: bento grid About section, floating pill navigation, ambient gradient orb hero background (replaces particle effects), scroll-triggered reveal animations via IntersectionObserver (replaces GSAP ScrollTrigger)
- **New sections added**: standalone Experience section (extracted from About sidebar), redesigned Skills section with color-coded category cards (fixes missing React import bugs in original), integrated Awards into the About bento grid
- **All chat functionality preserved**: streaming SSE, cached chip responses, Turnstile CAPTCHA, JWT auth, rate limiting — just restyled to match the new palette

### What changed (19 files, ~1100 lines added / ~900 removed)

| Area | Before | After |
|------|--------|-------|
| **Theme** | Cyan #38c0f2 + purple #6e40c9 | Indigo #6366f1 + violet #a855f7 on #09090b |
| **Hero** | Particle background, gradient animation | Ambient gradient orbs, dot grid, large gradient text |
| **Nav** | Fixed top bar with logo + links | Floating centered pill that appears on scroll |
| **About** | Photo + bio + sidebar timeline | Bento grid: photo card, bio card, stats grid, awards |
| **Experience** | Hidden timeline inside About (desktop only) | Standalone section with company-logo cards |
| **Projects** | GSAP ScrollTrigger animations | IntersectionObserver reveal, refined card design |
| **Skills** | Broken (missing imports), comma-separated text | Color-coded category cards with chip layout |
| **Contact** | Single-column form | Two-column name/email, refined inputs |
| **Footer** | Stacked with floating back-to-top | Minimal single-row with social + scroll-up |

## Test plan

- [ ] Verify hero loads with gradient orbs and chat input is functional
- [ ] Test AI chat: send a message, verify streaming works, test cached chip responses
- [ ] Verify floating nav appears after scrolling and links scroll to correct sections
- [ ] Check About bento grid layout on desktop (3-column) and mobile (stacked)
- [ ] Verify Experience section shows all 5 entries sorted by date
- [ ] Test Projects: featured cards render, "View all" expands, project links work
- [ ] Verify Skills section loads all 7 categories with colored chips
- [ ] Test Contact form submission with Turnstile CAPTCHA
- [ ] Check responsive behavior on mobile (375px), tablet (768px), desktop (1440px)
- [ ] Verify scroll-triggered reveal animations fire on each section

https://claude.ai/code/session_01BDs8i4tkEPe9EVXA2yKfoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDs8i4tkEPe9EVXA2yKfoC)_