### PR TITLE
Redesign portfolio with refined dark aesthetic

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,40 +2,48 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva — Software Engineer',
+  description:
+    'Software engineer specializing in applied AI, full-stack development, and production systems. View projects, experience, and get in touch.',
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'AI Engineer',
+    'Full Stack Developer',
+    'React',
+    'Next.js',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI & full-stack engineering portfolio.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: "David Riva's portfolio",
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI & full-stack engineering portfolio.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +51,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={inter.variable}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -4,10 +4,11 @@ import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
+const Skills = dynamic(() => import('@/components/Skills-Page/Skills'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
 
@@ -15,10 +16,11 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#0a0a0f',
+        color: '#e8e6e3',
         position: 'relative',
         minHeight: '100vh',
+        overflow: 'hidden',
       }}
     >
       <NavBar />
@@ -26,60 +28,119 @@ const MainPage = () => {
       <Box
         sx={{
           position: 'relative',
-          height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(110, 182, 240, 0.06) 0%, transparent 70%)',
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
+      <Box
+        id="about"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: '600px',
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+          },
+        }}
+      >
+        <About />
+      </Box>
 
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
+      <Box
+        id="experience"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: '600px',
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+          },
+        }}
+      >
+        <Experience />
+      </Box>
 
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+      <Box
+        id="projects"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: '600px',
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+          },
+        }}
+      >
+        <Projects />
+      </Box>
+
+      <Box
+        id="skills"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: '600px',
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+          },
+        }}
+      >
+        <Skills />
+      </Box>
+
+      <Box
+        id="contact"
+        sx={{
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: '600px',
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+          },
+        }}
+      >
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,191 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
-};
+import { Box, Typography, IconButton, Link, Button } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+import Image from 'next/image';
 
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '900px',
+        mx: 'auto',
         px: { xs: 3, md: 6 },
+        py: { xs: 10, md: 14 },
       }}
     >
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          gap: { xs: 4, md: 6 },
+          alignItems: { xs: 'center', md: 'flex-start' },
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Headshot */}
+        <Box sx={{ flexShrink: 0 }}>
+          <Box
+            sx={{
+              width: { xs: 120, md: 160 },
+              height: { xs: 120, md: 160 },
+              borderRadius: '20px',
+              overflow: 'hidden',
+              border: '1px solid rgba(255, 255, 255, 0.08)',
+              position: 'relative',
+            }}
+          >
+            <Image
+              alt="David Riva"
+              src="/images/headshot.webp"
+              fill
+              style={{ objectFit: 'cover' }}
+              priority
+              sizes="160px"
+            />
+          </Box>
         </Box>
-      </Box>
 
-      <AboutTextSection />
+        {/* Text content */}
+        <Box sx={{ flex: 1 }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'rgba(255, 255, 255, 0.3)',
+              mb: 1,
+              display: 'block',
+            }}
+          >
+            About
+          </Typography>
 
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
+          <Typography
+            variant="h3"
+            sx={{
+              fontSize: { xs: '1.5rem', md: '1.85rem' },
+              fontWeight: 700,
+              mb: 1,
+              color: '#e8e6e3',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            David Riva
+          </Typography>
+
+          <Typography
+            sx={{
+              fontSize: '0.95rem',
+              fontWeight: 500,
+              color: '#6eb6f0',
+              mb: 0.5,
+            }}
+          >
+            Software Engineer
+          </Typography>
+
+          <Typography
+            sx={{
+              fontSize: '0.85rem',
+              color: 'rgba(255, 255, 255, 0.35)',
+              mb: 3,
+            }}
+          >
+            Bay Area, CA
+          </Typography>
+
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'rgba(255, 255, 255, 0.6)',
+              mb: 2,
+              maxWidth: '580px',
+            }}
+          >
+            Software engineer with a focus on applied AI and full-stack development. I graduated from Colorado State
+            University with a B.S. in Computer Science, Summa Cum Laude, and I&apos;m passionate about building systems
+            that are both technically rigorous and genuinely useful.
+          </Typography>
+
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'rgba(255, 255, 255, 0.6)',
+              mb: 4,
+              maxWidth: '580px',
+            }}
+          >
+            Experienced in production ML pipelines, data engineering, and creating interfaces that make complex data
+            accessible. I believe in elegant problem-solving and maintaining high standards of craft.
+          </Typography>
+
+          {/* Actions */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Button
+              href="/documents/resume.pdf"
+              target="_blank"
+              endIcon={<ArrowOutwardIcon sx={{ fontSize: '0.85rem !important' }} />}
+              sx={{
+                color: '#e8e6e3',
+                bgcolor: 'rgba(255, 255, 255, 0.06)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
+                borderRadius: '10px',
+                textTransform: 'none',
+                fontSize: '0.8rem',
+                fontWeight: 500,
+                px: 2,
+                py: 0.75,
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  bgcolor: 'rgba(255, 255, 255, 0.1)',
+                  borderColor: 'rgba(255, 255, 255, 0.15)',
+                },
+              }}
+            >
+              Resume
+            </Button>
+
+            <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+              <IconButton
+                size="small"
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.4)',
+                  transition: 'color 0.2s ease',
+                  '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(255,255,255,0.06)' },
+                }}
+              >
+                <GitHubIcon sx={{ fontSize: '1.15rem' }} />
+              </IconButton>
+            </Link>
+
+            <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+              <IconButton
+                size="small"
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.4)',
+                  transition: 'color 0.2s ease',
+                  '&:hover': { color: '#6eb6f0', bgcolor: 'rgba(110, 182, 240, 0.08)' },
+                }}
+              >
+                <LinkedInIcon sx={{ fontSize: '1.15rem' }} />
+              </IconButton>
+            </Link>
+
+            <Link href="mailto:davidjriva@gmail.com">
+              <IconButton
+                size="small"
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.4)',
+                  transition: 'color 0.2s ease',
+                  '&:hover': { color: '#a78bfa', bgcolor: 'rgba(167, 139, 250, 0.08)' },
+                }}
+              >
+                <EmailOutlinedIcon sx={{ fontSize: '1.15rem' }} />
+              </IconButton>
+            </Link>
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -12,14 +12,14 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
-        borderRadius: '999px',
+        p: '6px 8px',
+        borderRadius: '14px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        border: '1px solid rgba(255,255,255,0.08)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.12)' },
+        '&:focus-within': { borderColor: 'rgba(110, 182, 240, 0.3)' },
       }}
     >
       <InputBase
