### PR TITLE
Redesign portfolio with warm neutral theme and modern layout

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,40 +2,49 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
+  weight: ['300', '400', '500', '600', '700'],
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    "David Riva's portfolio — software engineer specializing in applied AI, full-stack development, and production systems. View projects, experience, and get in touch.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'AI Engineer',
+    'Full Stack Developer',
+    'React',
+    'Next.js',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI engineer and full-stack developer building production-grade systems.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: 'David Riva portfolio preview',
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI engineer and full-stack developer building production-grade systems.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +52,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={inter.variable} style={{ margin: 0 }}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,21 +2,20 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
+import HeroChat from '@/components/Greeting-Page/HeroChat';
+import NavBar from '@/components/Navbar/NavBar';
+import Footer from '@/components/Footer/Footer';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
-import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
-import NavBar from '@/components/Navbar/NavBar';
-import Footer from '@/components/Footer/Footer';
 
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#0c0c0e',
+        color: '#e8e6e3',
         position: 'relative',
         minHeight: '100vh',
       }}
@@ -26,29 +25,19 @@ const MainPage = () => {
       <Box
         sx={{
           position: 'relative',
-          height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          minHeight: '100vh',
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(212, 160, 83, 0.06) 0%, transparent 70%)',
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <Box
           id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(232, 230, 227, 0.06)',
           }}
         >
           <About />
@@ -57,10 +46,8 @@ const MainPage = () => {
         <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(232, 230, 227, 0.06)',
           }}
         >
           <Projects />
@@ -69,9 +56,8 @@ const MainPage = () => {
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
             width: '100%',
-            color: '#ffffff',
+            borderTop: '1px solid rgba(232, 230, 227, 0.06)',
           }}
         >
           <Contact />
@@ -82,4 +68,5 @@ const MainPage = () => {
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,69 @@
+'use client';
+
 import { Box } from '@mui/material';
 import HeadShotImage from './HeadshotImage';
 import AboutHeader from './AboutHeader';
 import AboutFooter from './AboutFooter';
 import Biography from './Biography';
 import SimpleTimeline from './SimpleTimeline';
-
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
-};
+import SectionHeading from '@/components/SectionHeading';
 
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
         px: { xs: 3, md: 6 },
       }}
     >
+      <SectionHeading sectionName="About" subtitle="A bit about me" />
+
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          gap: { xs: 4, md: 6 },
+          alignItems: 'flex-start',
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Left column: headshot + bio */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <Box sx={{ display: 'flex', gap: 4, alignItems: 'flex-start', flexDirection: { xs: 'column', sm: 'row' } }}>
+            <Box
+              sx={{
+                flexShrink: 0,
+                width: { xs: 120, sm: 160 },
+                height: { xs: 120, sm: 160 },
+                borderRadius: '20px',
+                overflow: 'hidden',
+                border: '1px solid rgba(232, 230, 227, 0.08)',
+              }}
+            >
+              <HeadShotImage width={160} height={160} />
+            </Box>
+
+            <Box>
+              <AboutHeader />
+              <Biography />
+            </Box>
+          </Box>
+
+          <AboutFooter />
         </Box>
-      </Box>
 
