### PR TITLE
Redesign: Modern 2026 portfolio aesthetic

### DIFF
--- a/next-app/src/app/chat/page.js
+++ b/next-app/src/app/chat/page.js
@@ -1,0 +1,24 @@
+'use client';
+
+import { Box } from '@mui/material';
+import HeroChat from '@/components/Greeting-Page/HeroChat';
+import ParticleBackground from '@/components/ParticleBackground';
+
+const ChatPage = () => {
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        height: '100vh',
+        bgcolor: '#0a0a0b',
+        overflow: 'hidden',
+      }}
+    >
+      <ParticleBackground backgroundColor="#0a0a0b" />
+      <HeroChat />
+    </Box>
+  );
+};
+
+export default ChatPage;

--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,26 +2,36 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
+  weight: ['300', '400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva — Software Engineer',
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in AI, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'AI Engineer',
+    'React Developer',
+    'Node.js',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in AI & full-stack development.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
@@ -34,8 +44,8 @@ export const metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in AI & full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +53,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body
+        className={inter.variable}
+        style={{ background: '#0a0a0b', overflowX: 'hidden', margin: 0 }}
+      >
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -1,85 +1,192 @@
 'use client';
 
-import { Box } from '@mui/material';
+import { Box, Typography, Button } from '@mui/material';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import NavBar from '@/components/Navbar/NavBar';
+import Footer from '@/components/Footer/Footer';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
-import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
-import NavBar from '@/components/Navbar/NavBar';
-import Footer from '@/components/Footer/Footer';
 
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#0a0a0b',
+        color: '#f0ede6',
         position: 'relative',
         minHeight: '100vh',
       }}
     >
       <NavBar />
 
+      {/* Hero Section */}
       <Box
+        id="hero"
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          // Subtle radial gradient spots
+          background: `
+            radial-gradient(ellipse 600px 600px at 20% 50%, rgba(245, 158, 11, 0.04) 0%, transparent 70%),
+            radial-gradient(ellipse 500px 500px at 80% 30%, rgba(239, 68, 68, 0.03) 0%, transparent 70%),
+            #0a0a0b
+          `,
+          // Grain overlay via pseudo-element
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            opacity: 0.4,
+            pointerEvents: 'none',
+            backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E")`,
+            backgroundRepeat: 'repeat',
+            backgroundSize: '128px 128px',
+            zIndex: 1,
           },
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
-        <HeroChat />
+        <Box
+          sx={{
+            position: 'relative',
+            zIndex: 2,
+            textAlign: 'center',
+            px: 3,
+          }}
+        >
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: { xs: '2.5rem', sm: '3.5rem', md: '5rem', lg: '6rem' },
+              fontWeight: 700,
+              letterSpacing: '-0.03em',
+              lineHeight: 1,
+              mb: 2,
+              color: '#f0ede6',
+            }}
+          >
+            David Riva
+          </Typography>
+          <Typography
+            variant="h5"
+            sx={{
+              color: 'rgba(240, 237, 230, 0.6)',
+              fontWeight: 400,
+              fontSize: { xs: '1rem', sm: '1.25rem', md: '1.5rem' },
+              letterSpacing: '0.02em',
+              mb: 4,
+            }}
+          >
+            Software Engineer — AI & Full-Stack
+          </Typography>
+          <Button
+            component={Link}
+            href="/chat"
+            sx={{
+              color: '#f0ede6',
+              border: '1px solid rgba(240, 237, 230, 0.15)',
+              borderRadius: '50px',
+              px: 4,
+              py: 1.25,
+              textTransform: 'none',
+              fontSize: '0.9rem',
+              fontWeight: 500,
+              transition: 'all 0.3s ease',
+              '&:hover': {
+                borderColor: 'rgba(245, 158, 11, 0.5)',
+                bgcolor: 'rgba(245, 158, 11, 0.05)',
+              },
+            }}
+          >
+            Chat with my AI assistant
+          </Button>
+        </Box>
+
+        {/* Scroll indicator */}
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 40,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1,
+            zIndex: 2,
+            opacity: 0.5,
+            animation: 'scrollBounce 2s ease-in-out infinite',
+            '@keyframes scrollBounce': {
+              '0%, 100%': { transform: 'translateX(-50%) translateY(0)' },
+              '50%': { transform: 'translateX(-50%) translateY(8px)' },
+            },
+          }}
+        >
+          <Typography variant="caption" sx={{ color: 'rgba(240, 237, 230, 0.4)', fontSize: '0.7rem', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+            Scroll
+          </Typography>
+          <Box
+            sx={{
+              width: 1,
+              height: 24,
+              bgcolor: 'rgba(240, 237, 230, 0.2)',
+            }}
+          />
+        </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
+      {/* About Section */}
+      <Box
+        id="about"
+        sx={{
+          width: '100%',
+          background: `
+            radial-gradient(ellipse 800px 400px at 70% 0%, rgba(245, 158, 11, 0.02) 0%, transparent 70%),
+            #0a0a0b
+          `,
+        }}
+      >
+        <About />
+      </Box>
 
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
+      {/* Projects Section */}
+      <Box
+        id="projects"
+        sx={{
+          width: '100%',
+          background: `
+            radial-gradient(ellipse 600px 600px at 30% 50%, rgba(239, 68, 68, 0.02) 0%, transparent 70%),
+            #0a0a0b
+          `,
+        }}
+      >
+        <Projects />
+      </Box>
 
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+      {/* Contact Section */}
+      <Box
+        id="contact"
+        sx={{
+          width: '100%',
+          background: `
+            radial-gradient(ellipse 700px 500px at 60% 50%, rgba(245, 158, 11, 0.02) 0%, transparent 70%),
+            #0a0a0b
+          `,
+        }}
+      >
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,194 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
+import { Box, Typography, IconButton, Link as MuiLink } from '@mui/material';
+import HeadShotImage from './HeadshotImage';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+
+const cardSx = {
+  bgcolor: 'rgba(255, 255, 255, 0.03)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '24px',
+  p: 4,
+  transition: 'border-color 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+  },
 };
 
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        margin: '0 auto',
         px: { xs: 3, md: 6 },
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '80px', md: '120px' },
       }}
     >