@@ -34,24 +34,34 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#e8e6e3',
+          fontSize: '0.9rem',
+          fontFamily: 'inherit',
+          '& input::placeholder': { color: 'rgba(255,255,255,0.25)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          ml: 0.5,
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          background: input.trim() && !disabled ? '#e8e6e3' : 'rgba(255,255,255,0.06)',
+          transition: 'all 0.2s ease',
+          '&:hover': { background: '#fff' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.04)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <ArrowUpwardIcon
+          sx={{
+            color: input.trim() && !disabled ? '#0a0a0f' : 'rgba(255,255,255,0.15)',
+            fontSize: '1rem',
+          }}
+        />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,58 +7,57 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'inherit',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#e8e6e3',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
-          px: 2.5,
+          px: 2,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(110, 182, 240, 0.08)' : 'rgba(255,255,255,0.03)',
+          border: isUser ? '1px solid rgba(110, 182, 240, 0.12)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={6} dotColor="rgba(255,255,255,0.3)" spacing={3} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
-                li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
+                li: (props) => <li style={{ ...mdStyles, marginBottom: '4px' }} {...props} />,
+                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 600 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.2rem', mt: 1.5, mb: 0.5 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.05rem', mt: 1, mb: 0.5 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '0.95rem', mt: 1, mb: 0.5 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#6eb6f0',
+                      backgroundColor: 'rgba(110, 182, 240, 0.08)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
+                      fontSize: '0.85em',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +66,34 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.3)',
+                      color: '#e8e6e3',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.85rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{
+                      color: '#6eb6f0',
+                      textDecoration: 'none',
+                      borderBottom: '1px solid rgba(110, 182, 240, 0.3)',
+                    }}
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#e8e6e3' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,39 +1,44 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
-import SectionHeading from '../SectionHeading';
 
 const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '650px',
+        mx: 'auto',
+        px: { xs: 3, md: 6 },
+        py: { xs: 10, md: 14 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.3)', mb: 1, display: 'block' }}>
+        Contact
+      </Typography>
 
-      <Box
+      <Typography
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          fontSize: '1.15rem',
+          fontWeight: 600,
+          color: '#e8e6e3',
+          mb: 1,
+          letterSpacing: '-0.01em',
         }}
       >
-        <ContactForm />
-      </Box>
+        Get in touch
+      </Typography>
+
+      <Typography
+        sx={{
+          fontSize: '0.85rem',
+          color: 'rgba(255, 255, 255, 0.4)',
+          mb: 4,
+          maxWidth: '400px',
+        }}
+      >
+        Have a question or want to work together? Send me a message.
+      </Typography>
+
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,23 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': {
+    color: 'rgba(255, 255, 255, 0.35)',
+    fontSize: '0.85rem',
+    fontWeight: 500,
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#e8e6e3',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    borderRadius: '10px',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(110, 182, 240, 0.3)', borderWidth: '1px' },
   },
 };
 
@@ -46,27 +53,17 @@ const ContactForm = () => {
   };
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-      }}
-    >
+    <Box sx={{ width: '100%' }}>
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
         <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
 
         {!captchaToken && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: 2 }}>
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
               onSuccess={(token) => setCaptchaToken(token)}
@@ -76,36 +73,38 @@ const ContactForm = () => {
 
         <Button
           type="submit"
-          variant="contained"
           disabled={!captchaToken}
+          endIcon={<ArrowOutwardIcon sx={{ fontSize: '0.85rem !important' }} />}
           sx={{
-            width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            color: '#0a0a0f',
+            bgcolor: '#e8e6e3',
+            borderRadius: '10px',
+            textTransform: 'none',
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            px: 3,
+            py: 1,
+            transition: 'all 0.2s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              bgcolor: '#fff',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              bgcolor: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(255, 255, 255, 0.2)',
             },
           }}
         >