-      <AboutTextSection />
-
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
+        {/* Right column: timeline */}
+        <Box
+          sx={{
+            display: { xs: 'none', lg: 'block' },
+            flexShrink: 0,
+            width: 340,
+          }}
+        >
+          <SimpleTimeline />
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/About-Page/AboutFooter.js
+++ b/next-app/src/components/About-Page/AboutFooter.js
@@ -6,11 +6,10 @@ const AboutFooter = () => {
   return (
     <Box
       sx={{
-        marginTop: 4,
         display: 'flex',
-        justifyContent: 'flex-start',
+        alignItems: 'center',
         gap: 2,
-        flexDirection: { xs: 'column', sm: 'row', md: 'row' },
+        flexDirection: { xs: 'column', sm: 'row' },
       }}
     >
       <ResumeButton />

--- a/next-app/src/components/About-Page/AboutHeader.js
+++ b/next-app/src/components/About-Page/AboutHeader.js
@@ -1,25 +1,27 @@
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import ClickableLink from './ClickableLink';
 
 const AboutHeader = () => {
   return (
-    <>
+    <Box sx={{ mb: 1 }}>
       <Typography
-        variant="h1"
+        variant="h3"
         sx={{
-          fontWeight: 'bold',
-          marginBottom: 1,
-          fontSize: { xs: '1.75rem', sm: '2.5rem', md: '2.5rem' },
+          fontWeight: 600,
+          mb: 0.5,
+          fontSize: { xs: '1.3rem', md: '1.5rem' },
+          letterSpacing: '-0.015em',
         }}
       >
         David Riva
       </Typography>
 
       <Typography
-        variant="h5"
         sx={{
-          color: '#38c0f2',
-          marginBottom: 1,
+          color: '#d4a053',
+          fontSize: '0.9rem',
+          fontWeight: 500,
+          mb: 0.5,
         }}
       >
         Training Engineer, Generative AI
@@ -27,13 +29,14 @@ const AboutHeader = () => {
 
       <Typography
         sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          marginBottom: 2,
+          color: 'rgba(232, 230, 227, 0.4)',
+          fontSize: '0.85rem',
         }}
       >
-        Bay Area, CA. | <ClickableLink link="mailto:davidjriva@gmail.com" text="davidjriva@gmail.com" />
+        Bay Area, CA &middot;{' '}
+        <ClickableLink link="mailto:davidjriva@gmail.com" text="davidjriva@gmail.com" />
       </Typography>
-    </>
+    </Box>
   );
 };
 

--- a/next-app/src/components/About-Page/Biography.js
+++ b/next-app/src/components/About-Page/Biography.js
@@ -1,26 +1,16 @@
-import { Box, Typography } from '@mui/material';
-import ClickableLink from '@/components/About-Page/ClickableLink';
+import { Typography, Box } from '@mui/material';
 
 const Biography = () => {
   return (
-    <Box
-      sx={{
-        marginTop: 2,
-        maxWidth: '600px',
-        textAlign: 'left',
-      }}
-    >
-      <Typography variant="body1">
-        Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
-        University, where I received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m incredibly
-        passionate about software &amp; applied AI engineering.
+    <Box sx={{ mt: 2, maxWidth: '560px' }}>
+      <Typography variant="body1" sx={{ color: 'rgba(232, 230, 227, 0.65)', lineHeight: 1.75 }}>
+        I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State University where I
+        received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m passionate about applied AI
+        engineering and building production-grade systems.
       </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        I&apos;m experienced in full-stack development, data engineering, and big data visualization.
-      </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        I have a strong background in data structures, algorithms, and mathematical applications. I pride myself on
-        elegant problem-solving and my dedication to maintaining high standards of excellence.
+      <Typography variant="body1" sx={{ color: 'rgba(232, 230, 227, 0.65)', lineHeight: 1.75, mt: 2 }}>
+        My work spans full-stack development, AI orchestration, and data engineering. I take pride in elegant
+        problem-solving and maintaining high standards of code quality.
       </Typography>
     </Box>
   );

--- a/next-app/src/components/About-Page/ClickableLink.js
+++ b/next-app/src/components/About-Page/ClickableLink.js
@@ -5,10 +5,15 @@ const ClickableLink = ({ link, text }) => {
     <a
       href={link}
       target="_blank"
-      style={{ color: '#38c0f2', textDecoration: 'none' }}
-      onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
-      onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}
-      onClick={(e) => (e.currentTarget.style.color = '#0073e6')}
+      rel="noopener noreferrer"
+      style={{
+        color: '#d4a053',
+        textDecoration: 'none',
+        borderBottom: '1px solid transparent',
+        transition: 'border-color 0.2s ease',
+      }}
+      onMouseOver={(e) => (e.currentTarget.style.borderBottomColor = '#d4a053')}
+      onMouseOut={(e) => (e.currentTarget.style.borderBottomColor = 'transparent')}
     >
       {text}
     </a>

--- a/next-app/src/components/About-Page/HeadshotImage.js
+++ b/next-app/src/components/About-Page/HeadshotImage.js
@@ -2,23 +2,6 @@
 
 import { Box } from '@mui/material';
 import Image from 'next/image';
-import { keyframes } from '@emotion/react';
-
-const glowFrames = Array.from({ length: 51 }, (_, i) => {
-  const r = 240 - 2 * i;
-  const g = 240 - i;
-  const b = 250;
-  return `${i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const reverseGlowFrames = Array.from({ length: 50 }, (_, i) => {
-  const r = 140 + 2 * i;
-  const g = 190 + i;
-  const b = 250;
-  return `${51 + i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const glowAnimation = keyframes`${glowFrames}\n${reverseGlowFrames}`;
 
 const HeadShotImage = ({ width, height }) => {
   return (
@@ -28,8 +11,7 @@ const HeadShotImage = ({ width, height }) => {
         width,
         height,
         overflow: 'hidden',
-        borderRadius: '50%',
-        display: { xs: 'none', sm: 'block' },
+        borderRadius: '20px',
       }}
     >
       <Image
@@ -37,9 +19,7 @@ const HeadShotImage = ({ width, height }) => {
         src="/images/headshot.webp"
         width={width}
         height={height}
-        style={{
-          objectFit: 'cover',
-        }}
+        style={{ objectFit: 'cover' }}
         priority={true}
       />
     </Box>

--- a/next-app/src/components/About-Page/ResumeButton.js
+++ b/next-app/src/components/About-Page/ResumeButton.js
@@ -1,27 +1,31 @@
 'use client';
 
 import { Button } from '@mui/material';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 
 const ResumeButton = () => {
-  const handleResumeClick = () => {
-    window.open('/documents/resume.pdf', '_blank');
-  };
-
   return (
-    <Button 
-      variant="contained" 
-      onClick={handleResumeClick} 
-      sx={{ 
-        marginTop: '1rem', 
-        marginBottom: 2,
-        backgroundColor: '#1976d2',
-        color: 'white',
+    <Button
+      variant="outlined"
+      onClick={() => window.open('/documents/resume.pdf', '_blank')}
+      startIcon={<DescriptionOutlinedIcon sx={{ fontSize: '1rem !important' }} />}
+      sx={{
+        color: '#d4a053',
+        borderColor: 'rgba(212, 160, 83, 0.3)',
+        borderRadius: '10px',
+        textTransform: 'none',
+        fontSize: '0.85rem',
+        fontWeight: 500,
+        px: 2.5,
+        py: 0.75,
+        transition: 'all 0.25s ease',
         '&:hover': {
-          backgroundColor: '#1565c0',
+          borderColor: '#d4a053',
+          bgcolor: 'rgba(212, 160, 83, 0.06)',
         },
       }}
     >
-      View Resume as PDF
+      Resume
     </Button>
   );
 };

--- a/next-app/src/components/About-Page/SimpleTimeline.js
+++ b/next-app/src/components/About-Page/SimpleTimeline.js
@@ -1,99 +1,94 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import {
-  Timeline,
-  TimelineItem,
-  TimelineOppositeContent,
-  TimelineSeparator,
-  TimelineConnector,
-  TimelineDot,
-  TimelineContent,
-} from '@mui/lab';
+import { useEffect, useState } from 'react';
 import { Typography, Box } from '@mui/material';
 import Image from 'next/image';
 
-const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate, isEnd }) => {
+const TimelineEntry = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate, isLast }) => {
   const isCurrent = endDate === 'Present';
   const isGraduation = title.startsWith('Graduated');
 
   return (
-    <TimelineItem>
-      <TimelineOppositeContent sx={{ flex: 'none', width: 130, pr: 1.5, pt: '14px' }}>
+    <Box sx={{ display: 'flex', gap: 2, position: 'relative' }}>
+      {/* Connector line */}
+      {!isLast && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: 15,
+            top: 36,
+            bottom: -8,
+            width: '1px',
+            bgcolor: 'rgba(232, 230, 227, 0.06)',
+          }}
+        />
+      )}
+
+      {/* Logo dot */}
+      <Box
+        sx={{
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          bgcolor: '#fff',
+          border: isCurrent ? '1.5px solid rgba(212, 160, 83, 0.5)' : '1px solid rgba(232, 230, 227, 0.12)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          boxShadow: isCurrent ? '0 0 12px rgba(212, 160, 83, 0.15)' : 'none',
+        }}
+      >
+        <Image
+          src={`/images/${logoImage}`}
+          alt={`${company} logo`}
+          width={18}
+          height={18}
+          style={{ display: 'block', objectFit: 'contain' }}
+        />
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ pb: 3 }}>
         <Typography
-          variant="caption"
           sx={{
-            color: isCurrent ? '#38c0f2' : 'rgba(255,255,255,0.45)',
-            fontWeight: isCurrent ? 600 : 400,
-            lineHeight: 1.4,
-            display: 'block',
+            fontWeight: 500,
+            fontSize: '0.82rem',
+            lineHeight: 1.35,
+            color: '#e8e6e3',
+            mb: 0.25,
           }}
         >
-          {isGraduation ? startDate : `${startDate} –\u00a0${isCurrent ? 'Present' : endDate}`}
+          {isGraduation ? 'Graduated' : title.split(',')[0]}
         </Typography>
-      </TimelineOppositeContent>
-
-      <TimelineSeparator>
-        <TimelineDot
+        <Typography
+          component="a"
+          href={companyWebsiteLink}
+          target="_blank"
+          rel="noopener noreferrer"
           sx={{
-            backgroundColor: '#ffffff',
-            border: isCurrent
-              ? '1.5px solid rgba(56,192,242,0.6)'
-              : '1.5px solid rgba(255,255,255,0.2)',
-            boxShadow: isCurrent ? '0 0 10px 2px rgba(56,192,242,0.25)' : 'none',
-            p: '5px',
-            m: '6px 0',
+            color: '#d4a053',
+            textDecoration: 'none',
+            fontSize: '0.72rem',
+            fontWeight: 500,
+            display: 'block',
+            mb: 0.25,
+            '&:hover': { textDecoration: 'underline' },
           }}
         >
-          <Image
-            src={`/images/${logoImage}`}
-            alt={`${company} logo`}
-            width={20}
-            height={20}
-            style={{ display: 'block', objectFit: 'contain' }}
-          />
-        </TimelineDot>
-        {!isEnd && (
-          <TimelineConnector
-            sx={{
-              background: 'linear-gradient(to bottom, rgba(56,192,242,0.25), rgba(110,64,201,0.15))',
-              width: '1.5px',
-            }}
-          />
-        )}
-      </TimelineSeparator>
-
-      <TimelineContent sx={{ pl: 1.5, pt: '10px', pb: '16px' }}>
-        <Box>
-          <Typography
-            variant="body2"
-            sx={{
-              fontWeight: 600,
-              fontSize: '0.8rem',
-              lineHeight: 1.35,
-              color: '#ffffff',
-              mb: 0.25,
-            }}
-          >
-            {isGraduation ? 'Graduated' : title.split(',')[0]}
-          </Typography>
-          <Typography
-            component="a"
-            href={companyWebsiteLink}
-            target="_blank"
-            variant="caption"
-            sx={{
-              color: '#38c0f2',
-              textDecoration: 'none',
-              fontSize: '0.72rem',
-              '&:hover': { textDecoration: 'underline' },
-            }}
-          >
-            {company}
-          </Typography>
-        </Box>
-      </TimelineContent>
-    </TimelineItem>
+          {company}
+        </Typography>
+        <Typography
+          sx={{
+            color: isCurrent ? 'rgba(212, 160, 83, 0.7)' : 'rgba(232, 230, 227, 0.3)',
+            fontSize: '0.68rem',
+            fontWeight: isCurrent ? 500 : 400,
+          }}
+        >
+          {isGraduation ? startDate : `${startDate} – ${isCurrent ? 'Present' : endDate}`}
+        </Typography>
+      </Box>
+    </Box>
   );
 };
 
@@ -106,46 +101,33 @@ const SimpleTimeline = () => {
       .then((data) => setExperienceData(data));
   }, []);
 
