### PR TITLE
Complete portfolio redesign with modern 2026 UI

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,40 +2,48 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    'Explore the portfolio of David Riva, a software engineer specializing in applied AI, full-stack development, and data visualization.',
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'AI Engineer',
+    'React Developer',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: "David Riva's portfolio",
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +51,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={inter.variable}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -15,8 +15,8 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         position: 'relative',
         minHeight: '100vh',
       }}
@@ -27,40 +27,24 @@ const MainPage = () => {
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background:
+            'radial-gradient(ellipse 80% 50% at 50% -20%, rgba(59,130,246,0.12), transparent), radial-gradient(ellipse 60% 40% at 80% 60%, rgba(139,92,246,0.07), transparent), #09090b',
         }}
       >
         <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <Box id="about" sx={{ width: '100%' }}>
           <About />
         </Box>
 
         <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Projects />
@@ -69,9 +53,8 @@ const MainPage = () => {
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
             width: '100%',
-            color: '#ffffff',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Contact />
@@ -82,4 +65,5 @@ const MainPage = () => {
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,29 +1,85 @@
-import { Box } from '@mui/material';
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
 import HeadShotImage from './HeadshotImage';
 import AboutHeader from './AboutHeader';
 import AboutFooter from './AboutFooter';
 import Biography from './Biography';
 import SimpleTimeline from './SimpleTimeline';
+import SectionHeading from '@/components/SectionHeading';
 
-const AboutTextSection = () => {
+const BentoCard = ({ children, sx = {} }) => (
+  <Box
+    sx={{
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.06)',
+      borderRadius: '16px',
+      p: { xs: 3, md: 4 },
+      transition: 'border-color 0.3s ease',
+      '&:hover': {
+        borderColor: 'rgba(255,255,255,0.12)',
+      },
+      ...sx,
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const SkillsGrid = () => {
+  const [skillsData, setSkillsData] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/skills.json')
+      .then((res) => res.json())
+      .then((data) => setSkillsData(data))
+      .catch(() => {});
+  }, []);
+
   return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
+    <Box>
+      {skillsData.map((category) => (
+        <Box key={category.title} sx={{ mb: 3, '&:last-child': { mb: 0 } }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: '#71717a',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              mb: 1,
+              display: 'block',
+            }}
+          >
+            {category.title}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.75}>
+            {category.items.map((item) => (
+              <Chip
+                key={item}
+                label={item}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.05)',
+                  color: '#a1a1aa',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  fontSize: '0.72rem',
+                  height: '26px',
+                  fontWeight: 500,
+                  transition: 'all 0.2s ease',
+                  '&:hover': {
+                    bgcolor: 'rgba(59,130,246,0.08)',
+                    borderColor: 'rgba(59,130,246,0.2)',
+                    color: '#60a5fa',
+                  },
+                }}
+              />
+            ))}
+          </Stack>
+        </Box>
+      ))}
     </Box>
   );
 };
@@ -32,45 +88,116 @@ const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
         width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+        px: { xs: 2, md: 4, lg: 6 },
       }}
     >
+      <SectionHeading sectionName="About" />
+
+      {/* Top row: headshot + bio */}
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1.5fr' },
+          gap: 3,
+          mb: 3,
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
-        </Box>
+        {/* Profile card */}
+        <BentoCard
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            textAlign: 'center',
+            gap: 2.5,
+          }}
+        >
+          <Box
+            sx={{
+              p: '2px',
+              borderRadius: '50%',
+              background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+              flexShrink: 0,
+            }}
+          >
+            <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#09090b' }}>
+              <HeadShotImage width={160} height={160} />
+            </Box>
+          </Box>
+          <AboutHeader />
+          <AboutFooter />
+        </BentoCard>
+
+        {/* Bio card */}
+        <BentoCard>
+          <Typography
+            variant="caption"
+            sx={{
+              color: '#71717a',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              mb: 2,
+              display: 'block',
+            }}
+          >
+            Background
+          </Typography>
+          <Biography />
+        </BentoCard>
       </Box>
 
-      <AboutTextSection />
-
+      {/* Bottom row: timeline + skills */}
       <Box
         sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+          gap: 3,
         }}
       >
-        <SimpleTimeline />
+        {/* Timeline card */}
+        <BentoCard>
+          <Typography
+            variant="caption"
+            sx={{
+              color: '#71717a',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              mb: 2,
+              display: 'block',
+            }}
+          >
+            Experience
+          </Typography>
+          <SimpleTimeline />
+        </BentoCard>
+
+        {/* Skills card */}
+        <BentoCard>
+          <Typography
+            variant="caption"
+            sx={{
+              color: '#71717a',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              mb: 2,
+              display: 'block',
+            }}
+          >
+            Skills & Technologies
+          </Typography>
+          <SkillsGrid />
+        </BentoCard>
       </Box>
     </Box>
   );