-          Send Message
+          Send message
         </Button>
       </form>
 
       {status && (
         <Typography
-          variant="body2"
           sx={{
-            marginTop: 2,
-            textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            mt: 2,
+            fontSize: '0.8rem',
+            fontWeight: 500,
+            color: status.includes('success') ? 'rgba(110, 220, 150, 0.8)' : 'rgba(255, 120, 120, 0.8)',
           }}
         >
           {status}

--- a/next-app/src/components/Experience/Experience.js
+++ b/next-app/src/components/Experience/Experience.js
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Skeleton } from '@mui/material';
+import Image from 'next/image';
+
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, location, startDate, endDate, bulletPoints, isFirst }) => {
+  const isCurrent = endDate === 'Present' || new Date(endDate) > new Date();
+  const isGraduation = title.startsWith('Graduated');
+  const displayTitle = isGraduation ? 'B.S. Computer Science, Summa Cum Laude' : title.split(',')[0];
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: { xs: 2, md: 3 },
+        position: 'relative',
+      }}
+    >
+      {/* Timeline line */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column',
+          alignItems: 'center',
+          flexShrink: 0,
+          width: 40,
+          pt: 0.5,
+        }}
+      >
+        <Box
+          sx={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            bgcolor: isCurrent ? '#6eb6f0' : 'rgba(255, 255, 255, 0.15)',
+            flexShrink: 0,
+            boxShadow: isCurrent ? '0 0 12px rgba(110, 182, 240, 0.3)' : 'none',
+            mt: 1,
+          }}
+        />
+        <Box
+          sx={{
+            flex: 1,
+            width: '1px',
+            bgcolor: 'rgba(255, 255, 255, 0.06)',
+            mt: 1,
+          }}
+        />
+      </Box>
+
+      {/* Content */}
+      <Box
+        sx={{
+          flex: 1,
+          pb: 5,
+          minWidth: 0,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
+          <Box
+            sx={{
+              width: 28,
+              height: 28,
+              borderRadius: '8px',
+              overflow: 'hidden',
+              bgcolor: '#fff',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '1px solid rgba(255,255,255,0.08)',
+            }}
+          >
+            <Image
+              src={`/images/${logoImage}`}
+              alt={`${company} logo`}
+              width={20}
+              height={20}
+              style={{ objectFit: 'contain' }}
+            />
+          </Box>
+          <Box>
+            <Typography
+              component="a"
+              href={companyWebsiteLink}
+              target="_blank"
+              sx={{
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                color: '#e8e6e3',
+                textDecoration: 'none',
+                '&:hover': { color: '#6eb6f0' },
+                transition: 'color 0.2s ease',
+              }}
+            >
+              {company}
+            </Typography>
+            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
+              {location}
+            </Typography>
+          </Box>
+        </Box>
+
+        <Typography
+          sx={{
+            fontSize: '0.95rem',
+            fontWeight: 600,
+            color: '#e8e6e3',
+            mb: 0.5,
+          }}
+        >
+          {displayTitle}
+        </Typography>
+
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            color: isCurrent ? '#6eb6f0' : 'rgba(255, 255, 255, 0.3)',
+            fontWeight: isCurrent ? 500 : 400,
+            mb: bulletPoints ? 1.5 : 0,
+          }}
+        >
+          {isGraduation ? startDate : `${startDate} — ${isCurrent ? 'Present' : endDate}`}
+        </Typography>
+
+        {bulletPoints && bulletPoints.length > 0 && (
+          <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+            {bulletPoints.slice(0, 3).map((point, i) => (
+              <Box
+                component="li"
+                key={i}
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.45)',
+                  fontSize: '0.85rem',
+                  lineHeight: 1.65,
+                  mb: 0.5,
+                  '&::marker': { color: 'rgba(255,255,255,0.15)' },
+                }}
+              >
+                {point}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const Experience = () => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((d) => {
+        const sorted = [...d].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setData(sorted);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        maxWidth: '750px',
+        mx: 'auto',
+        px: { xs: 3, md: 6 },
+        py: { xs: 10, md: 14 },
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{ color: 'rgba(255, 255, 255, 0.3)', mb: 4, display: 'block' }}
+      >
+        Experience
+      </Typography>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {[1, 2, 3].map((i) => (
+            <Box key={i}>
+              <Skeleton variant="text" width="40%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+              <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+              <Skeleton variant="text" width="80%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        <Box>
+          {data.map((exp, i) => (
+            <ExperienceCard key={exp.title} {...exp} isFirst={i === 0} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,39 +1,73 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton, Link } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        px: { xs: 3, md: 6 },
+        py: 4,
+        maxWidth: '1100px',
+        mx: 'auto',
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <Box
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
-      </Typography>
+        <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255, 255, 255, 0.2)' }}>
+          © {new Date().getFullYear()} David Riva
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+            <IconButton
+              size="small"
+              sx={{
+                color: 'rgba(255, 255, 255, 0.2)',
+                '&:hover': { color: 'rgba(255, 255, 255, 0.5)' },
+              }}
+            >
+              <GitHubIcon sx={{ fontSize: '0.95rem' }} />
+            </IconButton>
+          </Link>
+          <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+            <IconButton
+              size="small"
+              sx={{
+                color: 'rgba(255, 255, 255, 0.2)',
+                '&:hover': { color: 'rgba(255, 255, 255, 0.5)' },
+              }}
+            >
+              <LinkedInIcon sx={{ fontSize: '0.95rem' }} />
+            </IconButton>
+          </Link>
+
+          <IconButton
+            size="small"
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            sx={{
+              ml: 1,
+              color: 'rgba(255, 255, 255, 0.2)',
+              border: '1px solid rgba(255, 255, 255, 0.06)',
+              borderRadius: '8px',
+              width: 28,
+              height: 28,
+              '&:hover': { color: 'rgba(255, 255, 255, 0.5)', borderColor: 'rgba(255,255,255,0.1)' },
+            }}
+          >
+            <KeyboardArrowUpIcon sx={{ fontSize: '0.9rem' }} />
+          </IconButton>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -3,81 +3,64 @@
 import { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
-  const getArticle = (role) => {
-    const vowels = ['a', 'e', 'i', 'o', 'u'];
-    return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
-  };
-
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = ROLES[roleIndex];
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
-      timer = setTimeout(() => {
-        setText((prev) => prev + currentRole[index]);
-        setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev + currentRole[index]);
+          setIndex((prev) => prev + 1);
+        },
+        80 + Math.random() * 40,
+      );
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 1500);
     } else if (deleting && index > 0) {
-      // Deleting logic
-      timer = setTimeout(() => {
-        setText((prev) => prev.slice(0, -1));
-        setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev.slice(0, -1));
+          setIndex((prev) => prev - 1);
+        },
+        35 + Math.random() * 25,
+      );
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
-    return () => clearInterval(blinkCursor);
+    const blink = setInterval(() => setCursorVisible((prev) => !prev), 400);
+    return () => clearInterval(blink);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1rem', sm: '1.15rem', md: '1.25rem' },
+        fontWeight: 400,
+        color: 'rgba(255, 255, 255, 0.4)',
+        letterSpacing: '0.01em',
+        minHeight: '1.6em',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {text}
+      <span style={{ color: '#6eb6f0', opacity: cursorVisible ? 0.7 : 0, transition: 'opacity 0.1s' }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -40,33 +40,9 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', accent: '#6eb6f0' },
+  { label: 'Tell me about your experience', accent: '#a78bfa' },
+  { label: 'Featured projects', accent: '#e8e6e3' },
 ];
 
 const HeroChat = () => {
@@ -89,8 +65,8 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100vh', color: '#e8e6e3', zIndex: 1 }}>
+      {/* Pre-chat greeting */}
       <Box
         sx={{
           position: 'absolute',
@@ -99,46 +75,59 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 3,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-20px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease, transform 400ms ease',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
         <Typography
-          variant="h1"
+          variant="caption"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
-            textAlign: 'center',
+            color: 'rgba(255, 255, 255, 0.35)',
+            fontSize: '0.7rem',
+            mb: -1,
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          Software Engineer
+        </Typography>
+
+        <Typography
+          variant="h1"
+          sx={{
+            fontSize: 'clamp(2.5rem, 8vw, 5rem)',
+            fontWeight: 700,
+            lineHeight: 1.05,
+            textAlign: 'center',
+            letterSpacing: '-0.04em',
+          }}
+        >
+          David Riva
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={
+              turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask my AI agent anything...'
+            }
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="body2" sx={{ color: 'rgba(255,100,100,0.7)', fontSize: '0.8rem' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ gap: 1 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -152,31 +141,28 @@ const HeroChat = () => {
               }}
               sx={{
                 height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                background: 'rgba(255, 255, 255, 0.03)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
+                  color: 'rgba(255, 255, 255, 0.5)',
+                  fontSize: '0.8rem',
+                  fontWeight: 500,
                   px: 2,
-                  py: 1,
+                  py: 0.85,
                 },
                 '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
+                  background: 'rgba(255, 255, 255, 0.06)',
+                  borderColor: 'rgba(255, 255, 255, 0.15)',
+                  '& .MuiChip-label': { color: '#e8e6e3' },
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +175,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +191,30 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.5,
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: 'none',
+            color: 'rgba(255, 255, 255, 0.25)',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            fontFamily: 'inherit',
+            '&:hover': { color: 'rgba(255, 255, 255, 0.5)' },
+            '@keyframes float': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(4px)' },
+            },
+            animation: 'float 2.5s ease-in-out infinite',
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Scroll to explore
+          <KeyboardArrowDownIcon sx={{ fontSize: '1rem' }} />
         </Box>
       </Box>
 
@@ -233,11 +226,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease 100ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +238,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.05)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #6eb6f0, #a78bfa)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.85rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +259,27 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', lineHeight: 1.2, color: '#e8e6e3' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
-              Knows David&apos;s experience, projects &amp; skills
+            <Typography sx={{ fontSize: '0.7rem', color: 'rgba(255,255,255,0.3)', lineHeight: 1.2 }}>
+              Knows about experience, projects & skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
-          </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.05)',
+            background: 'rgba(10, 10, 15, 0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +287,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -9,44 +9,39 @@ const Logo = () => {
   const container = useRef();
   const [hovered, setHovered] = useState(false);
 
-  useGSAP(() => {
-    if (hovered) {
-      // Brackets expand outward and disappear
-      gsap.to(".bracket-left", { x: -20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      gsap.to(".bracket-right", { x: 20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      
-      // Slash disappears as it "transforms" into the stand
-      gsap.to(".code-slash", { opacity: 0, scale: 0, duration: 0.3 });
-
-      // Monitor Screen assembles
-      gsap.fromTo(".monitor-screen", 
-        { opacity: 0, scale: 0.5 },
-        { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.5)" }
-      );
-
-      // Code appearance on screen
-      gsap.to(".monitor-code", { opacity: 1, duration: 0.3, delay: 0.4 });
-      gsap.fromTo(".code-line", 
-        { scaleX: 0 },
-        { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: "left center", ease: "power1.out" }
-      );
-      
-      // Monitor Stand slides up
-      gsap.fromTo(".monitor-stand-all",
-        { opacity: 0, y: 5 },
-        { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: "power2.out" }
-      );
-    } else {
-      // Restore to initial state
-      gsap.to(".bracket-left", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".bracket-right", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".code-slash", { opacity: 1, scale: 1, duration: 0.4 });
-      
-      gsap.to(".monitor-screen", { opacity: 0, scale: 0.5, duration: 0.3 });
-      gsap.to(".monitor-code", { opacity: 0, duration: 0.2 });
-      gsap.to(".monitor-stand-all", { opacity: 0, y: 5, duration: 0.3 });
-    }
-  }, { scope: container, dependencies: [hovered] });
+  useGSAP(
+    () => {
+      if (hovered) {
+        gsap.to('.bracket-left', { x: -20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.bracket-right', { x: 20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.code-slash', { opacity: 0, scale: 0, duration: 0.3 });
+        gsap.fromTo(
+          '.monitor-screen',
+          { opacity: 0, scale: 0.5 },
+          { opacity: 1, scale: 1, duration: 0.5, ease: 'back.out(1.5)' },
+        );
+        gsap.to('.monitor-code', { opacity: 1, duration: 0.3, delay: 0.4 });
+        gsap.fromTo(
+          '.code-line',
+          { scaleX: 0 },
+          { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: 'left center', ease: 'power1.out' },
+        );
+        gsap.fromTo(
+          '.monitor-stand-all',
+          { opacity: 0, y: 5 },
+          { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: 'power2.out' },
+        );
+      } else {
+        gsap.to('.bracket-left', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.bracket-right', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.code-slash', { opacity: 1, scale: 1, duration: 0.4 });
+        gsap.to('.monitor-screen', { opacity: 0, scale: 0.5, duration: 0.3 });
+        gsap.to('.monitor-code', { opacity: 0, duration: 0.2 });
+        gsap.to('.monitor-stand-all', { opacity: 0, y: 5, duration: 0.3 });
+      }
+    },
+    { scope: container, dependencies: [hovered] },
+  );
 
   return (
     <Box
@@ -57,41 +52,29 @@ const Logo = () => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        mr: 2,
         cursor: 'pointer',
-        width: 40,
-        height: 40,
+        width: 32,
+        height: 32,
       }}
     >
-      <svg width="40" height="40" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-        {/* Left Bracket */}
+      <svg width="32" height="32" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           className="bracket-left"
           d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
+          stroke="#6eb6f0"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {/* Right Bracket */}
         <path
           className="bracket-right"
           d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
+          stroke="#6eb6f0"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {/* The Slash */}
-        <path
-          className="code-slash"
-          d="M56 35L44 65"
-          stroke="currentColor"
-          strokeWidth="5"
-          strokeLinecap="round"
-        />
-        
-        {/* Monitor Screen Frame - Higher and More Compact */}
+        <path className="code-slash" d="M56 35L44 65" stroke="currentColor" strokeWidth="5" strokeLinecap="round" />
         <rect
           className="monitor-screen"
           x="30"
@@ -99,23 +82,19 @@ const Logo = () => {
           width="40"
           height="26"
           rx="2"
-          stroke="#38c0f2"
+          stroke="#6eb6f0"
           strokeWidth="4"
           opacity="0"
           style={{ transformOrigin: 'center' }}
         />
-
-        {/* Code Content on Screen - Adjusted for new rectangle position */}
         <g className="monitor-code" opacity="0">
           <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
+          <path className="code-line" d="M35 45H60" stroke="#6eb6f0" strokeWidth="2.5" strokeLinecap="round" />
           <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
         </g>
-        
-        {/* Monitor Stand Group - More Compact Stand */}
         <g className="monitor-stand-all" opacity="0">
-          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Shortened Stem */}
-          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Sized Base */}
+          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
         </g>
       </svg>
     </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -2,46 +2,20 @@
 
 import { Link as ScrollLink } from 'react-scroll';
 import { Toolbar, Box, AppBar, Typography } from '@mui/material';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Logo from './Logo';
-import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+const pages = ['About', 'Experience', 'Projects', 'Skills', 'Contact'];
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [activePage, setActivePage] = useState('');
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <AppBar
@@ -50,40 +24,90 @@ const NavBar = () => {
         top: 0,
         zIndex: 1100,
         width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
+        bgcolor: scrolled ? 'rgba(10, 10, 15, 0.85)' : 'transparent',
+        backdropFilter: scrolled ? 'blur(20px) saturate(180%)' : 'none',
         height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
+        color: '#e8e6e3',
+        transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+        borderBottom: scrolled ? '1px solid rgba(255, 255, 255, 0.04)' : '1px solid transparent',
         boxShadow: 'none',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: { xs: 2, md: 5 },
+          maxWidth: '1400px',
+          width: '100%',
+          mx: 'auto',
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 1.5 }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
           <Logo />
           <Typography
-            variant="h6"
-            component="div"
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              fontWeight: 700,
+              letterSpacing: '-0.02em',
+              fontSize: '1.1rem',
+              color: '#e8e6e3',
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            david<span style={{ color: '#6eb6f0' }}>riva</span>
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'flex' },
+            alignItems: 'center',
+            gap: 0.5,
+            bgcolor: 'rgba(255, 255, 255, 0.04)',
+            borderRadius: '100px',
+            border: '1px solid rgba(255, 255, 255, 0.06)',
+            px: 1,
+            py: 0.5,
+          }}
+        >
+          {pages.map((page) => {
+            const isActive = activePage === page;
+            return (
+              <ScrollLink
+                key={page}
+                to={page.toLowerCase()}
+                spy={true}
+                smooth={true}
+                offset={-70}
+                duration={500}
+                onSetActive={() => setActivePage(page)}
+                style={{ cursor: 'pointer' }}
+              >
+                <Box
+                  sx={{
+                    px: 2,
+                    py: 0.75,
+                    borderRadius: '100px',
+                    fontSize: '0.8rem',
+                    fontWeight: 500,
+                    letterSpacing: '0.02em',
+                    color: isActive ? '#fff' : 'rgba(255, 255, 255, 0.45)',
+                    bgcolor: isActive ? 'rgba(110, 182, 240, 0.12)' : 'transparent',
+                    transition: 'all 0.25s ease',
+                    '&:hover': {
+                      color: '#fff',
+                      bgcolor: isActive ? 'rgba(110, 182, 240, 0.12)' : 'rgba(255, 255, 255, 0.06)',
+                    },
+                  }}
+                >
+                  {page}
+                </Box>
+              </ScrollLink>
+            );
+          })}
         </Box>
       </Toolbar>
     </AppBar>

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,172 +2,163 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
-import LaunchIcon from '@mui/icons-material/Launch';
-
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
+import { Typography, Box, Card, CardContent, Chip, Stack } from '@mui/material';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
-        id={id}
+        component="a"
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+          color: '#e8e6e3',
+          border: '1px solid rgba(255, 255, 255, 0.05)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          cursor: 'pointer',
+          textDecoration: 'none',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            bgcolor: 'rgba(255, 255, 255, 0.035)',
+            borderColor: 'rgba(255, 255, 255, 0.1)',
+            boxShadow: '0 20px 40px rgba(0,0,0,0.3)',
+            '& .project-image': { transform: 'scale(1.04)' },
+            '& .arrow-icon': { opacity: 1, transform: 'translate(2px, -2px)' },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        {/* Image */}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? '200px' : '160px',
+            width: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, rgba(10,10,15,0) 40%, rgba(10,10,15,0.8) 100%)',
+            }}
+          />
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 2.5 }}>
+          {/* Header */}
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 1 }}>
+            <Typography
+              sx={{
+                fontWeight: 600,
+                fontSize: '0.95rem',
+                color: '#e8e6e3',
+                lineHeight: 1.3,
+                flex: 1,
+              }}
+            >
+              {title}
+            </Typography>
+            <ArrowOutwardIcon
+              className="arrow-icon"
+              sx={{
+                fontSize: '0.9rem',
+                color: 'rgba(255,255,255,0.3)',
+                ml: 1,
+                opacity: 0,
+                transition: 'all 0.2s ease',
+                flexShrink: 0,
+                mt: 0.25,
+              }}
+            />
+          </Box>
+
+          <Typography
+            sx={{
+              fontSize: '0.7rem',
+              color: 'rgba(255, 255, 255, 0.25)',
+              mb: 1.5,
+              fontWeight: 500,
+              letterSpacing: '0.03em',
+            }}
+          >
+            {dateStarted} — {dateCompleted}
+          </Typography>
+
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.45)',
+              lineHeight: 1.6,
+              mb: 2,
+              fontSize: '0.82rem',
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              flex: 1,
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          {/* Tech tags */}
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+            {allTools.slice(0, 5).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.04)',
+                  color: 'rgba(255, 255, 255, 0.4)',
+                  border: '1px solid rgba(255, 255, 255, 0.06)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 5 && (
+              <Chip
+                label={`+${allTools.length - 5}`}
+                size="small"
+                sx={{
+                  bgcolor: 'transparent',
+                  color: 'rgba(255, 255, 255, 0.25)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  border: 'none',
+                  '& .MuiChip-label': { px: 0.5 },
+                }}
+              />
+            )}
+          </Stack>
         </CardContent>
       </Card>
     );