-  const sortedExperienceData = [...experienceData].sort((a, b) => {
-    return new Date(b.startDate) - new Date(a.startDate);
-  });
+  const sorted = [...experienceData].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
 
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        background: 'rgba(255,255,255,0.03)',
-        border: '1px solid rgba(255,255,255,0.08)',
+        bgcolor: 'rgba(232, 230, 227, 0.02)',
+        border: '1px solid rgba(232, 230, 227, 0.06)',
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        px: 1,
-        py: 2,
+        p: 3,
       }}
     >
       <Typography
-        variant="overline"
         sx={{
-          color: 'rgba(255,255,255,0.55)',
-          fontSize: '0.85rem',
-          letterSpacing: '0.18em',
+          color: 'rgba(232, 230, 227, 0.4)',
+          fontSize: '0.7rem',
           fontWeight: 600,
-          mb: 0.5,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          mb: 2.5,
         }}
       >
         Experience
       </Typography>
-      <Timeline sx={{ maxWidth: '22vw', p: 0, m: 0 }}>
-        {sortedExperienceData.map((experience, index) => (
-          <React.Fragment key={experience.title}>
-            <SimpleTimelineItem
-              {...experience}
-              isEnd={index === sortedExperienceData.length - 1}
-            />
-          </React.Fragment>
-        ))}
-      </Timeline>
+
+      {sorted.map((exp, index) => (
+        <TimelineEntry key={exp.title} {...exp} isLast={index === sorted.length - 1} />
+      ))}
     </Box>
   );
 };

--- a/next-app/src/components/About-Page/SocialLinks.js
+++ b/next-app/src/components/About-Page/SocialLinks.js
@@ -1,54 +1,29 @@
 'use client';
 
-import React, { useState } from 'react';
 import { Box, IconButton, Link } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
-const SocialLinks = () => {
-  const [hasGitHubIconBeenClicked, setHasGitHubIconBeenClicked] = useState(false);
-  const [hasLinkedInIconBeenClicked, setHasLinkedInIconBeenClicked] = useState(false);
+const iconSx = {
+  color: 'rgba(232, 230, 227, 0.35)',
+  fontSize: '1.25rem',
+  p: 1,
+  '&:hover': {
+    color: '#e8e6e3',
+    bgcolor: 'rgba(232, 230, 227, 0.06)',
+  },
+};
 
+const SocialLinks = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
       <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
-        <IconButton
-          aria-label="GitHub Profile"
-          sx={{
-            color: hasGitHubIconBeenClicked ? '#9974cf' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#a28be5',
-            },
-            '&:active': {
-              color: '#9974cf',
-            },
-          }}
-          onClick={() => setHasGitHubIconBeenClicked(true)}
-        >
+        <IconButton aria-label="GitHub Profile" sx={iconSx}>
           <GitHubIcon fontSize="inherit" />
         </IconButton>
       </Link>
       <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
-        <IconButton
-          aria-label="LinkedIn Profile"
-          sx={{
-            color: hasLinkedInIconBeenClicked ? '#07a2f7' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#4abfff',
-            },
-            '&:active': {
-              color: '#07a2f7',
-            },
-          }}
-          onClick={() => setHasLinkedInIconBeenClicked(true)}
-        >
+        <IconButton aria-label="LinkedIn Profile" sx={iconSx}>
           <LinkedInIcon fontSize="inherit" />
         </IconButton>
       </Link>

