### PR TITLE
Redesign portfolio with modern 2026 aesthetic

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,10 +4,10 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['400', '500', '600', '700', '800', '900'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
@@ -15,8 +15,18 @@ const montserrat = Montserrat({
 
 export const metadata = {
   title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'UI/UX Design',
+    'React Developer',
+    'Node.js',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
     title: 'David Riva - Personal Portfolio',
     description: 'Experienced software engineer specializing in UI/UX and big data visualization.',

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -15,10 +15,20 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         position: 'relative',
         minHeight: '100vh',
+        '&::before': {
+          content: '""',
+          position: 'fixed',
+          inset: 0,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E")`,
+          backgroundRepeat: 'repeat',
+          backgroundSize: '256px 256px',
+          pointerEvents: 'none',
+          zIndex: 1,
+        },
       }}
     >
       <NavBar />
@@ -27,28 +37,20 @@ const MainPage = () => {
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(129, 140, 248, 0.08) 0%, #09090b 70%)',
         }}
       >
         <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', position: 'relative', zIndex: 2 }}>
         <Box
           id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
+            background: 'linear-gradient(180deg, #09090b 0%, #0c0c10 50%, #09090b 100%)',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(255, 255, 255, 0.04)',
           }}
         >
           <About />
@@ -57,10 +59,9 @@ const MainPage = () => {
         <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
+            bgcolor: '#09090b',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(255, 255, 255, 0.04)',
           }}
         >
           <Projects />
@@ -69,9 +70,9 @@ const MainPage = () => {
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
+            background: 'linear-gradient(180deg, #09090b 0%, #0c0c10 100%)',
             width: '100%',
-            color: '#ffffff',
+            borderTop: '1px solid rgba(255, 255, 255, 0.04)',
           }}
         >
           <Contact />

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box } from '@mui/material';
 import HeadShotImage from './HeadshotImage';
 import AboutHeader from './AboutHeader';
@@ -5,73 +7,64 @@ import AboutFooter from './AboutFooter';
 import Biography from './Biography';
 import SimpleTimeline from './SimpleTimeline';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
-};
-
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '60px', md: '80px' },
+        px: { xs: 3, sm: 4, md: 6 },
       }}
     >
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: { xs: 'center', md: 'flex-start' },
+          gap: { xs: 4, md: 6 },
+          mb: { xs: 6, md: 8 },
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        <Box
+          sx={{
+            flexShrink: 0,
+            position: 'relative',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              inset: -3,
+              borderRadius: '20px',
+              background: 'linear-gradient(135deg, rgba(129, 140, 248, 0.3), rgba(192, 132, 252, 0.15))',
+              zIndex: 0,
+            },
+          }}
+        >
+          <Box
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              borderRadius: '17px',
+              overflow: 'hidden',
+              bgcolor: '#09090b',
+              width: { xs: 200, sm: 240 },
+              height: { xs: 200, sm: 240 },
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            <HeadShotImage width={240} height={240} />
+          </Box>
+        </Box>
+
+        <Box sx={{ flex: 1, maxWidth: '640px' }}>
+          <AboutHeader />
+          <Biography />
+          <AboutFooter />
         </Box>
       </Box>
 
-      <AboutTextSection />
-
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
-      </Box>
+      <SimpleTimeline />
     </Box>
   );
 };