--- a/next-app/src/components/About-Page/AboutFooter.js
+++ b/next-app/src/components/About-Page/AboutFooter.js
@@ -6,11 +6,10 @@ const AboutFooter = () => {
   return (
     <Box
       sx={{
-        marginTop: 4,
         display: 'flex',
-        justifyContent: 'flex-start',
+        alignItems: 'center',
         gap: 2,
-        flexDirection: { xs: 'column', sm: 'row', md: 'row' },
+        flexDirection: { xs: 'column', sm: 'row' },
       }}
     >
       <ResumeButton />

--- a/next-app/src/components/About-Page/AboutHeader.js
+++ b/next-app/src/components/About-Page/AboutHeader.js
@@ -1,25 +1,29 @@
-import { Typography } from '@mui/material';
-import ClickableLink from './ClickableLink';
+import { Typography, Box } from '@mui/material';
 
 const AboutHeader = () => {
   return (
-    <>
+    <Box>
       <Typography
-        variant="h1"
+        variant="h4"
         sx={{
-          fontWeight: 'bold',
-          marginBottom: 1,
-          fontSize: { xs: '1.75rem', sm: '2.5rem', md: '2.5rem' },
+          fontWeight: 700,
+          mb: 0.5,
+          fontSize: { xs: '1.5rem', md: '1.75rem' },
+          letterSpacing: '-0.02em',
         }}
       >
         David Riva
       </Typography>
 
       <Typography
-        variant="h5"
+        variant="body1"
         sx={{
-          color: '#38c0f2',
-          marginBottom: 1,
+          background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          fontWeight: 600,
+          fontSize: '0.95rem',
+          mb: 0.5,
         }}
       >
         Training Engineer, Generative AI
@@ -27,13 +31,13 @@ const AboutHeader = () => {
 
       <Typography
         sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          marginBottom: 2,
+          color: '#71717a',
+          fontSize: '0.85rem',
         }}
       >
-        Bay Area, CA. | <ClickableLink link="mailto:davidjriva@gmail.com" text="davidjriva@gmail.com" />
+        Bay Area, CA
       </Typography>
-    </>
+    </Box>
   );
 };
 

--- a/next-app/src/components/About-Page/Biography.js
+++ b/next-app/src/components/About-Page/Biography.js
@@ -1,28 +1,21 @@
-import { Box, Typography } from '@mui/material';
-import ClickableLink from '@/components/About-Page/ClickableLink';
+import { Typography } from '@mui/material';
 
 const Biography = () => {
   return (
-    <Box
-      sx={{
-        marginTop: 2,
-        maxWidth: '600px',
-        textAlign: 'left',
-      }}
-    >
-      <Typography variant="body1">
+    <>
+      <Typography variant="body1" sx={{ color: '#a1a1aa', fontSize: '0.9rem', lineHeight: 1.75 }}>
         Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
-        University, where I received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m incredibly
-        passionate about software &amp; applied AI engineering.
+        University, where I received a B.S. in Computer Science with Summa Cum Laude distinctions.
       </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        I&apos;m experienced in full-stack development, data engineering, and big data visualization.
+      <Typography variant="body1" sx={{ color: '#a1a1aa', fontSize: '0.9rem', lineHeight: 1.75, mt: 2 }}>
+        I&apos;m incredibly passionate about applied AI engineering and full-stack development. I&apos;m experienced in
+        building production-grade AI systems, data engineering pipelines, and interactive web applications.
       </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
+      <Typography variant="body1" sx={{ color: '#a1a1aa', fontSize: '0.9rem', lineHeight: 1.75, mt: 2 }}>
         I have a strong background in data structures, algorithms, and mathematical applications. I pride myself on
         elegant problem-solving and my dedication to maintaining high standards of excellence.
       </Typography>
-    </Box>
+    </>
   );
 };
 

--- a/next-app/src/components/About-Page/ClickableLink.js
+++ b/next-app/src/components/About-Page/ClickableLink.js
@@ -5,10 +5,14 @@ const ClickableLink = ({ link, text }) => {
     <a
       href={link}
       target="_blank"
-      style={{ color: '#38c0f2', textDecoration: 'none' }}
-      onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
-      onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}
-      onClick={(e) => (e.currentTarget.style.color = '#0073e6')}
+      rel="noopener"
+      style={{
+        color: '#3b82f6',
+        textDecoration: 'none',
+        transition: 'opacity 0.2s',
+      }}
+      onMouseOver={(e) => (e.currentTarget.style.opacity = '0.8')}
+      onMouseOut={(e) => (e.currentTarget.style.opacity = '1')}
     >
       {text}
     </a>

--- a/next-app/src/components/About-Page/HeadshotImage.js
+++ b/next-app/src/components/About-Page/HeadshotImage.js
@@ -2,23 +2,6 @@
 
 import { Box } from '@mui/material';
 import Image from 'next/image';
-import { keyframes } from '@emotion/react';
-
-const glowFrames = Array.from({ length: 51 }, (_, i) => {
-  const r = 240 - 2 * i;
-  const g = 240 - i;
-  const b = 250;
-  return `${i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const reverseGlowFrames = Array.from({ length: 50 }, (_, i) => {
-  const r = 140 + 2 * i;
-  const g = 190 + i;
-  const b = 250;
-  return `${51 + i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const glowAnimation = keyframes`${glowFrames}\n${reverseGlowFrames}`;
 
 const HeadShotImage = ({ width, height }) => {
   return (
@@ -29,7 +12,6 @@ const HeadShotImage = ({ width, height }) => {
         height,
         overflow: 'hidden',
         borderRadius: '50%',
-        display: { xs: 'none', sm: 'block' },
       }}
     >
       <Image
@@ -37,9 +19,7 @@ const HeadShotImage = ({ width, height }) => {
         src="/images/headshot.webp"
         width={width}
         height={height}
-        style={{
-          objectFit: 'cover',
-        }}
+        style={{ objectFit: 'cover' }}
         priority={true}
       />
     </Box>

--- a/next-app/src/components/About-Page/ResumeButton.js
+++ b/next-app/src/components/About-Page/ResumeButton.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@mui/material';
+import LaunchIcon from '@mui/icons-material/Launch';
 
 const ResumeButton = () => {
   const handleResumeClick = () => {
@@ -8,20 +9,28 @@ const ResumeButton = () => {
   };
 
   return (
-    <Button 
-      variant="contained" 
-      onClick={handleResumeClick} 
-      sx={{ 
-        marginTop: '1rem', 
-        marginBottom: 2,
-        backgroundColor: '#1976d2',
-        color: 'white',
+    <Button
+      variant="outlined"
+      onClick={handleResumeClick}
+      endIcon={<LaunchIcon sx={{ fontSize: '0.85rem !important' }} />}
+      sx={{
+        color: '#a1a1aa',
+        borderColor: 'rgba(255,255,255,0.12)',
+        borderRadius: '10px',
+        textTransform: 'none',
+        fontSize: '0.8rem',
+        fontWeight: 500,
+        px: 2.5,
+        py: 0.75,
+        transition: 'all 0.2s ease',
         '&:hover': {
-          backgroundColor: '#1565c0',
+          borderColor: 'rgba(255,255,255,0.25)',
+          bgcolor: 'rgba(255,255,255,0.04)',
+          color: '#fafafa',
         },
       }}
     >
-      View Resume as PDF
+      View Resume
     </Button>
   );
 };

--- a/next-app/src/components/About-Page/SimpleTimeline.js
+++ b/next-app/src/components/About-Page/SimpleTimeline.js
@@ -19,28 +19,27 @@ const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, sta
 
   return (
     <TimelineItem>
-      <TimelineOppositeContent sx={{ flex: 'none', width: 130, pr: 1.5, pt: '14px' }}>
+      <TimelineOppositeContent sx={{ flex: 'none', width: 120, pr: 1.5, pt: '14px' }}>
         <Typography
           variant="caption"
           sx={{
-            color: isCurrent ? '#38c0f2' : 'rgba(255,255,255,0.45)',
+            color: isCurrent ? '#3b82f6' : '#52525b',
             fontWeight: isCurrent ? 600 : 400,
             lineHeight: 1.4,
             display: 'block',
+            fontSize: '0.72rem',
           }}
         >
-          {isGraduation ? startDate : `${startDate} –\u00a0${isCurrent ? 'Present' : endDate}`}
+          {isGraduation ? startDate : `${startDate} – ${isCurrent ? 'Present' : endDate}`}
         </Typography>
       </TimelineOppositeContent>
 
       <TimelineSeparator>
         <TimelineDot
           sx={{
-            backgroundColor: '#ffffff',
-            border: isCurrent
-              ? '1.5px solid rgba(56,192,242,0.6)'
-              : '1.5px solid rgba(255,255,255,0.2)',
-            boxShadow: isCurrent ? '0 0 10px 2px rgba(56,192,242,0.25)' : 'none',
+            backgroundColor: '#fafafa',
+            border: isCurrent ? '1.5px solid rgba(59,130,246,0.5)' : '1.5px solid rgba(255,255,255,0.15)',
+            boxShadow: isCurrent ? '0 0 12px 2px rgba(59,130,246,0.2)' : 'none',
             p: '5px',
             m: '6px 0',
           }}
@@ -48,16 +47,16 @@ const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, sta
           <Image
             src={`/images/${logoImage}`}
             alt={`${company} logo`}
-            width={20}
-            height={20}
+            width={18}
+            height={18}
             style={{ display: 'block', objectFit: 'contain' }}
           />
         </TimelineDot>
         {!isEnd && (
           <TimelineConnector
             sx={{
-              background: 'linear-gradient(to bottom, rgba(56,192,242,0.25), rgba(110,64,201,0.15))',
-              width: '1.5px',
+              background: 'linear-gradient(to bottom, rgba(59,130,246,0.2), rgba(139,92,246,0.1))',
+              width: '1px',
             }}
           />
         )}
@@ -71,7 +70,7 @@ const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, sta
               fontWeight: 600,
               fontSize: '0.8rem',
               lineHeight: 1.35,
-              color: '#ffffff',
+              color: '#fafafa',
               mb: 0.25,
             }}
           >
@@ -83,10 +82,11 @@ const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, sta
             target="_blank"
             variant="caption"
             sx={{
-              color: '#38c0f2',
+              color: '#3b82f6',
               textDecoration: 'none',
               fontSize: '0.72rem',
-              '&:hover': { textDecoration: 'underline' },
+              transition: 'opacity 0.2s',
+              '&:hover': { opacity: 0.8 },
             }}
           >
             {company}
@@ -111,42 +111,13 @@ const SimpleTimeline = () => {
   });
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        background: 'rgba(255,255,255,0.03)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        px: 1,
-        py: 2,
-      }}
-    >
-      <Typography
-        variant="overline"
-        sx={{
-          color: 'rgba(255,255,255,0.55)',
-          fontSize: '0.85rem',
-          letterSpacing: '0.18em',
-          fontWeight: 600,
-          mb: 0.5,
-        }}
-      >
-        Experience
-      </Typography>
-      <Timeline sx={{ maxWidth: '22vw', p: 0, m: 0 }}>
-        {sortedExperienceData.map((experience, index) => (
-          <React.Fragment key={experience.title}>
-            <SimpleTimelineItem
-              {...experience}
-              isEnd={index === sortedExperienceData.length - 1}
-            />
-          </React.Fragment>
-        ))}
-      </Timeline>
-    </Box>
+    <Timeline sx={{ p: 0, m: 0 }}>
+      {sortedExperienceData.map((experience, index) => (
+        <React.Fragment key={experience.title}>
+          <SimpleTimelineItem {...experience} isEnd={index === sortedExperienceData.length - 1} />
+        </React.Fragment>
+      ))}
+    </Timeline>
   );
 };
 

--- a/next-app/src/components/About-Page/SocialLinks.js
+++ b/next-app/src/components/About-Page/SocialLinks.js
@@ -1,35 +1,21 @@
 'use client';
 
-import React, { useState } from 'react';
 import { Box, IconButton, Link } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 const SocialLinks = () => {
-  const [hasGitHubIconBeenClicked, setHasGitHubIconBeenClicked] = useState(false);
-  const [hasLinkedInIconBeenClicked, setHasLinkedInIconBeenClicked] = useState(false);
-
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
       <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
         <IconButton
           aria-label="GitHub Profile"
           sx={{
-            color: hasGitHubIconBeenClicked ? '#9974cf' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#a28be5',
-            },
-            '&:active': {
-              color: '#9974cf',
-            },
+            color: '#71717a',
+            fontSize: '28px',
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#fafafa' },
           }}
-          onClick={() => setHasGitHubIconBeenClicked(true)}
         >
           <GitHubIcon fontSize="inherit" />
         </IconButton>
@@ -38,16 +24,11 @@ const SocialLinks = () => {
         <IconButton
           aria-label="LinkedIn Profile"
           sx={{
-            color: hasLinkedInIconBeenClicked ? '#07a2f7' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#4abfff',
-            },
-            '&:active': {
-              color: '#07a2f7',
-            },
+            color: '#71717a',
+            fontSize: '28px',
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#3b82f6' },
           }}
-          onClick={() => setHasLinkedInIconBeenClicked(true)}
         >
           <LinkedInIcon fontSize="inherit" />
         </IconButton>

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask me anything...' }) => {
   return (
     <Paper
       component="form"
@@ -15,11 +15,12 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         p: '4px 8px',
         borderRadius: '999px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        border: '1px solid rgba(255,255,255,0.1)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.2)' },
+        '&:focus-within': { borderColor: 'rgba(59,130,246,0.5)' },
       }}
     >
       <InputBase
@@ -34,11 +35,11 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontSize: '0.9rem',
+          '& input::placeholder': { color: '#52525b' },
         }}
       />
       <IconButton