--- a/next-app/src/components/Chat-Page/BouncingDotsLoadingAnimation.jsx
+++ b/next-app/src/components/Chat-Page/BouncingDotsLoadingAnimation.jsx
@@ -1,21 +1,13 @@
-import React from 'react';
 import { Box } from '@mui/material';
 
-const BouncingDotsLoadingAnimation = ({
-  dotSize = 4,
-  dotColor = '#a3a1a1',
-  spacing = 4,
-  animationDuration = 0.6,
-  jumpHeight = 4,
-}) => {
+const BouncingDotsLoadingAnimation = ({ dotSize = 4, dotColor = '#d4a053', spacing = 4 }) => {
   const dotStyle = (delay) => ({
     width: dotSize,
     height: dotSize,
     margin: `2px ${spacing}px`,
     borderRadius: '50%',
     backgroundColor: dotColor,
-    opacity: 1,
-    animation: `bouncing-loader ${animationDuration}s infinite alternate`,
+    animation: `bouncing-loader 0.6s infinite alternate`,
     animationDelay: `${delay}s`,
   });
 
@@ -24,16 +16,10 @@ const BouncingDotsLoadingAnimation = ({
       <Box sx={dotStyle(0)} />
       <Box sx={dotStyle(0.2)} />
       <Box sx={dotStyle(0.4)} />
-
       <style>
-        {`
-          @keyframes bouncing-loader {
-            to {
-              opacity: 0.1;
-              transform: translateY(-${jumpHeight}px);
-            }
-          }
-        `}
+        {`@keyframes bouncing-loader {
+          to { opacity: 0.15; transform: translateY(-4px); }
+        }`}
       </style>
     </Box>
   );

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -12,14 +12,14 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
-        borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        p: '6px 6px 6px 16px',
+        borderRadius: '14px',
+        backgroundColor: 'rgba(232, 230, 227, 0.03)',
+        border: '1px solid rgba(232, 230, 227, 0.08)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.25s ease',
+        '&:hover': { borderColor: 'rgba(232, 230, 227, 0.14)' },
+        '&:focus-within': { borderColor: 'rgba(212, 160, 83, 0.4)' },
       }}
     >
       <InputBase
@@ -34,24 +34,27 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#e8e6e3',
+          fontSize: '0.9rem',
+          fontFamily: 'var(--font-inter), sans-serif',
+          '& input::placeholder': { color: 'rgba(232, 230, 227, 0.25)', opacity: 1 },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          bgcolor: '#d4a053',
           ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&:hover': { bgcolor: '#e8c07a' },
+          '&.Mui-disabled': { bgcolor: 'rgba(232, 230, 227, 0.05)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <ArrowUpwardIcon sx={{ color: '#0c0c0e', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,59 +7,57 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-inter), sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#e8e6e3',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
           px: 2.5,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          bgcolor: isUser ? 'rgba(212, 160, 83, 0.08)' : 'rgba(232, 230, 227, 0.03)',
+          border: isUser ? '1px solid rgba(212, 160, 83, 0.15)' : '1px solid rgba(232, 230, 227, 0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={7} dotColor="#d4a053" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
+                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 600, color: '#e8e6e3' }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
-                      display: 'inline',
+                      color: '#d4a053',
+                      backgroundColor: 'rgba(212, 160, 83, 0.06)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
+                      fontSize: '0.85em',
                     }}
                     {...props}
                   />
@@ -67,18 +65,32 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      bgcolor: 'rgba(0,0,0,0.3)',
+                      color: '#e8e6e3',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.85rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{ color: '#d4a053', textDecoration: 'none', borderBottom: '1px solid rgba(212, 160, 83, 0.3)' }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#e8e6e3' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,5 +1,7 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography, Link, IconButton } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
 
@@ -7,32 +9,82 @@ const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+        px: { xs: 3, md: 6 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      <SectionHeading sectionName="Contact" subtitle="Let's connect" />
 
       <Box
         sx={{
           display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          flexDirection: { xs: 'column', md: 'row' },
+          gap: { xs: 4, md: 8 },
+          alignItems: 'flex-start',
         }}
       >
-        <ContactForm />
+        {/* Left — info */}
+        <Box sx={{ flex: 1, maxWidth: { md: 360 } }}>
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'rgba(232, 230, 227, 0.55)',
+              lineHeight: 1.75,
+              mb: 3,
+            }}
+          >
+            I&apos;m always open to discussing new opportunities, interesting projects, or just connecting. Feel free
+            to reach out.
+          </Typography>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+            <EmailOutlinedIcon sx={{ color: '#d4a053', fontSize: '1.1rem' }} />
+            <Link
+              href="mailto:davidjriva@gmail.com"
+              sx={{
+                color: '#e8e6e3',
+                textDecoration: 'none',
+                fontSize: '0.9rem',
+                '&:hover': { color: '#d4a053' },
+              }}
+            >
+              davidjriva@gmail.com
+            </Link>
+          </Box>
+
+          <Box sx={{ display: 'flex', gap: 0.5, mt: 2 }}>
+            <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="GitHub"
+                sx={{
+                  color: 'rgba(232, 230, 227, 0.35)',
+                  '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(232, 230, 227, 0.06)' },
+                }}
+              >
+                <GitHubIcon fontSize="small" />
+              </IconButton>
+            </Link>
+            <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="LinkedIn"
+                sx={{
+                  color: 'rgba(232, 230, 227, 0.35)',
+                  '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(232, 230, 227, 0.06)' },
+                }}
+              >
+                <LinkedInIcon fontSize="small" />
+              </IconButton>
+            </Link>
+          </Box>
+        </Box>
+
+        {/* Right — form */}
+        <Box sx={{ flex: 1, width: '100%' }}>
+          <ContactForm />
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -5,14 +5,16 @@ import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': { color: 'rgba(232, 230, 227, 0.35)', fontSize: '0.9rem' },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#e8e6e3',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(232, 230, 227, 0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(232, 230, 227, 0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(232, 230, 227, 0.15)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(212, 160, 83, 0.5)' },
   },
 };
 