-      <Box
+      {/* Section heading */}
+      <Typography
+        variant="h2"
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          fontSize: { xs: '2rem', md: '2.5rem' },
+          fontWeight: 700,
+          color: '#f0ede6',
+          mb: 6,
+          letterSpacing: '-0.02em',
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        About
+      </Typography>
+
+      {/* Bento grid */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' },
+          gridTemplateRows: { md: 'auto auto' },
+          gap: 3,
+        }}
+      >
+        {/* Card 1: Headshot + name (spans 2 rows on md) */}
+        <Box
+          sx={{
+            ...cardSx,
+            gridRow: { md: 'span 2' },
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            gap: 3,
+          }}
+        >
+          <Box
+            sx={{
+              width: 180,
+              height: 180,
+              borderRadius: '50%',
+              overflow: 'hidden',
+              border: '2px solid rgba(245, 158, 11, 0.2)',
+            }}
+          >
+            <HeadShotImage width={180} height={180} />
+          </Box>
+          <Box>
+            <Typography variant="h5" sx={{ fontWeight: 700, color: '#f0ede6', mb: 0.5 }}>
+              David Riva
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'rgba(240, 237, 230, 0.6)' }}>
+              Software Engineer
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'rgba(240, 237, 230, 0.4)', mt: 0.5 }}>
+              Bay Area, CA
+            </Typography>
+          </Box>
         </Box>
-      </Box>
 