@@ -46,12 +47,15 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         disabled={!input.trim() || disabled}
         sx={{
           ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          width: 34,
+          height: 34,
+          background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+          transition: 'opacity 0.2s ease',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#fff', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,11 +7,10 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#fafafa',
     marginBottom: '4px',
   };
 
@@ -29,36 +28,41 @@ const MessageItem = ({ msg }) => {
           px: 2.5,
           py: 1.5,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          background: isUser ? 'rgba(59,130,246,0.1)' : 'rgba(255,255,255,0.04)',
+          border: isUser ? '1px solid rgba(59,130,246,0.18)' : '1px solid rgba(255,255,255,0.08)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#3b82f6" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
+                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 600 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#60a5fa',
+                      backgroundColor: 'rgba(59,130,246,0.08)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
+                      fontSize: '0.85em',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +71,27 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.4)',
+                      color: '#fafafa',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      border: '1px solid rgba(255,255,255,0.06)',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a style={{ color: '#60a5fa', textDecoration: 'none' }} target="_blank" rel="noopener" {...props} />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { Box } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
@@ -7,33 +6,16 @@ const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
         width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '700px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+        px: { xs: 2, md: 4 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
-        <ContactForm />
-      </Box>
+      <SectionHeading sectionName="Get in Touch" />
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,23 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2.5,
+  '& .MuiInputLabel-root': {
+    color: '#52525b',
+    fontSize: '0.9rem',
+    '&.Mui-focused': { color: '#3b82f6' },
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255,255,255,0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.16)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(59,130,246,0.5)', borderWidth: '1px' },
   },
 };
 