@@ -49,21 +51,55 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        maxWidth: '600px',
+        bgcolor: 'rgba(232, 230, 227, 0.02)',
+        border: '1px solid rgba(232, 230, 227, 0.06)',
+        p: { xs: 3, md: 4 },
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+          <TextField
+            fullWidth
+            label="Name"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
+        <TextField
+          fullWidth
+          label="Subject"
+          name="subject"
+          value={formData.subject}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +114,23 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          fullWidth
           sx={{
-            width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            bgcolor: '#d4a053',
+            color: '#0c0c0e',
+            borderRadius: '12px',
+            textTransform: 'none',
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            py: 1.25,
+            boxShadow: 'none',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              bgcolor: '#e8c07a',
+              boxShadow: 'none',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              bgcolor: 'rgba(232, 230, 227, 0.06)',
+              color: 'rgba(232, 230, 227, 0.2)',
             },
           }}
         >
@@ -103,9 +142,10 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            color: status.includes('success') ? '#6ec87a' : '#e07070',
+            fontSize: '0.85rem',
           }}
         >
           {status}

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -7,32 +7,26 @@ const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        borderTop: '1px solid rgba(232, 230, 227, 0.06)',
+        color: 'rgba(232, 230, 227, 0.25)',
         width: '100%',
-        height: '10vh',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        py: 4,
+        gap: 2,
       }}
     >
       <ReturnToTopButton />
       <Typography
         variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
+          color: 'rgba(232, 230, 227, 0.2)',
           textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          fontSize: '0.8rem',
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Footer/ReturnToTopButton.js
+++ b/next-app/src/components/Footer/ReturnToTopButton.js
@@ -2,13 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { IconButton, Box } from '@mui/material';
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const ReturnToTopButton = () => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 200);
+    const onScroll = () => setVisible(window.scrollY > 300);
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
@@ -20,25 +20,25 @@ const ReturnToTopButton = () => {
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#38c0f2',
-        borderRadius: '8px',
-        padding: '4px',
-        maxWidth: '50px',
-        margin: '0 auto',
-        '@keyframes jump': {
-          '0%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-5px)' },
-          '100%': { transform: 'translateY(0)' },
-        },
-        '&:hover': { animation: 'jump 1s infinite' },
       }}
     >
       <IconButton
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        sx={{ color: 'white', fontSize: '1.5rem', padding: '4px' }}
+        sx={{
+          width: 36,
+          height: 36,
+          borderRadius: '10px',
+          border: '1px solid rgba(232, 230, 227, 0.1)',
+          color: 'rgba(232, 230, 227, 0.35)',
+          transition: 'all 0.25s ease',
+          '&:hover': {
+            borderColor: 'rgba(232, 230, 227, 0.2)',
+            color: '#e8e6e3',
+            bgcolor: 'rgba(232, 230, 227, 0.04)',
+          },
+        }}
       >
-        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 'inherit' }} />
+        <KeyboardArrowUpIcon fontSize="small" />
       </IconButton>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -3,81 +3,65 @@
 import { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
-  const getArticle = (role) => {
-    const vowels = ['a', 'e', 'i', 'o', 'u'];
-    return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
-  };
-
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = ROLES[roleIndex];
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
-      timer = setTimeout(() => {
-        setText((prev) => prev + currentRole[index]);
-        setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev + currentRole[index]);
+          setIndex((prev) => prev + 1);
+        },
+        80 + Math.random() * 40
+      );
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 2000);
     } else if (deleting && index > 0) {
-      // Deleting logic
-      timer = setTimeout(() => {
-        setText((prev) => prev.slice(0, -1));
-        setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev.slice(0, -1));
+          setIndex((prev) => prev - 1);
+        },
+        35 + Math.random() * 20
+      );
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
+    const blinkCursor = setInterval(() => setCursorVisible((prev) => !prev), 500);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.35rem', md: '1.5rem' },
+        fontWeight: 400,
+        color: 'rgba(232, 230, 227, 0.5)',
+        fontFamily: 'var(--font-inter), sans-serif',
+        letterSpacing: '-0.01em',
+        minHeight: '2em',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {text}
+      <span style={{ color: '#d4a053', opacity: cursorVisible ? 1 : 0, transition: 'opacity 0.1s' }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import { Box, Typography, Chip, Stack, IconButton, Link } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -40,33 +43,9 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?', variant: 'accent' },
+  { label: 'Tell me about your experience', variant: 'muted' },
+  { label: 'Featured projects', variant: 'muted' },
 ];
 
 const HeroChat = () => {
@@ -89,140 +68,257 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', minHeight: '100vh', color: '#e8e6e3', zIndex: 1 }}>
+      {/* Pre-chat hero */}
       <Box
         sx={{
           position: 'absolute',
           inset: 0,
           display: 'flex',
-          flexDirection: 'column',
+          flexDirection: { xs: 'column', md: 'row' },
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
-          px: 3,
+          gap: { xs: 4, md: 8 },
+          px: { xs: 3, md: 6, lg: 10 },
+          maxWidth: '1400px',
+          mx: 'auto',
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease-out, transform 400ms ease-out',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
-        <Typography
-          variant="h1"
+        {/* Left side — identity */}
+        <Box
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
-            textAlign: 'center',
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: { xs: 'center', md: 'flex-start' },
+            textAlign: { xs: 'center', md: 'left' },
+            maxWidth: 560,
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
-        </Typography>
-
-        <AnimatedTypingTypography />
-
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
-          <ChatInput
-            input={input}
-            setInput={setInput}
-            sendMessage={handleSend}
-            disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
-          />
-        </Box>
-
-        {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
-            Verification failed — chat is temporarily unavailable.
-          </Typography>
-        )}
-
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
-          {CHIPS.map((chip) => (
-            <Chip
-              key={chip.label}
-              label={chip.label}
-              disabled={!hasToken}
-              onClick={() => {
-                const cached = CHIP_CACHE[chip.label];
-                if (cached) addCachedExchange(chip.label, cached);
-                else sendMessage(chip.label);
-                setInput('');
-              }}
-              sx={{
-                height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
-                },
-                '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
-                },
-                '&.Mui-disabled': { opacity: 0.4 },
-              }}
-            />
-          ))}
-        </Stack>
-
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
-        {!hasToken && !turnstileError && (
-          <Box
+          <Typography
+            variant="caption"
             sx={{
-              visibility: needsChallenge ? 'visible' : 'hidden',
-              height: needsChallenge ? 'auto' : 0,
-              overflow: 'hidden',
-              display: 'flex',
-              justifyContent: 'center',
+              color: '#d4a053',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.15em',
+              mb: 2,
             }}
           >
-            <Turnstile
-              siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
-              onError={() => setTurnstileError(true)}
-              onBeforeInteractive={() => setNeedsChallenge(true)}
-              options={{ appearance: 'interaction-only' }}
-            />
-          </Box>
-        )}
+            SOFTWARE ENGINEER
+          </Typography>
 
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: { xs: 'clamp(2.5rem, 7vw, 3.5rem)', md: '3.75rem' },
+              fontWeight: 700,
+              lineHeight: 1.05,
+              letterSpacing: '-0.035em',
+              mb: 1.5,
+            }}
+          >
+            David Riva
+          </Typography>
+
+          <AnimatedTypingTypography />
+
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ mt: 3, alignItems: 'center' }}
+          >
+            <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="GitHub Profile"
+                sx={{
+                  color: 'rgba(232, 230, 227, 0.35)',
+                  '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(232, 230, 227, 0.06)' },
+                }}
+              >
+                <GitHubIcon fontSize="small" />
+              </IconButton>
+            </Link>
+            <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="LinkedIn Profile"
+                sx={{
+                  color: 'rgba(232, 230, 227, 0.35)',
+                  '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(232, 230, 227, 0.06)' },
+                }}
+              >
+                <LinkedInIcon fontSize="small" />
+              </IconButton>
+            </Link>
+            <IconButton
+              aria-label="Resume"
+              onClick={() => window.open('/documents/resume.pdf', '_blank')}
+              sx={{
+                color: 'rgba(232, 230, 227, 0.35)',
+                '&:hover': { color: '#e8e6e3', bgcolor: 'rgba(232, 230, 227, 0.06)' },
+              }}
+            >
+              <DescriptionOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+        </Box>
+
+        {/* Right side — chat interface */}
         <Box