-      <AboutTextSection />
+        {/* Card 2: Bio */}
+        <Box sx={{ ...cardSx, gridColumn: { md: 'span 2' } }}>
+          <Typography variant="body1" sx={{ color: 'rgba(240, 237, 230, 0.8)', lineHeight: 1.8 }}>
+            Software engineer passionate about AI and full-stack development. I build thoughtful, performant applications
+            with a focus on elegant problem-solving and user experience. Experienced in data engineering, big data
+            visualization, and distributed systems.
+          </Typography>
+        </Box>
 
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
+        {/* Card 3: Quick stats */}
+        <Box sx={{ ...cardSx }}>
+          <Typography variant="body2" sx={{ color: 'rgba(240, 237, 230, 0.4)', mb: 2, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' }}>
+            Quick Facts
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Typography variant="body1" sx={{ color: '#f0ede6', fontWeight: 500 }}>
+              2+ years experience
+            </Typography>
+            <Typography variant="body1" sx={{ color: '#f0ede6', fontWeight: 500 }}>
+              B.S. CS, Summa Cum Laude
+            </Typography>
+            <Typography variant="body1" sx={{ color: '#f0ede6', fontWeight: 500 }}>
+              Colorado State University
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Card 4: Social links */}
+        <Box sx={{ ...cardSx, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+          <Typography variant="body2" sx={{ color: 'rgba(240, 237, 230, 0.4)', mb: 2, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' }}>
+            Connect
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <MuiLink href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="GitHub Profile"
+                sx={{
+                  color: 'rgba(240, 237, 230, 0.6)',
+                  fontSize: '32px',
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  borderRadius: '12px',
+                  p: 1.5,
+                  '&:hover': { color: '#f0ede6', borderColor: 'rgba(255, 255, 255, 0.2)' },
+                }}
+              >
+                <GitHubIcon fontSize="inherit" />
+              </IconButton>
+            </MuiLink>
+            <MuiLink href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
+              <IconButton
+                aria-label="LinkedIn Profile"
+                sx={{
+                  color: 'rgba(240, 237, 230, 0.6)',
+                  fontSize: '32px',
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  borderRadius: '12px',
+                  p: 1.5,
+                  '&:hover': { color: '#f0ede6', borderColor: 'rgba(255, 255, 255, 0.2)' },
+                }}
+              >
+                <LinkedInIcon fontSize="inherit" />
+              </IconButton>
+            </MuiLink>
+          </Box>
+        </Box>
+
+        {/* Card 5: Resume link - spans full width on mobile */}
+        <Box
+          component="a"
+          href="/documents/resume.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            ...cardSx,
+            gridColumn: { md: 'span 3' },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            textDecoration: 'none',
+            cursor: 'pointer',
+            '&:hover': {
+              borderColor: 'rgba(245, 158, 11, 0.3)',
+              '& .arrow-icon': {
+                transform: 'translateX(4px) translateY(-4px)',
+              },
+            },
+          }}
+        >
+          <Box>
+            <Typography variant="body2" sx={{ color: 'rgba(240, 237, 230, 0.4)', mb: 0.5, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: '0.7rem' }}>
+              Resume
+            </Typography>
+            <Typography variant="body1" sx={{ color: '#f0ede6', fontWeight: 500 }}>
+              View my full resume
+            </Typography>
+          </Box>
+          <ArrowOutwardIcon
+            className="arrow-icon"
+            sx={{ color: 'rgba(240, 237, 230, 0.4)', transition: 'transform 0.2s ease' }}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -15,11 +15,11 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         p: '4px 8px',
         borderRadius: '999px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        border: '1px solid rgba(240,237,230,0.12)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        '&:hover': { borderColor: 'rgba(245,158,11,0.4)' },
+        '&:focus-within': { borderColor: '#f59e0b' },
       }}
     >
       <InputBase
@@ -36,9 +36,9 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         sx={{
           ml: 1,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#f0ede6',
+          fontFamily: 'var(--font-inter), Inter, sans-serif',
+          '& input::placeholder': { color: 'rgba(240,237,230,0.35)' },
         }}
       />
       <IconButton
@@ -46,7 +46,7 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         disabled={!input.trim() || disabled}
         sx={{
           ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          background: 'linear-gradient(135deg, #f59e0b, #ef4444)',
           '&:hover': { opacity: 0.85 },
           '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
         }}

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,11 +7,11 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-inter), Inter, sans-serif',
     fontWeight: 400,
     lineHeight: 1.6,
     fontSize: '0.95rem',
-    color: '#fff',
+    color: '#f0ede6',
     marginBottom: '4px',
   };
 
@@ -29,16 +29,16 @@ const MessageItem = ({ msg }) => {
           px: 2.5,
           py: 1.5,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
+          background: isUser ? 'rgba(245,158,11,0.08)' : 'rgba(255,255,255,0.04)',
           border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+            ? '1px solid rgba(245,158,11,0.2)'
+            : '1px solid rgba(255,255,255,0.08)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#f59e0b" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -55,8 +55,8 @@ const MessageItem = ({ msg }) => {
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
+                      color: '#f59e0b',
+                      backgroundColor: 'rgba(245,158,11,0.08)',
                       p: '0 4px',
                       borderRadius: 1,
                       display: 'inline',
@@ -71,7 +71,7 @@ const MessageItem = ({ msg }) => {
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => <a style={{ color: '#f59e0b', textDecoration: 'none' }} {...props} />,
               }}
             >
               {msg.text}

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,35 +1,48 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+'use client';
+
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
-import SectionHeading from '../SectionHeading';
 
 const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        margin: '0 auto',