--- a/next-app/src/components/About-Page/AboutFooter.js
+++ b/next-app/src/components/About-Page/AboutFooter.js
@@ -6,11 +6,10 @@ const AboutFooter = () => {
   return (
     <Box
       sx={{
-        marginTop: 4,
+        mt: 3,
         display: 'flex',
-        justifyContent: 'flex-start',
-        gap: 2,
-        flexDirection: { xs: 'column', sm: 'row', md: 'row' },
+        alignItems: 'center',
+        gap: 1.5,
       }}
     >
       <ResumeButton />

--- a/next-app/src/components/About-Page/AboutHeader.js
+++ b/next-app/src/components/About-Page/AboutHeader.js
@@ -1,25 +1,29 @@
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import ClickableLink from './ClickableLink';
 
 const AboutHeader = () => {
   return (
-    <>
+    <Box sx={{ mb: 2 }}>
       <Typography
-        variant="h1"
+        variant="h2"
         sx={{
-          fontWeight: 'bold',
-          marginBottom: 1,
-          fontSize: { xs: '1.75rem', sm: '2.5rem', md: '2.5rem' },
+          fontWeight: 800,
+          fontSize: { xs: '2rem', sm: '2.5rem' },
+          letterSpacing: '-0.03em',
+          mb: 0.5,
+          color: '#fafafa',
         }}
       >
         David Riva
       </Typography>
 
       <Typography
-        variant="h5"
         sx={{
-          color: '#38c0f2',
-          marginBottom: 1,
+          color: '#818cf8',
+          fontWeight: 600,
+          fontSize: '1.05rem',
+          mb: 1,
+          letterSpacing: '-0.01em',
         }}
       >
         Training Engineer, Generative AI
@@ -27,13 +31,13 @@ const AboutHeader = () => {
 
       <Typography
         sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          marginBottom: 2,
+          color: 'rgba(255, 255, 255, 0.4)',
+          fontSize: '0.9rem',
         }}
       >
-        Bay Area, CA. | <ClickableLink link="mailto:davidjriva@gmail.com" text="davidjriva@gmail.com" />
+        Bay Area, CA &middot; <ClickableLink link="mailto:davidjriva@gmail.com" text="davidjriva@gmail.com" />
       </Typography>
-    </>
+    </Box>
   );
 };
 

--- a/next-app/src/components/About-Page/Biography.js
+++ b/next-app/src/components/About-Page/Biography.js
@@ -1,26 +1,16 @@
 import { Box, Typography } from '@mui/material';
-import ClickableLink from '@/components/About-Page/ClickableLink';
 
 const Biography = () => {
   return (
-    <Box
-      sx={{
-        marginTop: 2,
-        maxWidth: '600px',
-        textAlign: 'left',
-      }}
-    >
-      <Typography variant="body1">
+    <Box sx={{ mt: 2.5 }}>
+      <Typography variant="body1" sx={{ color: 'rgba(255, 255, 255, 0.6)', fontSize: '0.95rem' }}>
         Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
         University, where I received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m incredibly
         passionate about software &amp; applied AI engineering.
       </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        I&apos;m experienced in full-stack development, data engineering, and big data visualization.
-      </Typography>
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        I have a strong background in data structures, algorithms, and mathematical applications. I pride myself on
-        elegant problem-solving and my dedication to maintaining high standards of excellence.
+      <Typography variant="body1" sx={{ mt: 2, color: 'rgba(255, 255, 255, 0.6)', fontSize: '0.95rem' }}>
+        I&apos;m experienced in full-stack development, data engineering, and big data visualization. I have a strong
+        background in data structures, algorithms, and mathematical applications.
       </Typography>
     </Box>
   );

--- a/next-app/src/components/About-Page/ClickableLink.js
+++ b/next-app/src/components/About-Page/ClickableLink.js
@@ -5,10 +5,13 @@ const ClickableLink = ({ link, text }) => {
     <a
       href={link}
       target="_blank"
-      style={{ color: '#38c0f2', textDecoration: 'none' }}
+      style={{
+        color: '#818cf8',
+        textDecoration: 'none',
+        transition: 'color 0.2s ease',
+      }}
       onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
       onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}
-      onClick={(e) => (e.currentTarget.style.color = '#0073e6')}
     >
       {text}
     </a>

--- a/next-app/src/components/About-Page/HeadshotImage.js
+++ b/next-app/src/components/About-Page/HeadshotImage.js
@@ -2,23 +2,6 @@
 
 import { Box } from '@mui/material';
 import Image from 'next/image';
-import { keyframes } from '@emotion/react';
-
-const glowFrames = Array.from({ length: 51 }, (_, i) => {
-  const r = 240 - 2 * i;
-  const g = 240 - i;
-  const b = 250;
-  return `${i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const reverseGlowFrames = Array.from({ length: 50 }, (_, i) => {
-  const r = 140 + 2 * i;
-  const g = 190 + i;
-  const b = 250;
-  return `${51 + i}% { box-shadow: 0 0 20px 5px rgba(${r}, ${g}, ${b}, 1); }`;
-}).join(' ');
-
-const glowAnimation = keyframes`${glowFrames}\n${reverseGlowFrames}`;
 
 const HeadShotImage = ({ width, height }) => {
   return (
@@ -28,7 +11,6 @@ const HeadShotImage = ({ width, height }) => {
         width,
         height,
         overflow: 'hidden',
-        borderRadius: '50%',
         display: { xs: 'none', sm: 'block' },
       }}
     >
@@ -37,9 +19,7 @@ const HeadShotImage = ({ width, height }) => {
         src="/images/headshot.webp"
         width={width}
         height={height}
-        style={{
-          objectFit: 'cover',
-        }}
+        style={{ objectFit: 'cover' }}
         priority={true}
       />
     </Box>

--- a/next-app/src/components/About-Page/ResumeButton.js
+++ b/next-app/src/components/About-Page/ResumeButton.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@mui/material';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 
 const ResumeButton = () => {
   const handleResumeClick = () => {
@@ -8,20 +9,28 @@ const ResumeButton = () => {
   };
 
   return (
-    <Button 
-      variant="contained" 
-      onClick={handleResumeClick} 
-      sx={{ 
-        marginTop: '1rem', 
-        marginBottom: 2,
-        backgroundColor: '#1976d2',
-        color: 'white',
+    <Button
+      variant="outlined"
+      onClick={handleResumeClick}
+      startIcon={<DescriptionOutlinedIcon sx={{ fontSize: '1rem !important' }} />}
+      sx={{
+        color: 'rgba(255, 255, 255, 0.7)',
+        borderColor: 'rgba(255, 255, 255, 0.12)',
+        borderRadius: '10px',
+        textTransform: 'none',
+        fontWeight: 500,
+        fontSize: '0.85rem',
+        px: 2.5,
+        py: 0.8,
+        transition: 'all 0.2s ease',
         '&:hover': {
-          backgroundColor: '#1565c0',
+          borderColor: 'rgba(129, 140, 248, 0.4)',
+          color: '#818cf8',
+          background: 'rgba(129, 140, 248, 0.06)',
         },
       }}
     >
-      View Resume as PDF
+      Resume
     </Button>
   );
 };

--- a/next-app/src/components/About-Page/SimpleTimeline.js
+++ b/next-app/src/components/About-Page/SimpleTimeline.js
@@ -1,99 +1,96 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import {
-  Timeline,
-  TimelineItem,
-  TimelineOppositeContent,
-  TimelineSeparator,
-  TimelineConnector,
-  TimelineDot,
-  TimelineContent,
-} from '@mui/lab';
 import { Typography, Box } from '@mui/material';
 import Image from 'next/image';
 
-const SimpleTimelineItem = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate, isEnd }) => {
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, startDate, endDate }) => {
   const isCurrent = endDate === 'Present';
   const isGraduation = title.startsWith('Graduated');
 
   return (
-    <TimelineItem>
-      <TimelineOppositeContent sx={{ flex: 'none', width: 130, pr: 1.5, pt: '14px' }}>
-        <Typography
-          variant="caption"
+    <Box
+      sx={{
+        minWidth: { xs: 220, sm: 240 },
+        maxWidth: 280,
+        p: 2.5,
+        borderRadius: '14px',
+        background: isCurrent ? 'rgba(129, 140, 248, 0.04)' : 'rgba(255, 255, 255, 0.02)',
+        border: isCurrent ? '1px solid rgba(129, 140, 248, 0.15)' : '1px solid rgba(255, 255, 255, 0.06)',
+        flexShrink: 0,
+        transition: 'all 0.25s ease',
+        '&:hover': {
+          background: 'rgba(129, 140, 248, 0.06)',
+          borderColor: 'rgba(129, 140, 248, 0.2)',
+          transform: 'translateY(-2px)',
+        },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+        <Box
           sx={{
-            color: isCurrent ? '#38c0f2' : 'rgba(255,255,255,0.45)',
-            fontWeight: isCurrent ? 600 : 400,
-            lineHeight: 1.4,
-            display: 'block',
-          }}
-        >
-          {isGraduation ? startDate : `${startDate} –\u00a0${isCurrent ? 'Present' : endDate}`}
-        </Typography>
-      </TimelineOppositeContent>
-
-      <TimelineSeparator>
-        <TimelineDot
-          sx={{
-            backgroundColor: '#ffffff',
-            border: isCurrent
-              ? '1.5px solid rgba(56,192,242,0.6)'
-              : '1.5px solid rgba(255,255,255,0.2)',
-            boxShadow: isCurrent ? '0 0 10px 2px rgba(56,192,242,0.25)' : 'none',
-            p: '5px',
-            m: '6px 0',
+            width: 32,
+            height: 32,
+            borderRadius: '8px',
+            bgcolor: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            overflow: 'hidden',
           }}
         >
           <Image
             src={`/images/${logoImage}`}
             alt={`${company} logo`}
-            width={20}
-            height={20}
-            style={{ display: 'block', objectFit: 'contain' }}
+            width={22}
+            height={22}
+            style={{ objectFit: 'contain' }}
           />
-        </TimelineDot>
-        {!isEnd && (
-          <TimelineConnector
-            sx={{
-              background: 'linear-gradient(to bottom, rgba(56,192,242,0.25), rgba(110,64,201,0.15))',
-              width: '1.5px',
-            }}
-          />
-        )}
-      </TimelineSeparator>
-
-      <TimelineContent sx={{ pl: 1.5, pt: '10px', pb: '16px' }}>
+        </Box>
         <Box>
-          <Typography
-            variant="body2"
-            sx={{
-              fontWeight: 600,
-              fontSize: '0.8rem',
-              lineHeight: 1.35,
-              color: '#ffffff',
-              mb: 0.25,
-            }}
-          >
-            {isGraduation ? 'Graduated' : title.split(',')[0]}
-          </Typography>
           <Typography
             component="a"
             href={companyWebsiteLink}
             target="_blank"
-            variant="caption"
             sx={{
-              color: '#38c0f2',
+              color: '#fafafa',
               textDecoration: 'none',
-              fontSize: '0.72rem',
-              '&:hover': { textDecoration: 'underline' },
+              fontWeight: 600,
+              fontSize: '0.82rem',
+              display: 'block',
+              lineHeight: 1.3,
+              '&:hover': { color: '#818cf8' },
             }}
           >
             {company}
           </Typography>
         </Box>
-      </TimelineContent>
-    </TimelineItem>
+      </Box>
+
+      <Typography
+        sx={{
+          fontWeight: 500,
+          fontSize: '0.78rem',
+          color: 'rgba(255, 255, 255, 0.6)',
+          lineHeight: 1.4,
+          mb: 1,
+        }}
+      >
+        {isGraduation ? 'Graduated' : title.split(',')[0]}
+      </Typography>
+
+      <Typography
+        variant="caption"
+        sx={{
+          color: isCurrent ? '#818cf8' : 'rgba(255, 255, 255, 0.3)',
+          fontWeight: isCurrent ? 500 : 400,
+          fontSize: '0.72rem',
+        }}
+      >
+        {isGraduation ? startDate : `${startDate} – ${isCurrent ? 'Present' : endDate}`}
+      </Typography>
+    </Box>
   );
 };
 
@@ -110,42 +107,41 @@ const SimpleTimeline = () => {
     return new Date(b.startDate) - new Date(a.startDate);
   });
 
+  if (sortedExperienceData.length === 0) return null;
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        background: 'rgba(255,255,255,0.03)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        px: 1,
-        py: 2,
-      }}
-    >
+    <Box>
       <Typography
-        variant="overline"
         sx={{
-          color: 'rgba(255,255,255,0.55)',
-          fontSize: '0.85rem',
-          letterSpacing: '0.18em',
+          color: 'rgba(255, 255, 255, 0.3)',
+          fontSize: '0.75rem',
           fontWeight: 600,
-          mb: 0.5,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          mb: 2,
         }}
       >
         Experience
       </Typography>
-      <Timeline sx={{ maxWidth: '22vw', p: 0, m: 0 }}>
-        {sortedExperienceData.map((experience, index) => (
-          <React.Fragment key={experience.title}>
-            <SimpleTimelineItem
-              {...experience}
-              isEnd={index === sortedExperienceData.length - 1}
-            />
-          </React.Fragment>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          overflowX: 'auto',
+          pb: 1,
+          '&::-webkit-scrollbar': { height: 4 },
+          '&::-webkit-scrollbar-track': { background: 'transparent' },
+          '&::-webkit-scrollbar-thumb': {
+            background: 'rgba(255, 255, 255, 0.08)',
+            borderRadius: 2,
+          },
+        }}
+      >
+        {sortedExperienceData.map((experience) => (
+          <ExperienceCard key={experience.title} {...experience} />
         ))}
-      </Timeline>
+      </Box>
     </Box>
   );
 };

--- a/next-app/src/components/About-Page/SocialLinks.js
+++ b/next-app/src/components/About-Page/SocialLinks.js
@@ -1,35 +1,21 @@
 'use client';
 
-import React, { useState } from 'react';
 import { Box, IconButton, Link } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 const SocialLinks = () => {
-  const [hasGitHubIconBeenClicked, setHasGitHubIconBeenClicked] = useState(false);
-  const [hasLinkedInIconBeenClicked, setHasLinkedInIconBeenClicked] = useState(false);
-
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
       <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
         <IconButton
           aria-label="GitHub Profile"
           sx={{
-            color: hasGitHubIconBeenClicked ? '#9974cf' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#a28be5',
-            },
-            '&:active': {
-              color: '#9974cf',
-            },
+            color: 'rgba(255, 255, 255, 0.4)',
+            fontSize: '28px',
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#818cf8' },
           }}
-          onClick={() => setHasGitHubIconBeenClicked(true)}
         >
           <GitHubIcon fontSize="inherit" />
         </IconButton>
@@ -38,16 +24,11 @@ const SocialLinks = () => {
         <IconButton
           aria-label="LinkedIn Profile"
           sx={{
-            color: hasLinkedInIconBeenClicked ? '#07a2f7' : 'inherit',
-            fontSize: '40px',
-            '&:hover': {
-              color: '#4abfff',
-            },
-            '&:active': {
-              color: '#07a2f7',
-            },
+            color: 'rgba(255, 255, 255, 0.4)',
+            fontSize: '28px',
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#818cf8' },
           }}
-          onClick={() => setHasLinkedInIconBeenClicked(true)}
         >
           <LinkedInIcon fontSize="inherit" />
         </IconButton>

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -14,12 +14,13 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         alignItems: 'center',
         p: '4px 8px',
         borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        backgroundColor: 'rgba(255, 255, 255, 0.03)',
+        border: '1px solid rgba(255, 255, 255, 0.08)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(129, 140, 248, 0.3)' },
+        '&:focus-within': { borderColor: 'rgba(129, 140, 248, 0.5)' },
       }}
     >
       <InputBase
@@ -34,24 +35,28 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+          fontSize: '0.9rem',
+          '& input::placeholder': { color: 'rgba(255, 255, 255, 0.25)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          ml: 0.5,
+          width: 34,
+          height: 34,
+          background: 'linear-gradient(135deg, #818cf8, #c084fc)',
+          borderRadius: '50%',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255, 255, 255, 0.05)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#fff', fontSize: '0.95rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,11 +7,11 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: 'rgba(255, 255, 255, 0.85)',
     marginBottom: '4px',
   };
 
@@ -29,16 +29,14 @@ const MessageItem = ({ msg }) => {
           px: 2.5,
           py: 1.5,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          background: isUser ? 'rgba(129, 140, 248, 0.1)' : 'rgba(255, 255, 255, 0.03)',
+          border: isUser ? '1px solid rgba(129, 140, 248, 0.15)' : '1px solid rgba(255, 255, 255, 0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#818cf8" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -47,16 +45,25 @@ const MessageItem = ({ msg }) => {
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
                 strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography
+                    sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }}
+                    {...props}
+                  />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
+                      color: '#818cf8',
+                      backgroundColor: 'rgba(129, 140, 248, 0.08)',
                       p: '0 4px',
                       borderRadius: 1,
                       display: 'inline',
@@ -67,18 +74,25 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                      color: '#fff',
+                      p: 1.5,
+                      borderRadius: 2,
+                      overflowX: 'auto',
+                      border: '1px solid rgba(255, 255, 255, 0.06)',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => <a style={{ color: '#818cf8', textDecoration: 'none' }} {...props} />,
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,5 +1,4 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
 
@@ -7,31 +6,27 @@ const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '60px', md: '80px' },
+        px: { xs: 3, sm: 4, md: 6 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
-
-      <Box
+      <SectionHeading sectionName="Get in Touch" />
+      <Typography
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
+          color: 'rgba(255, 255, 255, 0.4)',
+          fontSize: '0.95rem',
+          mb: 4,
+          maxWidth: '500px',
+          lineHeight: 1.6,
+          textAlign: { xs: 'center', md: 'left' },
         }}
       >
+        Have a question or want to work together? Send me a message and I&apos;ll get back to you.
+      </Typography>
+      <Box sx={{ maxWidth: '600px', mx: { xs: 'auto', md: 0 } }}>
         <ContactForm />
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,23 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2.5,
+  '& .MuiInputLabel-root': {
+    color: 'rgba(255, 255, 255, 0.3)',
+    fontSize: '0.9rem',
+    '&.Mui-focused': { color: '#818cf8' },
+  },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    borderRadius: '12px',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.12)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(129, 140, 248, 0.5)' },
   },
 };
 
@@ -46,27 +53,52 @@ const ContactForm = () => {
   };
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-      }}
-    >
+    <Box sx={{ width: '100%' }}>
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <TextField
+            fullWidth
+            label="Name"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
+        <TextField
+          fullWidth
+          label="Subject"
+          name="subject"
+          value={formData.subject}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={4}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: 2 }}>
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
               onSuccess={(token) => setCaptchaToken(token)}
@@ -78,20 +110,26 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.9rem !important' }} />}
           sx={{
-            width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
+            px: 4,
+            py: 1.25,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            textTransform: 'none',
+            background: 'linear-gradient(135deg, #818cf8, #c084fc)',
+            color: '#fff',
+            borderRadius: '12px',
             border: 'none',
+            boxShadow: 'none',
+            transition: 'all 0.2s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #9098fc, #cc96fd)',
+              boxShadow: '0 8px 24px rgba(129, 140, 248, 0.2)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(255, 255, 255, 0.2)',
             },
           }}
         >
@@ -103,9 +141,9 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
-            textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            mt: 2,
+            color: status.includes('success') ? '#34d399' : '#f87171',
+            fontSize: '0.85rem',
           }}
         >
           {status}

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,39 +1,69 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, IconButton, Link } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import ReturnToTopButton from './ReturnToTopButton';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        bgcolor: '#09090b',
+        borderTop: '1px solid rgba(255, 255, 255, 0.04)',
         width: '100%',
-        height: '10vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
         position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <Box
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          maxWidth: '1200px',
+          mx: 'auto',
+          px: { xs: 3, md: 6 },
+          py: 4,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
-      </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'rgba(255, 255, 255, 0.2)',
+            fontSize: '0.78rem',
+          }}
+        >
+          &copy; {new Date().getFullYear()} David Riva
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" color="inherit">
+            <IconButton
+              aria-label="GitHub"
+              size="small"
+              sx={{
+                color: 'rgba(255, 255, 255, 0.2)',
+                '&:hover': { color: 'rgba(255, 255, 255, 0.5)' },
+              }}
+            >
+              <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+            </IconButton>
+          </Link>
+          <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" color="inherit">
+            <IconButton
+              aria-label="LinkedIn"
+              size="small"
+              sx={{
+                color: 'rgba(255, 255, 255, 0.2)',
+                '&:hover': { color: 'rgba(255, 255, 255, 0.5)' },
+              }}
+            >
+              <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+            </IconButton>
+          </Link>
+        </Box>
+      </Box>
+      <ReturnToTopButton />
     </Box>
   );
 };

--- a/next-app/src/components/Footer/ReturnToTopButton.js
+++ b/next-app/src/components/Footer/ReturnToTopButton.js
@@ -2,13 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { IconButton, Box } from '@mui/material';
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const ReturnToTopButton = () => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 200);
+    const onScroll = () => setVisible(window.scrollY > 300);
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
@@ -18,27 +18,31 @@ const ReturnToTopButton = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#38c0f2',
-        borderRadius: '8px',
-        padding: '4px',
-        maxWidth: '50px',
-        margin: '0 auto',
-        '@keyframes jump': {
-          '0%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-5px)' },
-          '100%': { transform: 'translateY(0)' },
-        },
-        '&:hover': { animation: 'jump 1s infinite' },
+        position: 'fixed',
+        bottom: 24,
+        right: 24,
+        zIndex: 1000,
       }}
     >
       <IconButton
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        sx={{ color: 'white', fontSize: '1.5rem', padding: '4px' }}
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: '10px',
+          bgcolor: 'rgba(255, 255, 255, 0.06)',
+          border: '1px solid rgba(255, 255, 255, 0.08)',
+          backdropFilter: 'blur(12px)',
+          color: 'rgba(255, 255, 255, 0.5)',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            bgcolor: 'rgba(129, 140, 248, 0.1)',
+            borderColor: 'rgba(129, 140, 248, 0.2)',
+            color: '#818cf8',
+          },
+        }}
       >
-        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 'inherit' }} />
+        <KeyboardArrowUpIcon sx={{ fontSize: '1.2rem' }} />
       </IconButton>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -6,78 +6,74 @@ import { Typography } from '@mui/material';
 const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const baseTypingSpeed = 100;
+  const baseDeletingSpeed = 50;
+  const delayBeforeDeleting = 1200;
+  const delayBetweenRoles = 500;
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
   const getRandomSpeed = (baseSpeed) => {
     return baseSpeed + Math.random() * 50;
   };
 
-  // Typing and deleting effect logic
   useEffect(() => {
     const currentRole = `${ROLES[roleIndex]}.`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, getRandomSpeed(baseTypingSpeed));
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
       timer = setTimeout(() => {
         setDeleting(true);
       }, delayBeforeDeleting);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, getRandomSpeed(baseDeletingSpeed));
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, delayBetweenRoles);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
     const blinkCursor = setInterval(() => {
       setCursorVisible((prev) => !prev);
-    }, 300);
+    }, 400);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1rem', sm: '1.2rem', md: '1.35rem' },
+        fontWeight: 400,
+        color: 'rgba(255, 255, 255, 0.5)',
+        letterSpacing: '-0.01em',
+        textAlign: 'center',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      I&apos;m {getArticle(ROLES[roleIndex])}{' '}
+      <span style={{ color: '#818cf8', fontWeight: 500 }}>{text}</span>
+      <span style={{ color: '#818cf8', opacity: cursorVisible ? 0.8 : 0 }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -42,30 +42,27 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 const CHIPS = [
   {
     label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
+    bg: 'rgba(129, 140, 248, 0.08)',
+    border: 'rgba(129, 140, 248, 0.25)',
+    color: '#818cf8',
+    hoverBg: 'rgba(129, 140, 248, 0.15)',
+    hoverBorder: 'rgba(129, 140, 248, 0.5)',
   },
   {
     label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
+    bg: 'rgba(192, 132, 252, 0.08)',
+    border: 'rgba(192, 132, 252, 0.25)',
+    color: '#c084fc',
+    hoverBg: 'rgba(192, 132, 252, 0.15)',
+    hoverBorder: 'rgba(192, 132, 252, 0.5)',
   },
   {
     label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
+    bg: 'rgba(255, 255, 255, 0.04)',
+    border: 'rgba(255, 255, 255, 0.1)',
+    color: 'rgba(255, 255, 255, 0.6)',
+    hoverBg: 'rgba(255, 255, 255, 0.08)',
+    hoverBorder: 'rgba(255, 255, 255, 0.2)',
   },
 ];
 
@@ -89,7 +86,7 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#fafafa', zIndex: 1 }}>
       {/* Pre-chat view */}
       <Box
         sx={{
@@ -99,7 +96,7 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
           transform: started ? 'translateY(-10px)' : 'translateY(0)',
@@ -110,35 +107,38 @@ const HeroChat = () => {
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
+            fontSize: 'clamp(3rem, 10vw, 7rem)',
             fontWeight: 900,
-            lineHeight: 1.1,
+            lineHeight: 0.95,
             textAlign: 'center',
+            letterSpacing: '-0.04em',
+            background: 'linear-gradient(135deg, #fafafa 0%, rgba(255,255,255,0.6) 100%)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          David Riva
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask me anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: 'rgba(248, 113, 113, 0.85)', minHeight: '1.2em' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" useFlexGap>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -154,29 +154,26 @@ const HeroChat = () => {
                 height: 'auto',
                 background: chip.bg,
                 border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                borderRadius: '999px',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.75,
                 },
                 '&:hover': {
                   background: chip.hoverBg,
                   borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +186,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +202,36 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.5,
+            px: 2.5,
+            py: 1,
+            borderRadius: '999px',
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            color: 'rgba(255, 255, 255, 0.4)',
+            fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+            fontWeight: 500,
+            fontSize: '0.8rem',
+            letterSpacing: '0.03em',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            '&:hover': {
+              borderColor: 'rgba(255, 255, 255, 0.2)',
+              color: 'rgba(255, 255, 255, 0.7)',
+              background: 'rgba(255, 255, 255, 0.03)',
+            },
+            '@keyframes subtleBounce': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(3px)' },
+            },
+            animation: 'subtleBounce 2.5s ease-in-out infinite',
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Explore
+          <KeyboardArrowDownIcon sx={{ fontSize: '1rem' }} />
         </Box>
       </Box>
 
@@ -237,7 +247,6 @@ const HeroChat = () => {
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +255,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #818cf8, #c084fc)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
               fontWeight: 800,
-              fontSize: '1rem',
+              fontSize: '0.9rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +276,30 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2, color: '#fafafa' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255, 255, 255, 0.3)', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255, 255, 255, 0.2)' }}>
+            scroll down for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+            background: 'rgba(9, 9, 11, 0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +307,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -68,7 +68,7 @@ const Logo = () => {
         <path
           className="bracket-left"
           d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -77,7 +77,7 @@ const Logo = () => {
         <path
           className="bracket-right"
           d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -99,7 +99,7 @@ const Logo = () => {
           width="40"
           height="26"
           rx="2"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="4"
           opacity="0"
           style={{ transformOrigin: 'center' }}
@@ -108,7 +108,7 @@ const Logo = () => {
         {/* Code Content on Screen - Adjusted for new rectangle position */}
         <g className="monitor-code" opacity="0">
           <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
+          <path className="code-line" d="M35 45H60" stroke="#818cf8" strokeWidth="2.5" strokeLinecap="round" />
           <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
         </g>
         

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -7,12 +7,15 @@ import Logo from './Logo';
 import './ScrollLink.css';
 
 const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
+  margin: '0 20px',
+  fontWeight: 500,
   textDecoration: 'none',
   cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
+  fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+  transition: 'color 0.2s ease',
+  fontSize: '0.85rem',
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
 };
 
 const FormattedLink = ({ page, active, setActivePage }) => {
@@ -27,10 +30,8 @@ const FormattedLink = ({ page, active, setActivePage }) => {
       className="scroll-link"
       style={{
         ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+        color: active ? '#818cf8' : 'rgba(255, 255, 255, 0.4)',
+        fontWeight: active ? 600 : 500,
       }}
     >
       {page}
@@ -50,16 +51,24 @@ const NavBar = () => {
         top: 0,
         zIndex: 1100,
         width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
+        bgcolor: 'rgba(9, 9, 11, 0.8)',
+        backdropFilter: 'blur(20px) saturate(180%)',
+        height: '60px',
+        color: '#fafafa',
         transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
+        borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
         boxShadow: 'none',
       }}
     >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
+      <Toolbar
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: { xs: 2, md: 5 },
+          minHeight: '60px !important',
+        }}
+      >
         <Box
           sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
@@ -69,14 +78,13 @@ const NavBar = () => {
             variant="h6"
             component="div"
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              fontWeight: 700,
+              letterSpacing: '-0.02em',
+              fontSize: '1.1rem',
+              color: '#fafafa',
             }}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
+            david<span style={{ color: '#818cf8' }}>riva</span>
           </Typography>
         </Box>
 

--- a/next-app/src/components/Navbar/ScrollLink.css
+++ b/next-app/src/components/Navbar/ScrollLink.css
@@ -1,26 +1,24 @@
 .scroll-link {
-    font-size: 0.9rem; /* Default font size for xs */
+  font-size: 0.8rem;
+  position: relative;
 }
-  
+
 @media (min-width: 600px) {
-    .scroll-link {
-        font-size: 1rem; /* Font size for sm */
-    }
+  .scroll-link {
+    font-size: 0.82rem;
+  }
 }
 
 @media (min-width: 900px) {
-    .scroll-link {
-        font-size: 1.2rem; /* Font size for md */
-    }
+  .scroll-link {
+    font-size: 0.85rem;
+  }
 }
 
-/* Hover effect */
 .scroll-link:hover {
-    color: #fff;
-    transform: scale(1.1);
+  color: #fafafa !important;
 }
-  
-/* Click effect (active state) */
+
 .scroll-link:active {
-    transform: scale(0.95);
+  opacity: 0.7;
 }

--- a/next-app/src/components/ParticleBackground.js
+++ b/next-app/src/components/ParticleBackground.js
@@ -5,7 +5,6 @@ import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import baseOptions from '../particles-options/parallax-bubble.json';
 
-// Start engine initialization immediately on module load, not on component mount
 const engineReady = initParticlesEngine(async (engine) => {
   await loadSlim(engine);
 });
@@ -26,7 +25,7 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.background,
         color: {
           ...baseOptions.background?.color,
-          value: isTransparent ? '#000000' : (backgroundColor || '#0b0920'),
+          value: isTransparent ? '#000000' : (backgroundColor || '#09090b'),
         },
         opacity: isTransparent ? 0 : (baseOptions.background?.opacity ?? 1),
       },
@@ -34,14 +33,23 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.particles,
         color: {
           ...baseOptions.particles?.color,
-          value: '#ffffff',
+          value: '#818cf8',
+        },
+        opacity: {
+          ...baseOptions.particles?.opacity,
+          value: { min: 0.02, max: 0.06 },
         },
         links: baseOptions.particles?.links
           ? {
               ...baseOptions.particles.links,
-              color: { ...baseOptions.particles.links.color, value: '#ffffff' },
+              color: { ...baseOptions.particles.links.color, value: '#818cf8' },
+              opacity: 0.04,
             }
           : baseOptions.particles?.links,
+        number: {
+          ...baseOptions.particles?.number,
+          value: 200,
+        },
       },
       interactivity: interactive ? baseOptions.interactivity : undefined,
     }),

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,169 +2,160 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Card, Chip, Stack } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
         id={id}
+        component="a"
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(255, 255, 255, 0.02)',
+          color: '#fafafa',
+          border: '1px solid rgba(255, 255, 255, 0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          cursor: 'pointer',
+          textDecoration: 'none',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: 'rgba(129, 140, 248, 0.2)',
+            background: 'rgba(129, 140, 248, 0.03)',
+            boxShadow: '0 16px 48px rgba(0, 0, 0, 0.3)',
+            '& .project-image': { transform: 'scale(1.04)' },
+            '& .launch-icon': { opacity: 1, transform: 'translate(0, 0)' },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? 200 : 160,
+            width: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
-        </CardContent>
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 30%, rgba(9, 9, 11, 0.8) 100%)',
+            }}
+          />
+          <Box
+            className="launch-icon"
+            sx={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              width: 30,
+              height: 30,
+              borderRadius: '8px',
+              bgcolor: 'rgba(9, 9, 11, 0.6)',
+              backdropFilter: 'blur(8px)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: 0,
+              transform: 'translate(4px, -4px)',
+              transition: 'all 0.3s ease',
+            }}
+          >
+            <LaunchIcon sx={{ fontSize: '0.85rem', color: '#818cf8' }} />
+          </Box>
+        </Box>
+
+        <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: { xs: 2, sm: 2.5 } }}>
+          <Typography
+            component="h3"
+            sx={{
+              fontWeight: 700,
+              fontSize: featured ? '1rem' : '0.9rem',
+              color: '#fafafa',
+              lineHeight: 1.3,
+              mb: 0.5,
+            }}
+          >
+            {title}
+          </Typography>
+
+          <Typography
+            variant="caption"
+            sx={{ color: 'rgba(255, 255, 255, 0.25)', display: 'block', mb: 1.5, fontSize: '0.72rem' }}
+          >
+            {dateStarted} – {dateCompleted}
+          </Typography>
+
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'rgba(255, 255, 255, 0.45)',
+              lineHeight: 1.6,
+              mb: 2,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              fontSize: '0.8rem',
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 'auto' }}>
+            {allTools.slice(0, 5).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(129, 140, 248, 0.06)',
+                  color: 'rgba(129, 140, 248, 0.8)',
+                  border: '1px solid rgba(129, 140, 248, 0.1)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 5 && (
+              <Chip
+                label={`+${allTools.length - 5}`}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.04)',
+                  color: 'rgba(255, 255, 255, 0.3)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  fontWeight: 500,
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            )}
+          </Stack>
+        </Box>
       </Card>
     );
   }

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -10,18 +10,14 @@ const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1200px',
+        mx: 'auto',
+        pt: { xs: '80px', md: '120px' },
+        pb: { xs: '60px', md: '80px' },
+        px: { xs: 2, sm: 3, md: 6 },
       }}
     >
       <SectionHeading sectionName="Projects" />
-
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,14 +18,14 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        duration: 0.6,
+        stagger: 0.1,
+        ease: 'power2.out',
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
       }
     );
     ScrollTrigger.refresh();
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -52,16 +52,12 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.5, stagger: 0.06, ease: 'power2.out' });
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,58 +88,77 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.02)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(255, 255, 255, 0.06)',
+                  overflow: 'hidden',
+                }}
+              >
+                <Skeleton
+                  variant="rectangular"
+                  height={200}
+                  sx={{ bgcolor: 'rgba(255, 255, 255, 0.04)' }}
+                />
+                <Box sx={{ p: 2.5 }}>
+                  <Skeleton variant="text" sx={{ fontSize: '1.2rem', bgcolor: 'rgba(255, 255, 255, 0.04)' }} />
+                  <Skeleton variant="text" width="50%" sx={{ bgcolor: 'rgba(255, 255, 255, 0.04)' }} />
+                  <Skeleton
+                    variant="text"
+                    sx={{ mt: 1, bgcolor: 'rgba(255, 255, 255, 0.04)' }}
+                    height={48}
+                  />
+                </Box>
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
-            <Button
-              onClick={() => setShowAll((prev) => !prev)}
-              endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-              sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
-                px: 3,
-                py: 0.85,
-                textTransform: 'none',
-                fontSize: '0.85rem',
-                fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
-                },
-              }}
-            >
-              {showAll ? 'Show less' : `View all ${projectData.length} projects`}
-            </Button>
-          </Box>
+          {otherProjects.length > 0 && (
+            <>
+              <Box sx={{ mt: 4, textAlign: 'center' }}>
+                <Button
+                  onClick={() => setShowAll((prev) => !prev)}
+                  endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                  sx={{
+                    color: 'rgba(255, 255, 255, 0.4)',
+                    borderColor: 'rgba(255, 255, 255, 0.08)',
+                    border: '1px solid',
+                    borderRadius: '999px',
+                    px: 3,
+                    py: 0.75,
+                    textTransform: 'none',
+                    fontSize: '0.82rem',
+                    fontWeight: 500,
+                    transition: 'all 0.2s ease',
+                    '&:hover': {
+                      bgcolor: 'rgba(255, 255, 255, 0.04)',
+                      borderColor: 'rgba(255, 255, 255, 0.15)',
+                      color: 'rgba(255, 255, 255, 0.7)',
+                    },
+                  }}
+                >
+                  {showAll ? 'Show less' : `View all ${projectData.length} projects`}
+                </Button>
+              </Box>
 
-          <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
-            </Box>
-          </Collapse>
-        </Box>
+              <Collapse in={showAll} timeout={400}>
+                <Box sx={{ mt: 3 }}>
+                  <AllProjects projects={otherProjects} />
+                </Box>
+              </Collapse>
+            </>
+          )}
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -2,39 +2,33 @@ import { Box, Typography } from '@mui/material';
 
 const SectionHeading = ({ sectionName }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: { xs: 5, md: 6 }, pt: 2 }}>
       <Typography
         variant="h2"
         sx={{
           fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
+          color: '#fafafa',
+          fontSize: { xs: '2.2rem', sm: '2.8rem', md: '3.2rem' },
+          letterSpacing: '-0.03em',
           lineHeight: 1.1,
-          textAlign: 'center',
+          textAlign: { xs: 'center', md: 'left' },
           position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          display: 'inline-block',
         }}
       >
         {sectionName}
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: '-8px',
+            left: { xs: '50%', md: 0 },
+            transform: { xs: 'translateX(-50%)', md: 'none' },
+            width: '40px',
+            height: '3px',
+            background: 'linear-gradient(90deg, #818cf8, #c084fc)',
+            borderRadius: '2px',
+          }}
+        />
       </Typography>
     </Box>
   );

--- a/next-app/src/components/StyledButton.jsx
+++ b/next-app/src/components/StyledButton.jsx
@@ -8,32 +8,30 @@ const StyledButton = ({ href, onClick, text, icon, component, ...props }) => {
       component={component}
       {...props}
       sx={{
-        marginTop: '20px',
-        backgroundColor: 'rgba(10, 115, 201, 0.15)',
-        border: '2px solid #38c0f2',
-        borderRadius: '50px',
-        padding: '12px 24px',
-        color: '#38c0f2',
+        mt: 2,
+        backgroundColor: 'rgba(129, 140, 248, 0.08)',
+        border: '1px solid rgba(129, 140, 248, 0.3)',
+        borderRadius: '12px',
+        padding: '10px 24px',
+        color: '#818cf8',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: '10px',
-        fontWeight: 'bold',
-        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
-        transition: 'all 0.3s ease-in-out',
+        gap: '8px',
+        fontWeight: 600,
         textTransform: 'none',
+        transition: 'all 0.2s ease',
         '&:hover': {
-          backgroundColor: 'rgba(10, 115, 201, 0.3)',
-          transform: 'scale(1.05)',
-          boxShadow: '0px 6px 8px rgba(0, 0, 0, 0.15)',
+          backgroundColor: 'rgba(129, 140, 248, 0.12)',
+          borderColor: 'rgba(129, 140, 248, 0.5)',
         },
       }}
     >
       <Typography
         sx={{
-          color: '#38c0f2',
-          fontSize: { xs: '0.9rem', sm: '1rem', md: '1.1rem' },
-          fontWeight: '500',
+          color: '#818cf8',
+          fontSize: { xs: '0.85rem', sm: '0.9rem', md: '0.95rem' },
+          fontWeight: 500,
         }}
       >
         {text}

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,33 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: 'rgba(255, 255, 255, 0.5)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#818cf8',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#c084fc',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.03em', lineHeight: 1.0 },
+    h2: { fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.01em' },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7, color: 'rgba(255, 255, 255, 0.7)' },
+    body2: { fontWeight: 400, lineHeight: 1.6, color: 'rgba(255, 255, 255, 0.5)' },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual redesign of the portfolio, replacing the 2023 glassmorphic cyan/purple theme with a refined "Midnight Studio" design language optimized for 2026 UI/UX trends.

- **New color system**: Near-black background (`#09090b`), indigo-violet accent gradient (`#818cf8` → `#c084fc`), subtle grain texture overlay — replaces the previous cyan (`#38c0f2`) / purple (`#6e40c9`) palette
- **Refined typography**: Tighter letter-spacing, larger hero text with gradient fill, more font weights loaded (400–900), reduced visual noise
- **Layout improvements**: Horizontal experience cards (replacing vertical timeline), side-by-side contact form fields, left-aligned section headings with subtle gradient underline, fixed back-to-top button, minimal inline footer
- **Modern interactions**: Hover-reveal launch icons on project cards, capped tech chip display (`+N` overflow), subtler particle effects (indigo-tinted, reduced count/opacity), cleaner scroll-to-explore button with gentle bounce animation

All 29 component files updated for color and layout consistency. No API routes, data files, or chat functionality were modified — only visual presentation layer.

### Design details

| Element | Before | After |
|---|---|---|
| Background | `#0b0920` deep blue | `#09090b` near-black |
| Primary accent | `#38c0f2` cyan | `#818cf8` indigo |
| Secondary accent | `#6e40c9` purple | `#c084fc` violet |
| Headshot | Circle with gradient ring | Rounded rectangle with soft glow |
| Timeline | Vertical MUI Timeline | Horizontal scrolling cards |
| Navbar brand | `DAVIDRIVA` uppercase | `davidriva` lowercase |
| Section headings | Centered, 4rem, wide underline | Left-aligned, 3.2rem, 40px gradient bar |
| Contact form | Full-width stacked fields | Name/email side-by-side, left-aligned |
| Footer | Centered copyright + scroll button | Inline copyright + social icons, fixed FAB |

## Test plan

- [ ] Verify homepage loads with new dark background and indigo accent colors
- [ ] Confirm hero section displays large gradient "David Riva" text with typing animation
- [ ] Test AI chat interaction (pre-chat chips, send message, chat-active view)
- [ ] Verify About section layout: headshot left, bio right, horizontal experience cards below
- [ ] Check Projects section: featured cards render with hover effects and launch icons
- [ ] Expand "View all projects" and confirm remaining cards appear
- [ ] Submit contact form (with Turnstile verification)
- [ ] Test responsive layout at mobile (375px), tablet (768px), and desktop (1440px) breakpoints
- [ ] Verify navbar scroll-spy highlights active section
- [ ] Confirm back-to-top button appears after scrolling and works correctly
- [ ] Run `npm run build` — passes cleanly
- [ ] Run `npm run lint` — no warnings or errors

https://claude.ai/code/session_016tksozkr8rz7JbPGKYQa2o

---
_Generated by [Claude Code](https://claude.ai/code/session_016tksozkr8rz7JbPGKYQa2o)_