@@ -49,24 +56,44 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        bgcolor: 'rgba(255,255,255,0.03)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        color: '#fafafa',
+        p: { xs: 3, md: 4 },
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        transition: 'border-color 0.3s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.1)' },
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2, mb: 0.5 }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2.5 }}>
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
               onSuccess={(token) => setCaptchaToken(token)}
@@ -78,20 +105,25 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '1rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
+            py: 1.5,
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+            color: '#fff',
+            borderRadius: '12px',
             border: 'none',
+            textTransform: 'none',
+            letterSpacing: '-0.01em',
+            transition: 'opacity 0.2s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255,255,255,0.06)',
+              color: 'rgba(255,255,255,0.25)',
             },
           }}
         >
@@ -103,9 +135,10 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2.5,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.85rem',
+            color: status.includes('success') ? '#22c55e' : '#ef4444',
           }}
         >
           {status}

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -7,32 +7,28 @@ const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        bgcolor: '#09090b',
+        borderTop: '1px solid rgba(255,255,255,0.06)',
+        color: '#52525b',
         width: '100%',
-        height: '10vh',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        py: 4,
+        gap: 2,
       }}
     >
       <ReturnToTopButton />
       <Typography
         variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
+          color: '#3f3f46',
           textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          fontSize: '0.8rem',
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        {new Date().getFullYear()} David Riva
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Footer/ReturnToTopButton.js
+++ b/next-app/src/components/Footer/ReturnToTopButton.js
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { IconButton, Box } from '@mui/material';
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import { Box, IconButton } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const ReturnToTopButton = () => {
   const [visible, setVisible] = useState(false);
@@ -21,24 +21,21 @@ const ReturnToTopButton = () => {
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
-        backgroundColor: '#38c0f2',
-        borderRadius: '8px',
-        padding: '4px',
-        maxWidth: '50px',
-        margin: '0 auto',
-        '@keyframes jump': {
-          '0%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-5px)' },
-          '100%': { transform: 'translateY(0)' },
+        borderRadius: '10px',
+        border: '1px solid rgba(255,255,255,0.08)',
+        bgcolor: 'rgba(255,255,255,0.04)',
+        transition: 'all 0.2s ease',
+        '&:hover': {
+          borderColor: 'rgba(255,255,255,0.16)',
+          bgcolor: 'rgba(255,255,255,0.06)',
         },
-        '&:hover': { animation: 'jump 1s infinite' },
       }}
     >
       <IconButton
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        sx={{ color: 'white', fontSize: '1.5rem', padding: '4px' }}
+        sx={{ color: '#71717a', fontSize: '1.25rem', p: 1 }}
       >