+        px: { xs: 3, md: 6 },
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '80px', md: '120px' },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      {/* Section heading */}
+      <Typography
+        variant="h2"
+        sx={{
+          fontSize: { xs: '2rem', md: '2.5rem' },
+          fontWeight: 700,
+          color: '#f0ede6',
+          mb: 1,
+          letterSpacing: '-0.02em',
+        }}
+      >
+        Get in Touch
+      </Typography>
+      <Typography
+        variant="body1"
+        sx={{
+          color: 'rgba(240, 237, 230, 0.5)',
+          mb: 6,
+          fontSize: '1rem',
+        }}
+      >
+        Have a project in mind? Let&apos;s talk.
+      </Typography>
 
       <Box
         sx={{
           display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          justifyContent: { xs: 'center', md: 'flex-start' },
+          width: '100%',
         }}
       >
         <ContactForm />

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -5,14 +5,29 @@ import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
-  '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+  marginBottom: 3,
+  '& .MuiInputLabel-root': {
+    color: 'rgba(240, 237, 230, 0.4)',
+    fontSize: '0.9rem',
+  },
+  '& .MuiInputLabel-root.Mui-focused': {
+    color: '#f59e0b',
+  },
+  '& .MuiInput-root': {
+    color: '#f0ede6',
+    fontSize: '1rem',
+    '&::before': {
+      borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+    },
+    '&:hover::before': {
+      borderBottom: '1px solid rgba(255, 255, 255, 0.25)',
+    },
+    '&::after': {
+      borderBottom: '2px solid #f59e0b',
+    },
+  },
+  '& .MuiInput-underline:hover:not(.Mui-disabled):before': {
+    borderBottom: '1px solid rgba(255, 255, 255, 0.25)',
   },
 };
 
@@ -49,24 +64,56 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        maxWidth: '700px',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Your Name"
+          name="name"
+          variant="standard"
+          value={formData.name}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
+        <TextField
+          fullWidth
+          label="Your Email"
+          name="email"
+          type="email"
+          variant="standard"
+          value={formData.email}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
+        <TextField
+          fullWidth
+          label="Subject"
+          name="subject"
+          variant="standard"
+          value={formData.subject}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          variant="standard"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: 3, mt: 1 }}>
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
               onSuccess={(token) => setCaptchaToken(token)}
@@ -80,18 +127,24 @@ const ContactForm = () => {
           disabled={!captchaToken}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+            padding: '14px 0',
+            fontSize: '0.95rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #f59e0b 0%, #ef4444 100%)',
             color: '#ffffff',
-            borderRadius: '8px',
+            borderRadius: '12px',
             border: 'none',
+            textTransform: 'none',
+            letterSpacing: '0.01em',
+            transition: 'all 0.3s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #fbbf24 0%, #f87171 100%)',
+              transform: 'translateY(-1px)',
+              boxShadow: '0 8px 24px rgba(245, 158, 11, 0.2)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(240, 237, 230, 0.25)',
             },
           }}
         >
@@ -103,9 +156,10 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
+            marginTop: 2.5,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            color: status.includes('success') ? '#4caf50' : '#ef4444',
+            fontWeight: 500,
           }}
         >
           {status}

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,82 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton, Link as MuiLink } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
+        borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+        px: { xs: 3, md: 6 },
+        py: 4,
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: { xs: 'column', md: 'row' },
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        justifyContent: 'space-between',
+        gap: 2,
+        maxWidth: '1200px',
+        margin: '0 auto',
+        width: '100%',
       }}
     >
-      <ReturnToTopButton />
+      {/* Left: copyright */}
       <Typography
         variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          color: 'rgba(240, 237, 230, 0.35)',