-          component="button"
-          onClick={scrollToAbout}
           sx={{
-            position: 'absolute',
-            bottom: 32,
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
-            background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
-            cursor: 'pointer',
-            transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            flex: 1,
+            maxWidth: 520,
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          <Box
+            sx={{
+              bgcolor: 'rgba(232, 230, 227, 0.02)',
+              border: '1px solid rgba(232, 230, 227, 0.06)',
+              borderRadius: '16px',
+              p: 3,
+              backdropFilter: 'blur(16px)',
+            }}
+          >
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 500,
+                color: 'rgba(232, 230, 227, 0.35)',
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                mb: 2,
+              }}
+            >
+              Ask my AI agent anything
+            </Typography>
+
+            <ChatInput
+              input={input}
+              setInput={setInput}
+              sendMessage={handleSend}
+              disabled={!hasToken}
+              placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask about my work...'}
+            />
+
+            {turnstileError && (
+              <Typography
+                variant="body2"
+                sx={{ color: 'rgba(220, 100, 100, 0.8)', mt: 1.5, fontSize: '0.8rem' }}
+              >
+                Verification failed — chat is temporarily unavailable.
+              </Typography>
+            )}
+
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 2.5 }}>
+              {CHIPS.map((chip) => (
+                <Chip
+                  key={chip.label}
+                  label={chip.label}
+                  disabled={!hasToken}
+                  onClick={() => {
+                    const cached = CHIP_CACHE[chip.label];
+                    if (cached) addCachedExchange(chip.label, cached);
+                    else sendMessage(chip.label);
+                    setInput('');
+                  }}
+                  sx={{
+                    height: 'auto',
+                    bgcolor: chip.variant === 'accent' ? 'rgba(212, 160, 83, 0.08)' : 'rgba(232, 230, 227, 0.04)',
+                    border:
+                      chip.variant === 'accent'
+                        ? '1px solid rgba(212, 160, 83, 0.2)'
+                        : '1px solid rgba(232, 230, 227, 0.08)',
+                    borderRadius: '100px',
+                    cursor: 'pointer',
+                    transition: 'all 0.25s ease',
+                    '& .MuiChip-label': {
+                      color:
+                        chip.variant === 'accent' ? '#d4a053' : 'rgba(232, 230, 227, 0.55)',
+                      fontFamily: 'var(--font-inter), sans-serif',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                      px: 1.5,
+                      py: 0.75,
+                    },
+                    '&:hover': {
+                      bgcolor:
+                        chip.variant === 'accent' ? 'rgba(212, 160, 83, 0.14)' : 'rgba(232, 230, 227, 0.08)',
+                      borderColor:
+                        chip.variant === 'accent' ? 'rgba(212, 160, 83, 0.4)' : 'rgba(232, 230, 227, 0.15)',
+                    },
+                    '&.Mui-disabled': { opacity: 0.3 },
+                  }}
+                />
+              ))}
+            </Stack>
+          </Box>
+
+          {!hasToken && !turnstileError && (
+            <Box
+              sx={{
+                visibility: needsChallenge ? 'visible' : 'hidden',
+                height: needsChallenge ? 'auto' : 0,
+                overflow: 'hidden',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              <Turnstile
+                siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
+                onSuccess={(captchaToken) => {
+                  fetchToken(captchaToken);
+                  setNeedsChallenge(false);
+                }}
+                onError={() => setTurnstileError(true)}
+                onBeforeInteractive={() => setNeedsChallenge(true)}
+                options={{ appearance: 'interaction-only' }}
+              />
+            </Box>
+          )}
         </Box>
+      </Box>
+
+      {/* Scroll indicator */}
+      <Box
+        component="button"
+        onClick={scrollToAbout}
+        sx={{
+          position: 'absolute',
+          bottom: 32,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          display: started ? 'none' : 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 40,
+          height: 40,
+          borderRadius: '50%',
+          background: 'transparent',
+          border: '1px solid rgba(232, 230, 227, 0.12)',
+          color: 'rgba(232, 230, 227, 0.35)',
+          cursor: 'pointer',
+          transition: 'all 0.3s ease',
+          zIndex: 2,
+          '@keyframes float': {
+            '0%, 100%': { transform: 'translateX(-50%) translateY(0)' },
+            '50%': { transform: 'translateX(-50%) translateY(4px)' },
+          },
+          animation: 'float 2.5s ease-in-out infinite',
+          '&:hover': {
+            borderColor: 'rgba(232, 230, 227, 0.3)',
+            color: '#e8e6e3',
+          },
+        }}
+      >
+        <KeyboardArrowDownIcon fontSize="small" />
       </Box>
 
       {/* Chat-active view */}
@@ -233,75 +329,87 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease-out 120ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
             display: 'flex',
             alignItems: 'center',
             gap: 1.5,
-            px: 3,
+            px: { xs: 2, md: 4 },
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(232, 230, 227, 0.06)',
+            mt: '56px',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #d4a053, #b8863a)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
-              color: '#fff',
+              fontWeight: 700,
+              fontSize: '0.75rem',
+              color: '#0c0c0e',
               flexShrink: 0,
             }}
           >