-        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 'inherit' }} />
+        <KeyboardArrowUpIcon sx={{ fontSize: 'inherit' }} />
       </IconButton>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -6,66 +6,58 @@ import { Typography } from '@mui/material';
 const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const baseTypingSpeed = 100;
+  const baseDeletingSpeed = 50;
+  const delayBeforeDeleting = 1200;
+  const delayBetweenRoles = 500;
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
   const getRandomSpeed = (baseSpeed) => {
     return baseSpeed + Math.random() * 50;
   };
 
-  // Typing and deleting effect logic
   useEffect(() => {
     const currentRole = `${ROLES[roleIndex]}.`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, getRandomSpeed(baseTypingSpeed));
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
       timer = setTimeout(() => {
         setDeleting(true);
       }, delayBeforeDeleting);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, getRandomSpeed(baseDeletingSpeed));
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, delayBetweenRoles);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
     const blinkCursor = setInterval(() => {
       setCursorVisible((prev) => !prev);
-    }, 300);
+    }, 400);
     return () => clearInterval(blinkCursor);
   }, []);
 
@@ -73,11 +65,24 @@ const AnimatedTypingTypography = () => {
     <Typography
       variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.25rem', sm: '1.5rem', md: '1.75rem' },
+        fontWeight: 400,
+        color: '#a1a1aa',
+        letterSpacing: '-0.02em',
       }}
     >
       I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      <span
+        style={{
+          background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          opacity: cursorVisible ? 1 : 0,
+          transition: 'opacity 0.1s',
+        }}
+      >
+        |
+      </span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -42,30 +42,27 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 const CHIPS = [
   {
     label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
+    bg: 'rgba(59,130,246,0.08)',
+    border: 'rgba(59,130,246,0.2)',
+    color: '#60a5fa',
+    hoverBg: 'rgba(59,130,246,0.15)',
+    hoverBorder: 'rgba(59,130,246,0.45)',
   },
   {
     label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
+    bg: 'rgba(139,92,246,0.08)',
+    border: 'rgba(139,92,246,0.2)',
+    color: '#c4b5fd',
+    hoverBg: 'rgba(139,92,246,0.15)',
+    hoverBorder: 'rgba(139,92,246,0.45)',
   },
   {
     label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
+    bg: 'rgba(255,255,255,0.04)',
+    border: 'rgba(255,255,255,0.1)',
+    color: '#a1a1aa',
+    hoverBg: 'rgba(255,255,255,0.08)',
+    hoverBorder: 'rgba(255,255,255,0.2)',
   },
 ];
 