+          fontSize: '0.8rem',
+          order: { xs: 3, md: 1 },
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        &copy; 2026 David Riva
+      </Typography>
+
+      {/* Center: social links */}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          order: { xs: 1, md: 2 },
+        }}
+      >
+        <MuiLink href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
+          <IconButton
+            aria-label="GitHub"
+            size="small"
+            sx={{
+              color: 'rgba(240, 237, 230, 0.4)',
+              '&:hover': { color: '#f0ede6' },
+            }}
+          >
+            <GitHubIcon fontSize="small" />
+          </IconButton>
+        </MuiLink>
+        <MuiLink href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
+          <IconButton
+            aria-label="LinkedIn"
+            size="small"
+            sx={{
+              color: 'rgba(240, 237, 230, 0.4)',
+              '&:hover': { color: '#f0ede6' },
+            }}
+          >
+            <LinkedInIcon fontSize="small" />
+          </IconButton>
+        </MuiLink>
+      </Box>
+
+      {/* Right: built with */}
+      <Typography
+        variant="body2"
+        sx={{
+          color: 'rgba(240, 237, 230, 0.35)',
+          fontSize: '0.8rem',
+          order: { xs: 2, md: 3 },
+        }}
+      >
+        Built with Next.js
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -77,7 +77,7 @@ const AnimatedTypingTypography = () => {
       }}
     >
       I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      <span style={{ color: '#f59e0b', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -42,29 +42,29 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 const CHIPS = [
   {
     label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
+    bg: 'rgba(245,158,11,0.1)',
+    border: 'rgba(245,158,11,0.4)',
+    color: '#f59e0b',
+    hoverBg: 'rgba(245,158,11,0.2)',
+    hoverBorder: 'rgba(245,158,11,0.7)',
+    glow: '0 0 14px rgba(245,158,11,0.25)',
   },
   {
     label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
+    bg: 'rgba(239,68,68,0.1)',
+    border: 'rgba(239,68,68,0.4)',
+    color: '#f87171',
+    hoverBg: 'rgba(239,68,68,0.2)',
+    hoverBorder: 'rgba(239,68,68,0.7)',
+    glow: '0 0 14px rgba(239,68,68,0.25)',
   },
   {
     label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
+    bg: 'rgba(240,237,230,0.05)',
+    border: 'rgba(240,237,230,0.2)',
+    color: 'rgba(240,237,230,0.8)',
+    hoverBg: 'rgba(240,237,230,0.1)',
+    hoverBorder: 'rgba(240,237,230,0.4)',
     glow: 'none',
   },
 ];
@@ -116,8 +116,8 @@ const HeroChat = () => {
             textAlign: 'center',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          <span style={{ color: '#f0ede6' }}>Hello, I&apos;m </span>
+          <span style={{ color: '#f59e0b' }}>David</span>
         </Typography>
 
         <AnimatedTypingTypography />
@@ -159,7 +159,7 @@ const HeroChat = () => {
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
+                  fontFamily: 'var(--font-inter), Inter, sans-serif',
                   fontSize: '0.9rem',
                   fontWeight: 600,
                   px: 2,
@@ -212,7 +212,7 @@ const HeroChat = () => {
             background: 'transparent',
             border: '1px solid rgba(255,255,255,0.4)',
             color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
+            fontFamily: 'var(--font-inter), Inter, sans-serif',
             fontWeight: 600,
             fontSize: '0.9rem',
             cursor: 'pointer',
@@ -254,7 +254,7 @@ const HeroChat = () => {
               width: 36,
               height: 36,
               borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              background: 'linear-gradient(135deg, #f59e0b, #ef4444)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,175 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
+import { Toolbar, Box, AppBar, Typography, IconButton, Drawer, List, ListItem, ListItemButton, ListItemText } from '@mui/material';
 import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
-
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
-
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
+import Link from 'next/link';
 
 const pages = ['About', 'Projects', 'Contact'];
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [activePage, setActivePage] = useState('');
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const linkSx = (active) => ({
+    color: active ? '#f0ede6' : 'rgba(240, 237, 230, 0.6)',
+    fontWeight: active ? 600 : 400,
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+    textDecoration: 'none',
+    padding: '6px 12px',
+    borderRadius: '6px',
+    transition: 'all 0.2s ease',
+    '&:hover': {
+      color: '#f0ede6',
+      bgcolor: 'rgba(240, 237, 230, 0.04)',
+    },
+  });
 
   return (
-    <AppBar
-      position="fixed"
-      sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
-      }}
-    >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
-            sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
-            }}
+    <>
+      <AppBar
+        position="fixed"
+        sx={{
+          top: 0,
+          zIndex: 1100,
+          width: '100%',
+          bgcolor: 'rgba(10, 10, 11, 0.8)',
+          backdropFilter: 'blur(20px)',
+          height: '64px',
+          color: '#f0ede6',
+          borderBottom: '1px solid rgba(240, 237, 230, 0.06)',
+          boxShadow: 'none',
+        }}
+      >
+        <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 }, height: '100%' }}>
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{
+                fontWeight: 800,
+                fontSize: '1.25rem',
+                color: '#f0ede6',
+                letterSpacing: '-0.02em',
+              }}
+            >
+              DR
+            </Typography>
+          </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
+          {/* Desktop nav */}
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 1 }}>
+            {pages.map((page) => (
+              <ScrollLink
+                key={page}
+                to={page.toLowerCase()}
+                spy={true}
+                smooth={true}
+                offset={-70}
+                duration={500}
+                onSetActive={() => setActivePage(page)}
+                style={{ textDecoration: 'none' }}
+              >
+                <Box component="span" sx={linkSx(activePage === page)}>
+                  {page}
+                </Box>
+              </ScrollLink>
+            ))}
+            <Box
+              component={Link}
+              href="/chat"
+              sx={{
+                ...linkSx(false),
+                ml: 1,
+                border: '1px solid rgba(240, 237, 230, 0.1)',
+                borderRadius: '50px',
+                px: 2,
+                py: 0.75,
+                fontSize: '0.8rem',
+                textDecoration: 'none',
+                '&:hover': {
+                  color: '#f0ede6',
+                  borderColor: 'rgba(245, 158, 11, 0.4)',
+                  bgcolor: 'rgba(245, 158, 11, 0.05)',
+                },
+              }}
+            >
+              Chat
+            </Box>
+          </Box>
+
+          {/* Mobile hamburger */}
+          <IconButton
+            aria-label="Open menu"
+            onClick={() => setMobileOpen(true)}
+            sx={{ display: { xs: 'flex', md: 'none' }, color: '#f0ede6' }}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      {/* Mobile drawer */}
+      <Drawer
+        anchor="right"
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        PaperProps={{
+          sx: {
+            bgcolor: 'rgba(10, 10, 11, 0.95)',
+            backdropFilter: 'blur(20px)',
+            width: 260,
+            pt: 2,
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, mb: 2 }}>
+          <IconButton onClick={() => setMobileOpen(false)} sx={{ color: '#f0ede6' }}>
+            <CloseIcon />
+          </IconButton>
         </Box>
-      </Toolbar>
-    </AppBar>
+        <List>
+          {pages.map((page) => (
+            <ListItem key={page} disablePadding>
+              <ScrollLink
+                to={page.toLowerCase()}
+                spy={true}
+                smooth={true}
+                offset={-70}
+                duration={500}
+                onClick={() => setMobileOpen(false)}
+                style={{ width: '100%', textDecoration: 'none' }}
+              >
+                <ListItemButton sx={{ px: 3, py: 1.5 }}>
+                  <ListItemText
+                    primary={page}
+                    primaryTypographyProps={{
+                      sx: { color: 'rgba(240, 237, 230, 0.8)', fontWeight: 500, fontSize: '1rem' },
+                    }}
+                  />
+                </ListItemButton>
+              </ScrollLink>
+            </ListItem>
+          ))}
+          <ListItem disablePadding>
+            <ListItemButton component={Link} href="/chat" sx={{ px: 3, py: 1.5 }}>
+              <ListItemText
+                primary="Chat"
+                primaryTypographyProps={{
+                  sx: { color: 'rgba(240, 237, 230, 0.8)', fontWeight: 500, fontSize: '1rem' },
+                }}
+              />
+            </ListItemButton>
+          </ListItem>
+        </List>
+      </Drawer>
+    </>
   );
 };
 

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,168 +2,173 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
-import LaunchIcon from '@mui/icons-material/Launch';
-
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
+import { Typography, Box, Card, CardContent, Chip, Stack } from '@mui/material';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const ProjectCard = forwardRef(
   (
     { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
     ref
   ) => {
+    const allTools = technologies ? technologies.flatMap((t) => t.tools) : [];
+
     return (
       <Card
         ref={ref}
         id={id}
+        component="a"
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
-          borderRadius: '16px',
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+          color: '#f0ede6',
+          border: '1px solid rgba(255, 255, 255, 0.06)',
+          borderRadius: '24px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.3s ease',
+          cursor: 'pointer',
+          textDecoration: 'none',
+          position: 'relative',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: 'rgba(255, 255, 255, 0.12)',
+            '& .project-image': { transform: 'scale(1.03)' },
+            '& .arrow-icon': {
+              opacity: 1,
+              transform: 'translate(0, 0)',
+            },
           },
         }}
         onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        {/* Arrow icon on hover */}
+        <Box
+          className="arrow-icon"
+          sx={{
+            position: 'absolute',
+            top: 16,
+            right: 16,
+            zIndex: 3,
+            opacity: 0,
+            transform: 'translate(-4px, 4px)',
+            transition: 'all 0.3s ease',
+            bgcolor: 'rgba(255, 255, 255, 0.1)',
+            backdropFilter: 'blur(8px)',
+            borderRadius: '50%',
+            width: 36,
+            height: 36,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ArrowOutwardIcon sx={{ fontSize: '1rem', color: '#f0ede6' }} />
+        </Box>
+
+        {/* Image */}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? '240px' : '200px',
+            width: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 50%, rgba(10, 10, 11, 0.8) 100%)',
+            }}
+          />
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: { xs: 2.5, md: 3 } }}>
+          {/* Title */}
+          <Typography
+            variant="h6"
+            component="h3"
+            sx={{
+              fontWeight: 700,
+              mb: 0.5,
+              color: '#f0ede6',
+              lineHeight: 1.3,
+              fontSize: featured ? '1.1rem' : '1rem',
+            }}
+          >
+            {title}
+          </Typography>
+
+          {/* Date */}
+          <Typography
+            variant="caption"
+            sx={{ color: 'rgba(240, 237, 230, 0.35)', display: 'block', mb: 1.5, fontSize: '0.75rem' }}
+          >
+            {dateStarted} – {dateCompleted}
+          </Typography>
+
+          {/* Description */}
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'rgba(240, 237, 230, 0.55)',
+              lineHeight: 1.6,
+              mb: 2.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              fontSize: '0.85rem',
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          {/* Tech chips */}
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 'auto' }}>
+            {allTools.slice(0, 5).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.05)',
+                  color: 'rgba(240, 237, 230, 0.6)',
+                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 5 && (
+              <Chip
+                label={`+${allTools.length - 5}`}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.03)',
+                  color: 'rgba(240, 237, 230, 0.4)',
+                  border: '1px solid rgba(255, 255, 255, 0.06)',
+                  fontSize: '0.65rem',
+                  height: '22px',
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            )}
+          </Stack>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -1,26 +1,42 @@
-import { Box } from '@mui/material';
-import SectionHeading from '@/components/SectionHeading';
-import ProjectsContainer from './ProjectsContainer';
+'use client';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
+import { Box, Typography } from '@mui/material';
+import ProjectsContainer from './ProjectsContainer';
 
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
+        maxWidth: '1200px',
         margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        px: { xs: 3, md: 6 },
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '80px', md: '120px' },
       }}
     >