-            D
+            DR
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', lineHeight: 1.2, color: '#e8e6e3' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
-              Knows David&apos;s experience, projects &amp; skills
+            <Typography sx={{ fontSize: '0.7rem', color: 'rgba(232, 230, 227, 0.3)', lineHeight: 1.2 }}>
+              Knows my experience, projects & skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography
+            component="button"
+            onClick={scrollToAbout}
+            sx={{
+              fontSize: '0.7rem',
+              color: 'rgba(232, 230, 227, 0.3)',
+              cursor: 'pointer',
+              background: 'none',
+              border: 'none',
+              fontFamily: 'var(--font-inter), sans-serif',
+              '&:hover': { color: '#d4a053' },
+            }}
+          >
+            scroll to portfolio ↓
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
-        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: { xs: 1, md: 2 }, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
-            px: 3,
+            px: { xs: 2, md: 4 },
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(232, 230, 227, 0.06)',
+            bgcolor: 'rgba(12, 12, 14, 0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
-          <ChatInput
-            input={input}
-            setInput={setInput}
-            sendMessage={handleSend}
-            disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
-          />
+          <Box sx={{ maxWidth: 700, mx: 'auto' }}>
+            <ChatInput
+              input={input}
+              setInput={setInput}
+              sendMessage={handleSend}
+              disabled={!hasToken}
+              placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
+            />
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -3,42 +3,41 @@
 import { Link as ScrollLink } from 'react-scroll';
 import { Toolbar, Box, AppBar, Typography } from '@mui/material';
 import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const NAV_ITEMS = ['About', 'Projects', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+const NavLink = ({ page, active, setActivePage }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-70}
+    duration={500}
+    onSetActive={() => setActivePage(page)}
+    style={{ cursor: 'pointer', textDecoration: 'none' }}
+  >
+    <Box
+      sx={{
+        px: 2,
+        py: 0.75,
+        borderRadius: '100px',
+        fontSize: '0.85rem',
+        fontWeight: active ? 600 : 400,
+        fontFamily: 'var(--font-inter), sans-serif',
+        color: active ? '#e8e6e3' : 'rgba(232, 230, 227, 0.4)',
+        bgcolor: active ? 'rgba(232, 230, 227, 0.06)' : 'transparent',
+        transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        letterSpacing: '0.02em',
+        '&:hover': {
+          color: '#e8e6e3',
+          bgcolor: 'rgba(232, 230, 227, 0.04)',
+        },
       }}
     >
       {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+    </Box>
+  </ScrollLink>
+);
 
 const NavBar = () => {
   const [activePage, setActivePage] = useState('About');
@@ -50,39 +49,63 @@ const NavBar = () => {
         top: 0,
         zIndex: 1100,
         width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
+        bgcolor: 'rgba(12, 12, 14, 0.8)',
+        backdropFilter: 'blur(20px) saturate(1.2)',
+        height: '56px',
+        color: '#e8e6e3',
+        borderBottom: '1px solid rgba(232, 230, 227, 0.06)',
         boxShadow: 'none',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: { xs: 2, md: 4, lg: 6 },
+          minHeight: '56px !important',
+          maxWidth: '1400px',
+          width: '100%',
+          mx: 'auto',
+        }}
+      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 0.5 }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
+          <Box
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              width: 28,
+              height: 28,
+              borderRadius: '8px',
+              background: 'linear-gradient(135deg, #d4a053, #b8863a)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontWeight: 700,
+              fontSize: '0.8rem',
+              color: '#0c0c0e',
+              mr: 1,
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            DR
+          </Box>
+          <Typography
+            sx={{
+              fontWeight: 600,
+              fontFamily: 'var(--font-inter), sans-serif',
+              fontSize: '0.95rem',
+              color: '#e8e6e3',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            david riva
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 0.5 }}>
+          {NAV_ITEMS.map((page) => (
+            <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
           ))}
         </Box>
       </Toolbar>

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -4,23 +4,23 @@ import Image from 'next/image';
 import { forwardRef } from 'react';
 import CardContent from '@mui/material/CardContent';
 import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
-import LaunchIcon from '@mui/icons-material/Launch';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const ProjectImage = ({ coverImage, title, featured }) => {
   return (
     <Box
       sx={{
         position: 'relative',
-        height: featured ? '220px' : '180px',
+        height: featured ? '200px' : '170px',
         width: '100%',
-        bgcolor: 'background.paper',
+        bgcolor: 'rgba(232, 230, 227, 0.02)',
         overflow: 'hidden',
       }}
     >
       <Image
         src={`/images/${coverImage}`}
         alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+        style={{ objectFit: 'cover', transition: 'transform 0.6s cubic-bezier(0.16, 1, 0.3, 1)' }}
         className="project-image"
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -29,102 +29,17 @@ const ProjectImage = ({ coverImage, title, featured }) => {
         sx={{
           position: 'absolute',
           inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
+          background: 'linear-gradient(to bottom, transparent 30%, rgba(12, 12, 14, 0.85) 100%)',
         }}
       />
     </Box>
   );
 };
 
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
@@ -133,37 +48,123 @@ const ProjectCard = forwardRef(
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(232, 230, 227, 0.02)',
+          color: '#e8e6e3',
+          border: featured
+            ? '1px solid rgba(212, 160, 83, 0.12)'
+            : '1px solid rgba(232, 230, 227, 0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+          transition: 'all 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
           cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            border: featured
+              ? '1px solid rgba(212, 160, 83, 0.25)'
+              : '1px solid rgba(232, 230, 227, 0.12)',
+            boxShadow: '0 16px 48px rgba(0, 0, 0, 0.2)',
+            '& .project-image': { transform: 'scale(1.04)' },
           },
         }}
         onClick={onClick}
       >
         <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