-  }
+  },
 );
 
 ProjectCard.displayName = 'ProjectCard';

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -1,26 +1,19 @@
-import { Box } from '@mui/material';
-import SectionHeading from '@/components/SectionHeading';
+import { Box, Typography } from '@mui/material';
 import ProjectsContainer from './ProjectsContainer';
-
-export const metadata = {
-  title: 'David Riva | Projects',
-};
 
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1100px',
+        mx: 'auto',
+        px: { xs: 3, md: 6 },
+        py: { xs: 10, md: 14 },
       }}
     >
-      <SectionHeading sectionName="Projects" />
+      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.3)', mb: 4, display: 'block' }}>
+        Projects
+      </Typography>
 
       <ProjectsContainer />
     </Box>

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -1,76 +1,10 @@
 'use client';
 
 import { Box, Skeleton, Grid, Collapse, Button } from '@mui/material';
-import { useState, useEffect, useRef, useMemo, memo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import ProjectCard from './ProjectCard';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import gsap from 'gsap';
-import { ScrollTrigger } from 'gsap/ScrollTrigger';
-
-gsap.registerPlugin(ScrollTrigger);
-
-const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.featured-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 40, opacity: 0 },
-      {
-        y: 0,
-        opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
-      }
-    );
-    ScrollTrigger.refresh();
-    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
-  }, [projects]);
-
-  return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
-            <ProjectCard {...project} featured />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-});
-FeaturedProjects.displayName = 'FeaturedProjects';
-
-const AllProjects = ({ projects }) => {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
-  }, [projects]);
-
-  return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
-            <ProjectCard {...project} />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-};
 
 const ProjectsContainer = () => {
   const [projectData, setProjectData] = useState([]);
@@ -92,45 +26,59 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
-            <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+            <Grid key={item} size={{ xs: 12, sm: 6, lg: 4 }}>
+              <Box
+                sx={{
+                  p: 2.5,
+                  bgcolor: 'rgba(255,255,255,0.02)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(255,255,255,0.04)',
+                }}
+              >
+                <Skeleton
+                  variant="rectangular"
+                  height={180}
+                  sx={{ borderRadius: '10px', bgcolor: 'rgba(255,255,255,0.04)' }}
+                />
+                <Skeleton variant="text" sx={{ mt: 2, bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
-          <FeaturedProjects projects={featuredProjects} />
+        <Box>
+          <Grid container spacing={2.5}>
+            {featuredProjects.map((project) => (
+              <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title}>
+                <ProjectCard {...project} featured />
+              </Grid>
+            ))}
+          </Grid>
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
             <Button
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
-                px: 3,
-                py: 0.85,
+                color: 'rgba(255,255,255,0.4)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '10px',
+                px: 2.5,
+                py: 0.75,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.8rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
+                bgcolor: 'rgba(255,255,255,0.02)',
+                transition: 'all 0.2s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.05)',
+                  borderColor: 'rgba(255,255,255,0.12)',
+                  color: '#e8e6e3',
                 },
               }}
             >