-      <SectionHeading sectionName="Projects" />
+      {/* Section heading */}
+      <Typography
+        variant="h2"
+        sx={{
+          fontSize: { xs: '2rem', md: '2.5rem' },
+          fontWeight: 700,
+          color: '#f0ede6',
+          mb: 1,
+          letterSpacing: '-0.02em',
+        }}
+      >
+        Selected Work
+      </Typography>
+      <Typography
+        variant="body1"
+        sx={{
+          color: 'rgba(240, 237, 230, 0.5)',
+          mb: 6,
+          fontSize: '1rem',
+        }}
+      >
+        Featured projects and experiments
+      </Typography>
 
       <ProjectsContainer />
     </Box>

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -1,74 +1,33 @@
 'use client';
 
 import { Box, Skeleton, Grid, Collapse, Button } from '@mui/material';
-import { useState, useEffect, useRef, useMemo, memo } from 'react';
+import { useState, useEffect, useMemo, memo } from 'react';
 import ProjectCard from './ProjectCard';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import gsap from 'gsap';
-import { ScrollTrigger } from 'gsap/ScrollTrigger';
-
-gsap.registerPlugin(ScrollTrigger);
 
 const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.featured-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 40, opacity: 0 },
-      {
-        y: 0,
-        opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
-      }
-    );
-    ScrollTrigger.refresh();
-    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
-  }, [projects]);
-
   return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