-          />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 2.5 }}>
+          <Box sx={{ mb: 2 }}>
+            <Typography
+              sx={{
+                fontWeight: 600,
+                mb: 0.5,
+                color: '#e8e6e3',
+                lineHeight: 1.3,
+                fontSize: featured ? '0.95rem' : '0.88rem',
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              sx={{
+                color: 'rgba(232, 230, 227, 0.25)',
+                fontSize: '0.72rem',
+                fontWeight: 500,
+                letterSpacing: '0.02em',
+                mb: 1.5,
+              }}
+            >
+              {dateStarted} – {dateCompleted}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'rgba(232, 230, 227, 0.45)',
+                lineHeight: 1.6,
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                fontSize: '0.82rem',
+              }}
+            >
+              {short_description}
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
+            {allTools.slice(0, 6).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(232, 230, 227, 0.04)',
+                  color: 'rgba(232, 230, 227, 0.5)',
+                  border: '1px solid rgba(232, 230, 227, 0.06)',
+                  fontSize: '0.68rem',
+                  fontWeight: 500,
+                  height: '22px',
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 6 && (
+              <Chip
+                label={`+${allTools.length - 6}`}
+                size="small"
+                sx={{
+                  bgcolor: 'transparent',
+                  color: 'rgba(232, 230, 227, 0.3)',
+                  fontSize: '0.68rem',
+                  fontWeight: 500,
+                  height: '22px',
+                  '& .MuiChip-label': { px: 0.5 },
+                }}
+              />
+            )}
+          </Stack>
+
+          <Button
+            variant="text"
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={<ArrowOutwardIcon sx={{ fontSize: '0.85rem !important' }} />}
+            sx={{
+              mt: 'auto',
+              color: '#d4a053',
+              textTransform: 'none',
+              fontSize: '0.8rem',
+              fontWeight: 500,
+              px: 0,
+              justifyContent: 'flex-start',
+              '&:hover': {
+                bgcolor: 'transparent',
+                opacity: 0.8,
+              },
+            }}
+          >
+            View Project
+          </Button>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,18 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+        px: { xs: 3, md: 6 },
       }}
     >
-      <SectionHeading sectionName="Projects" />
-
+      <SectionHeading sectionName="Projects" subtitle="Selected work" />
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,14 +18,14 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
+        duration: 0.7,
+        stagger: 0.1,
         ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
       }
     );
     ScrollTrigger.refresh();
@@ -52,11 +52,7 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.5, stagger: 0.06, ease: 'power2.out' });
   }, [projects]);
 
   return (
@@ -92,45 +88,50 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
         <Grid container spacing={3}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: 'rgba(232, 230, 227, 0.02)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(232, 230, 227, 0.06)',
+                }}
+              >
+                <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px' }} />
+                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.25rem' }} />
                 <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+                <Skeleton variant="text" sx={{ mt: 1 }} height={50} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <Box sx={{ mt: 5, textAlign: 'center' }}>
             <Button
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
+                color: 'rgba(232, 230, 227, 0.45)',
+                borderColor: 'rgba(232, 230, 227, 0.1)',
                 border: '1px solid',
-                borderRadius: '50px',
+                borderRadius: '100px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.82rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
                 transition: 'all 0.25s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(232, 230, 227, 0.04)',
+                  borderColor: 'rgba(232, 230, 227, 0.2)',
+                  color: '#e8e6e3',
                 },
               }}
             >
@@ -143,7 +144,7 @@ const ProjectsContainer = () => {
               <AllProjects projects={otherProjects} />
             </Box>
           </Collapse>
-        </Box>
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,41 +1,35 @@
 import { Box, Typography } from '@mui/material';
 
-const SectionHeading = ({ sectionName }) => {
+const SectionHeading = ({ sectionName, subtitle }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: 6 }}>
       <Typography
-        variant="h2"
+        variant="caption"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          color: '#d4a053',
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          letterSpacing: '0.12em',
+          mb: 1.5,
+          display: 'block',
         }}
       >
-        {sectionName}
+        {sectionName.toUpperCase()}
       </Typography>
+      {subtitle && (
+        <Typography
+          variant="h2"
+          sx={{
+            fontWeight: 700,
+            color: '#e8e6e3',
+            fontSize: { xs: '2rem', md: '2.75rem' },
+            letterSpacing: '-0.025em',
+            lineHeight: 1.12,
+          }}
+        >
+          {subtitle}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,36 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#0c0c0e',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#e8e6e3',
+      secondary: 'rgba(232, 230, 227, 0.5)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#d4a053',
+      light: '#e8c07a',
+      dark: '#b8863a',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#7b8794',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), "Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+    h1: { fontWeight: 700, fontSize: '3.5rem', letterSpacing: '-0.03em', lineHeight: 1.08 },
+    h2: { fontWeight: 700, fontSize: '2.75rem', letterSpacing: '-0.025em', lineHeight: 1.12 },
+    h3: { fontWeight: 600, fontSize: '1.5rem', letterSpacing: '-0.015em', lineHeight: 1.25 },
+    h4: { fontWeight: 600, fontSize: '1.25rem', letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600, fontSize: '1.1rem' },
+    h6: { fontWeight: 600, fontSize: '0.95rem' },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '1rem', letterSpacing: '0.01em' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.875rem' },
+    caption: { fontWeight: 500, fontSize: '0.75rem', letterSpacing: '0.04em', textTransform: 'uppercase' },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual redesign of the portfolio, replacing the cold purple/cyan palette with a warm charcoal + amber/gold aesthetic and modernizing every section's layout.

- **Theme**: New color system — charcoal base (`#0c0c0e`), warm text (`#e8e6e3`), amber accent (`#d4a053`). Switched from Montserrat to Inter with a refined type scale and generous whitespace.
- **Hero**: Split layout with identity/social links on the left and the AI chat card on the right. Removed particle background for a cleaner, faster experience.
- **Nav**: Minimal redesign with pill-style active indicators and a compact rounded logo mark replacing the animated SVG.
- **About**: Horizontal layout with rounded headshot, inline bio, and a custom lightweight timeline replacing the MUI Lab Timeline component.
- **Projects**: Refined cards with softer borders, text-style CTA links, tech chip overflow (`+N`), and smoother hover animations.
- **Contact**: Side-by-side layout with contact info on the left and the form on the right, including a split name/email row.
- **Footer**: Minimal single-line copyright with a rounded back-to-top button.

All 26 component files updated. No new dependencies. Lint passes clean. Backend API routes are unchanged.

## Test plan

- [ ] Verify the homepage loads with the new dark charcoal background and amber accents
- [ ] Confirm the nav bar renders with pill-style active state and smooth scroll works for About/Projects/Contact
- [ ] Test the AI chat: enter a message or click a chip, verify the chat view activates with the new styling
- [ ] Verify the About section shows headshot, bio, social links, resume button, and experience timeline (desktop)
- [ ] Confirm project cards render with cover images, tech chips, and "View Project" links
- [ ] Test the contact form submission flow (name/email side-by-side, captcha, send)
- [ ] Check responsive behavior on mobile (stacked hero, hidden timeline, collapsed nav links)
- [ ] Verify no console errors on page load

https://claude.ai/code/session_01UURPmUA7SuVPzH2oUJudpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UURPmUA7SuVPzH2oUJudpD)_