@@ -89,7 +86,7 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#fafafa', zIndex: 1 }}>
       {/* Pre-chat view */}
       <Box
         sx={{
@@ -99,7 +96,7 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
           transform: started ? 'translateY(-10px)' : 'translateY(0)',
@@ -110,35 +107,44 @@ const HeroChat = () => {
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
+            fontSize: 'clamp(2.5rem, 7vw, 4.5rem)',
+            fontWeight: 800,
+            lineHeight: 1.05,
             textAlign: 'center',
+            letterSpacing: '-0.04em',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          <span style={{ color: '#fafafa' }}>Hello, I&apos;m </span>
+          <span
+            style={{
+              background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
+            David
+          </span>
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask me anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: 'rgba(248,113,113,0.9)', minHeight: '1.2em' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ mt: 0.5 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -154,29 +160,26 @@ const HeroChat = () => {
                 height: 'auto',
                 background: chip.bg,
                 border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                backdropFilter: 'blur(12px)',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
+                  fontSize: '0.85rem',
+                  fontWeight: 500,
                   px: 2,
                   py: 1,
                 },
                 '&:hover': {
                   background: chip.hoverBg,
                   borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.35 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +192,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -206,21 +212,24 @@ const HeroChat = () => {
             display: 'inline-flex',
             alignItems: 'center',
             gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            px: 2.5,
+            py: 1,
+            borderRadius: '999px',
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: '1px solid rgba(255,255,255,0.12)',
+            color: '#a1a1aa',
+            fontWeight: 500,
+            fontSize: '0.85rem',
             cursor: 'pointer',
-            transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            transition: 'all 0.25s ease',
+            '&:hover': {
+              borderColor: 'rgba(255,255,255,0.25)',
+              color: '#fafafa',
+              background: 'rgba(255,255,255,0.04)',
+            },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
+          <KeyboardDoubleArrowDownIcon sx={{ fontSize: '1rem' }} />
           View my work
         </Box>
       </Box>
@@ -237,7 +246,6 @@ const HeroChat = () => {
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +254,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Box
             sx={{
               width: 36,
               height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.9rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +275,28 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', lineHeight: 1.2, color: '#fafafa' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.75rem', color: '#71717a', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
-          </Typography>
+          <Typography sx={{ fontSize: '0.75rem', color: '#52525b' }}>↓ scroll for portfolio</Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+            background: 'rgba(9,9,11,0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +304,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask me anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -68,7 +68,7 @@ const Logo = () => {
         <path
           className="bracket-left"
           d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
+          stroke="#3b82f6"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -77,7 +77,7 @@ const Logo = () => {
         <path
           className="bracket-right"
           d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
+          stroke="#3b82f6"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -99,7 +99,7 @@ const Logo = () => {
           width="40"
           height="26"
           rx="2"
-          stroke="#38c0f2"
+          stroke="#3b82f6"
           strokeWidth="4"
           opacity="0"
           style={{ transformOrigin: 'center' }}
@@ -108,7 +108,7 @@ const Logo = () => {
         {/* Code Content on Screen - Adjusted for new rectangle position */}
         <g className="monitor-code" opacity="0">
           <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
+          <path className="code-line" d="M35 45H60" stroke="#3b82f6" strokeWidth="2.5" strokeLinecap="round" />
           <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
         </g>
         

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -6,15 +6,6 @@ import { useState } from 'react';
 import Logo from './Logo';
 import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
 const FormattedLink = ({ page, active, setActivePage }) => {
   return (
     <ScrollLink
@@ -26,11 +17,17 @@ const FormattedLink = ({ page, active, setActivePage }) => {
       onSetActive={() => setActivePage(page)}
       className="scroll-link"
       style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+        margin: '0 2px',
+        padding: '6px 16px',
+        fontWeight: active ? 500 : 400,
+        textDecoration: 'none',
+        cursor: 'pointer',
+        fontSize: '0.875rem',
+        letterSpacing: '-0.01em',
+        transition: 'all 0.2s ease',
+        color: active ? '#fafafa' : '#71717a',
+        borderRadius: '8px',
+        backgroundColor: active ? 'rgba(255,255,255,0.08)' : 'transparent',
       }}
     >
       {page}
@@ -50,18 +47,26 @@ const NavBar = () => {
         top: 0,
         zIndex: 1100,
         width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
+        bgcolor: 'rgba(9, 9, 11, 0.8)',
+        backdropFilter: 'blur(20px) saturate(180%)',
+        height: '60px',
+        color: '#fafafa',
         transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
+        borderBottom: '1px solid rgba(255,255,255,0.06)',
         boxShadow: 'none',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: { xs: 2, md: 4 },
+          minHeight: '60px !important',
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 1.5 }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
           <Logo />
@@ -69,18 +74,27 @@ const NavBar = () => {
             variant="h6"
             component="div"
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              fontWeight: 600,
+              letterSpacing: '-0.02em',
+              fontSize: '1.05rem',
+              color: '#fafafa',
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            David Riva
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'flex' },
+            alignItems: 'center',
+            gap: 0.5,
+            p: '4px',
+            borderRadius: '12px',
+            bgcolor: 'rgba(255,255,255,0.04)',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
           {pages.map((page) => (
             <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
           ))}

--- a/next-app/src/components/Navbar/ScrollLink.css
+++ b/next-app/src/components/Navbar/ScrollLink.css
@@ -1,26 +1,12 @@
 .scroll-link {
-    font-size: 0.9rem; /* Default font size for xs */
-}
-  
-@media (min-width: 600px) {
-    .scroll-link {
-        font-size: 1rem; /* Font size for sm */
-    }
+    font-size: 0.875rem;
 }
 
-@media (min-width: 900px) {
-    .scroll-link {
-        font-size: 1.2rem; /* Font size for md */
-    }
-}
-
-/* Hover effect */
 .scroll-link:hover {
-    color: #fff;
-    transform: scale(1.1);
+    color: #fafafa !important;
+    background-color: rgba(255, 255, 255, 0.06) !important;
 }
-  
-/* Click effect (active state) */
+
 .scroll-link:active {
-    transform: scale(0.95);
+    transform: scale(0.98);
 }

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -11,16 +11,16 @@ const ProjectImage = ({ coverImage, title, featured }) => {
     <Box
       sx={{
         position: 'relative',
-        height: featured ? '220px' : '180px',
+        height: featured ? '200px' : '170px',
         width: '100%',
-        bgcolor: 'background.paper',
+        bgcolor: '#18181b',
         overflow: 'hidden',
       }}
     >
       <Image
         src={`/images/${coverImage}`}
         alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+        style={{ objectFit: 'cover', transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)' }}
         className="project-image"
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -29,7 +29,7 @@ const ProjectImage = ({ coverImage, title, featured }) => {
         sx={{
           position: 'absolute',
           inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
+          background: 'linear-gradient(to bottom, transparent 40%, rgba(9,9,11,0.8) 100%)',
         }}
       />
     </Box>
@@ -42,24 +42,31 @@ const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, f
       <Typography
         variant={featured ? 'h6' : 'body1'}
         component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
+        sx={{
+          fontWeight: 600,
+          mb: 0.5,
+          color: '#fafafa',
+          lineHeight: 1.3,
+          fontSize: featured ? '1rem' : '0.9rem',
+          letterSpacing: '-0.01em',
+        }}
       >
         {title}
       </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
+      <Typography variant="caption" sx={{ color: '#52525b', display: 'block', mb: 1.5, fontSize: '0.72rem' }}>
         {dateStarted} – {dateCompleted}
       </Typography>
       <Typography
         variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
+          color: '#71717a',
           lineHeight: 1.6,
           mb: 2,
           display: '-webkit-box',
           WebkitLineClamp: 3,
           WebkitBoxOrient: 'vertical',
           overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
+          fontSize: featured ? '0.82rem' : '0.78rem',
         }}
       >
         {short_description}
@@ -71,20 +78,20 @@ const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, f
 const ProjectTech = ({ technologies }) => {
   const allTools = technologies.flatMap((t) => t.tools);
   return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
+    <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
       {allTools.map((tool, index) => (
         <Chip
           key={index}
           label={tool}
           size="small"
           sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
+            bgcolor: 'rgba(59,130,246,0.06)',
+            color: '#60a5fa',
+            border: '1px solid rgba(59,130,246,0.12)',
+            fontSize: '0.68rem',
             height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
+            fontWeight: 500,
+            '&:hover': { bgcolor: 'rgba(59,130,246,0.12)' },
           }}
         />
       ))}
@@ -99,19 +106,22 @@ const ProjectFooter = ({ link }) => {
       href={link}
       target="_blank"
       rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
+      endIcon={<LaunchIcon sx={{ fontSize: '0.85rem !important' }} />}
       fullWidth
       sx={{
         mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
+        color: '#a1a1aa',
+        borderColor: 'rgba(255,255,255,0.1)',
+        borderRadius: '10px',
         textTransform: 'none',
         fontSize: '0.8rem',
+        fontWeight: 500,
         py: 0.75,
+        transition: 'all 0.2s ease',
         '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
+          borderColor: 'rgba(59,130,246,0.4)',
+          bgcolor: 'rgba(59,130,246,0.06)',
+          color: '#60a5fa',
         },
       }}
     >
@@ -133,22 +143,19 @@ const ProjectCard = forwardRef(
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(255,255,255,0.03)',
+          color: '#fafafa',
+          border: featured ? '1px solid rgba(59,130,246,0.12)' : '1px solid rgba(255,255,255,0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+          transition: 'all 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
           cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: featured ? 'rgba(59,130,246,0.3)' : 'rgba(255,255,255,0.15)',
+            boxShadow: '0 16px 48px rgba(0,0,0,0.3)',
+            '& .project-image': { transform: 'scale(1.04)' },
           },
         }}
         onClick={onClick}

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -10,18 +10,16 @@ const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
+        width: '100%',
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+        px: { xs: 2, md: 4, lg: 6 },
         textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
       }}
     >
       <SectionHeading sectionName="Projects" />
-
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -22,10 +22,10 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
+        duration: 0.7,
+        stagger: 0.1,
         ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
       }
     );
     ScrollTrigger.refresh();
@@ -52,11 +52,7 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 30, opacity: 0 }, { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' });
   }, [projects]);
 
   return (
@@ -92,13 +88,20 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
         <Grid container spacing={3}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: 'rgba(255,255,255,0.03)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                }}
+              >
+                <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px' }} />
                 <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
                 <Skeleton variant="text" width="60%" />
                 <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
@@ -107,30 +110,29 @@ const ProjectsContainer = () => {
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <Box>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <Box sx={{ mt: 5, textAlign: 'center' }}>
             <Button
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
+                color: '#71717a',
+                borderColor: 'rgba(255,255,255,0.1)',
                 border: '1px solid',
-                borderRadius: '50px',
+                borderRadius: '999px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
                 fontSize: '0.85rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
                 bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
+                transition: 'all 0.2s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.06)',
+                  borderColor: 'rgba(255,255,255,0.2)',
+                  color: '#fafafa',
                 },
               }}
             >

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -2,36 +2,25 @@ import { Box, Typography } from '@mui/material';
 
 const SectionHeading = ({ sectionName }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
+    <Box
+      sx={{
+        mb: 8,
+        display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        pt: '40px'
       }}
     >
       <Typography
         variant="h2"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
+          fontWeight: 700,
+          fontSize: { xs: '2rem', md: '3rem' },
+          letterSpacing: '-0.03em',
           lineHeight: 1.1,
           textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          background: 'linear-gradient(180deg, #fafafa 0%, #71717a 100%)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
         }}
       >
         {sectionName}

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,33 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: '#18181b',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: '#a1a1aa',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#3b82f6',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#8b5cf6',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
+    h1: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.05 },
+    h2: { fontWeight: 700, letterSpacing: '-0.025em', lineHeight: 1.1 },
+    h3: { fontWeight: 600, letterSpacing: '-0.02em' },
+    h4: { fontWeight: 600, letterSpacing: '-0.015em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7 },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual overhaul of the portfolio site, touching 27 component files with a cohesive modern design system.

**Design direction: refined minimalism with depth** — neutral dark backgrounds, blue/violet accent gradient, Inter font, generous whitespace, and subtle glassmorphism.

### Key changes

- **New design system**: Neutral dark palette (`#09090b` base), blue (`#3b82f6`) + violet (`#8b5cf6`) accent gradient, Inter font with tight letter-spacing, consistent border/surface tokens across all components
- **NavBar**: Frosted glass effect with a pill-tab navigation group instead of underline-active links
- **Hero section**: Larger heading with gradient text on "David", lighter-weight typewriter subtitle, refined chat chips without glow shadows
- **About section**: Bento-grid layout — profile card (headshot + name + links), biography card, experience timeline card, and a new **skills & technologies** card that loads `skills.json` and displays categorized skill pills
- **Projects section**: Cleaner cards with subtler borders, refined hover elevation (`translateY(-4px)` + shadow), updated tech chip styling
- **Contact section**: Two-column name/email row, updated form field styling with rounded inputs, gradient submit button
- **Footer**: Minimal single-line with subtle bordered back-to-top button
- **Section headings**: White-to-zinc gradient text fade replacing the underline accent bar
- **Typography**: Swapped Montserrat → Inter across layout and all components

### What's preserved
- All chat functionality (useChat hook, streaming, Turnstile auth, cached chip responses)
- Data loading patterns (client-side fetch from `/data/*.json`)
- GSAP scroll-triggered animations on project cards
- Particle background (colors updated to match new palette)
- All API routes unchanged

## Test plan

- [ ] Verify hero section renders with gradient heading and typewriter animation
- [ ] Verify chat input works — send a message and confirm streaming response
- [ ] Verify quick-action chips load cached responses
- [ ] Scroll to About — confirm bento grid layout with headshot, bio, timeline, and skills cards
- [ ] Verify skills load from `skills.json` and display as categorized pill tags
- [ ] Verify experience timeline renders with company logos
- [ ] Scroll to Projects — confirm featured cards render with images and GSAP reveal animation
- [ ] Click "View all projects" — confirm expand/collapse works
- [ ] Scroll to Contact — confirm two-column form layout and Turnstile widget
- [ ] Test mobile responsive layout (xs/sm breakpoints) for nav, hero, about grid, and form
- [ ] Verify NavBar glass effect and pill-tab active state on scroll
- [ ] Run `npm run build` — passes cleanly

https://claude.ai/code/session_01UTeMHJ47LoehnZdtQT2ZGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTeMHJ47LoehnZdtQT2ZGH)_