-            <ProjectCard {...project} featured />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
+    <Grid container spacing={4} sx={{ width: '100%', margin: 0 }}>
+      {projects.map((project) => (
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title}>
+          <ProjectCard {...project} featured />
+        </Grid>
+      ))}
+    </Grid>
   );
 });
 FeaturedProjects.displayName = 'FeaturedProjects';
 
 const AllProjects = ({ projects }) => {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (!containerRef.current || projects.length === 0) return;
-    const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
-  }, [projects]);
-
   return (
-    <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
-        {projects.map((project) => (
-          <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
-            <ProjectCard {...project} />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
+    <Grid container spacing={4} sx={{ width: '100%', margin: 0 }}>
+      {projects.map((project) => (
+        <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title}>
+          <ProjectCard {...project} />
+        </Grid>
+      ))}
+    </Grid>
   );
 };
 
@@ -92,57 +51,61 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={4}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box sx={{ bgcolor: 'rgba(255,255,255,0.02)', borderRadius: '24px', overflow: 'hidden' }}>
+                <Skeleton variant="rectangular" height={220} sx={{ bgcolor: 'rgba(255,255,255,0.05)' }} />
+                <Box sx={{ p: 3 }}>
+                  <Skeleton variant="text" sx={{ fontSize: '1.2rem', bgcolor: 'rgba(255,255,255,0.05)' }} />
+                  <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.03)' }} />
+                  <Skeleton variant="text" sx={{ mt: 1, bgcolor: 'rgba(255,255,255,0.03)' }} height={60} />
+                </Box>
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <Box>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
-            <Button
-              onClick={() => setShowAll((prev) => !prev)}
-              endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-              sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
-                px: 3,
-                py: 0.85,
-                textTransform: 'none',
-                fontSize: '0.85rem',
-                fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
-                },
-              }}
-            >
-              {showAll ? 'Show less' : `View all ${projectData.length} projects`}
-            </Button>
-          </Box>
+          {otherProjects.length > 0 && (
+            <>
+              <Box sx={{ mt: 5, textAlign: 'center' }}>
+                <Button
+                  onClick={() => setShowAll((prev) => !prev)}
+                  endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                  sx={{
+                    color: 'rgba(240, 237, 230, 0.55)',
+                    borderColor: 'rgba(255, 255, 255, 0.1)',
+                    border: '1px solid',
+                    borderRadius: '50px',
+                    px: 3.5,
+                    py: 1,
+                    textTransform: 'none',
+                    fontSize: '0.85rem',
+                    fontWeight: 500,
+                    transition: 'all 0.25s ease',
+                    '&:hover': {
+                      bgcolor: 'rgba(255, 255, 255, 0.04)',
+                      borderColor: 'rgba(255, 255, 255, 0.2)',
+                      color: '#f0ede6',
+                    },
+                  }}
+                >
+                  {showAll ? 'Show less' : `View all ${projectData.length} projects`}
+                </Button>
+              </Box>
 
-          <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
-            </Box>
-          </Collapse>
+              <Collapse in={showAll} timeout={400}>
+                <Box sx={{ mt: 4 }}>
+                  <AllProjects projects={otherProjects} />
+                </Box>
+              </Collapse>
+            </>
+          )}
         </Box>
       )}
     </Box>

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,42 +1,20 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 const SectionHeading = ({ sectionName }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
+    <Typography
+      variant="h2"
+      sx={{
+        fontSize: { xs: '2rem', md: '2.5rem' },
+        fontWeight: 700,
+        color: '#f0ede6',
+        mb: 4,
+        letterSpacing: '-0.02em',
+        textAlign: 'left',
       }}
     >
-      <Typography
-        variant="h2"
-        sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
-        }}
-      >
-        {sectionName}
-      </Typography>
-    </Box>
+      {sectionName}
+    </Typography>
   );
 };
 

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,30 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#0a0a0b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#f0ede6',
+      secondary: 'rgba(240, 237, 230, 0.6)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#f59e0b',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#ef4444',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), Inter, -apple-system, BlinkMacSystemFont, sans-serif',
+    h1: { fontWeight: 700, fontSize: '3.5rem', lineHeight: 1.1, letterSpacing: '-0.02em' },
+    h2: { fontWeight: 700, fontSize: '2.5rem', lineHeight: 1.2, letterSpacing: '-0.01em' },
+    h3: { fontWeight: 600, fontSize: '1.75rem', lineHeight: 1.3 },
+    h4: { fontWeight: 600, fontSize: '1.5rem' },
+    h5: { fontWeight: 600, fontSize: '1.25rem' },
+    h6: { fontWeight: 600, fontSize: '1rem' },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '1rem' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.875rem' },
   },
 });
 