@@ -139,8 +87,14 @@ const ProjectsContainer = () => {
           </Box>
 
           <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
+            <Box sx={{ mt: 3 }}>
+              <Grid container spacing={2.5}>
+                {otherProjects.map((project) => (
+                  <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title}>
+                    <ProjectCard {...project} />
+                  </Grid>
+                ))}
+              </Grid>
             </Box>
           </Collapse>
         </Box>

--- a/next-app/src/components/Skills-Page/Skills.js
+++ b/next-app/src/components/Skills-Page/Skills.js
@@ -1,47 +1,96 @@
-import React from 'react';
-import { Box, Divider } from '@mui/material';
-import SkillCard from './SkillCard';
-import SkillCardContainer from '@/components/Skills-Page/SkillCardContainer';
-import SectionHeading from '@/components/SectionHeading';
+'use client';
 
-export const metadata = {
-  title: 'David Riva | Skills',
-};
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Skeleton } from '@mui/material';
 
 const Skills = () => {
-  const [skillsData, setSkillsData] = useState([]);
+  const [skills, setSkills] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetch('/data/skills.json')
       .then((res) => res.json())
-      .then((data) => setSkillsData(data));
+      .then((data) => {
+        setSkills(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   }, []);
 
   return (
     <Box
       sx={{
-        marginTop: 10,
-        padding: '5rem',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        backgroundColor: '#565859',
-        borderTop: '8px solid rgba(0,0,0,0.1)',
-        boxShadow: '0px 1px 0px rgba(255,255,255,0.2)',
+        maxWidth: '900px',
+        mx: 'auto',
+        px: { xs: 3, md: 6 },
+        py: { xs: 10, md: 14 },
       }}
     >
-      <SectionHeading sectionName="Skills" />
+      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.3)', mb: 4, display: 'block' }}>
+        Skills & Tools
+      </Typography>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', marginTop: 10 }}>
-        {skillsData.map((skill, index) => (
-          <React.Fragment key={skill.title}>
-            <SkillCardContainer {...skill} />
-            {index < skillsData.length - 1 && <Divider sx={{ margin: '1rem 0', backgroundColor: 'lightgray' }} />}
-          </React.Fragment>
-        ))}
-      </Box>
+      {loading ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {[1, 2, 3].map((i) => (
+            <Box key={i}>
+              <Skeleton variant="text" width="20%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+              <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+                {[1, 2, 3, 4].map((j) => (
+                  <Skeleton
+                    key={j}
+                    variant="rounded"
+                    width={80}
+                    height={28}
+                    sx={{ borderRadius: '8px', bgcolor: 'rgba(255,255,255,0.04)' }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {skills.map((category) => (
+            <Box key={category.title}>
+              <Typography
+                sx={{
+                  fontSize: '0.8rem',
+                  fontWeight: 600,
+                  color: 'rgba(255, 255, 255, 0.5)',
+                  mb: 1.5,
+                  letterSpacing: '0.02em',
+                }}
+              >
+                {category.title}
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                {category.items.map((item) => (
+                  <Chip
+                    key={item}
+                    label={item}
+                    sx={{
+                      bgcolor: 'rgba(255, 255, 255, 0.03)',
+                      color: 'rgba(255, 255, 255, 0.55)',
+                      border: '1px solid rgba(255, 255, 255, 0.06)',
+                      borderRadius: '8px',
+                      fontSize: '0.78rem',
+                      fontWeight: 500,
+                      height: '30px',
+                      transition: 'all 0.2s ease',
+                      '&:hover': {
+                        bgcolor: 'rgba(255, 255, 255, 0.06)',
+                        borderColor: 'rgba(255, 255, 255, 0.1)',
+                        color: '#e8e6e3',
+                      },
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,34 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#0a0a0f',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#e8e6e3',
+      secondary: 'rgba(255, 255, 255, 0.5)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#6eb6f0',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#a78bfa',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), system-ui, -apple-system, sans-serif',
+    h1: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.05 },
+    h2: { fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.1 },
+    h3: { fontWeight: 600, letterSpacing: '-0.015em', lineHeight: 1.2 },
+    h4: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '1rem', letterSpacing: '0.01em' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.875rem' },
+    caption: { fontWeight: 500, letterSpacing: '0.06em', textTransform: 'uppercase', fontSize: '0.75rem' },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete UI redesign of the portfolio website, moving from the cyan/purple glassmorphism + particle background aesthetic to a refined, minimal dark design aligned with 2026 UI trends.

- **Theme overhaul**: Switched from Montserrat to Inter, new palette (`#6eb6f0` accent, `#0a0a0f` background), tighter typography with negative letter-spacing for a modern editorial feel
- **New Experience section**: Dedicated vertical timeline with company logos, replacing the sidebar-only timeline that was hidden on most screen sizes
- **Simplified visual hierarchy**: Removed particle background, heavy gradients, and GSAP scroll animations in favor of subtle radial gradients, gentle hover states, and clean section dividers
- **Redesigned every section**: Hero (large type + AI chat), About (magazine layout), Projects (cleaner cards with hover arrows), Skills (grouped tag cloud), Contact (side-by-side fields, light CTA button), Nav (floating pill navigation), Footer (compact single-row)

### What changed (18 files)

| Area | Changes |
|------|---------|
| `theme.js` | Inter font, new color palette, refined typography scale |
| `layout.js` | Inter font import, updated metadata |
| `page.js` | Added Experience + Skills sections, removed ParticleBackground, subtle section dividers |
| `NavBar` | Floating pill nav with scroll-aware background, removed CSS file dependency |
| `HeroChat` | Larger typography, muted chip styling, softer chat bubbles |
| `About` | Self-contained component (merged header/bio/footer/social), rounded headshot, integrated resume button |
| `Experience/` | **New component** — vertical timeline with company logos and bullet points |
| `Projects` | Cleaner cards, hover arrow reveal, muted tech tags, removed GSAP |
| `Skills` | Complete rewrite — grouped tag cloud replacing divider-separated lists, fixed missing hook imports |
| `Contact` | Side-by-side name/email, light submit button, minimal styling |
| `Footer` | Compact row with social icons and scroll-to-top |
| `Chat components` | Updated palette and bubble styling to match new design |

## Test plan

- [ ] Verify all sections render correctly on desktop (1440px+)
- [ ] Test responsive layout on mobile (375px) and tablet (768px)
- [ ] Verify AI chat flow works (pre-chat greeting → chip click → chat view)
- [ ] Test navigation pill highlighting on scroll
- [ ] Verify contact form submission still works
- [ ] Check all external links (GitHub, LinkedIn, resume PDF)
- [ ] Confirm no console errors on page load

https://claude.ai/code/session_01DYXmJnxwPC6NTi6ti6jhpt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYXmJnxwPC6NTi6ti6jhpt)_