### PR DESCRIPTION
## Summary

- **Complete visual overhaul** with a warm dark palette (#0a0a0b base, off-white #f0ede6 text, amber #f59e0b → coral #ef4444 gradient accents)
- **Bento grid About section** replacing the old side-by-side layout — headshot card, bio card, quick stats, social links, and resume link as interactive grid tiles
- **Editorial project cards** with larger imagery, hover-reveal arrow icons, and subtle tech chips
- **Minimal glassmorphism navbar** with "DR" monogram, mobile drawer menu, and dedicated Chat link
- **Grain-textured hero** with fluid typography replacing the particle background on the homepage
- **Dedicated /chat page** preserving the full AI chat experience with particle background
- **Inter font family** replacing Montserrat for a cleaner, more modern feel
- **Underline-style contact form** with gradient submit button
- **Consistent amber/coral theming** across all chat components (inputs, messages, loading dots)

## Test plan

- [ ] Verify homepage renders correctly: hero → about → projects → contact → footer
- [ ] Test navbar scroll links navigate to correct sections
- [ ] Test mobile hamburger menu opens/closes and links work
- [ ] Verify /chat page loads with particle background and chat functionality
- [ ] Confirm project cards link out correctly and "View all" toggle works
- [ ] Test contact form submission with Turnstile verification
- [ ] Check responsive behavior at mobile (375px), tablet (768px), and desktop (1440px)
- [ ] Verify `npm run build` passes without errors

https://claude.ai/code/session_01CL8zbbErpKnDdDYHM49bTE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL8zbbErpKnDdDYHM49bTE)_