### PR TITLE
Complete portfolio redesign with modern 2026 design system

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,40 +2,54 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter, Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+});
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['400', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in applied AI, full-stack development, and data visualization. View projects involving React, Next.js, LangChain, and distributed systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'AI Engineer',
+    'React Developer',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: "David Riva's portfolio preview",
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +57,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={`${inter.variable} ${montserrat.variable}`} style={{ overflowX: 'hidden' }}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
@@ -15,8 +16,8 @@ const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         position: 'relative',
         minHeight: '100vh',
       }}
@@ -27,40 +28,70 @@ const MainPage = () => {
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(99, 102, 241, 0.12) 0%, transparent 70%)',
+          overflow: 'hidden',
         }}
       >
         <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <Box
           id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
+            position: 'relative',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '60%',
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+            },
           }}
         >
           <About />
         </Box>
 
         <Box
+          id="experience"
+          sx={{
+            position: 'relative',
+            width: '100%',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '60%',
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+            },
+          }}
+        >
+          <Experience />
+        </Box>
+
+        <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
+            position: 'relative',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '60%',
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+            },
           }}
         >
           <Projects />
@@ -69,9 +100,18 @@ const MainPage = () => {
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
+            position: 'relative',
             width: '100%',
-            color: '#ffffff',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '60%',
+              height: '1px',
+              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)',
+            },
           }}
         >
           <Contact />

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,229 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
+import { Box, Typography, Button, IconButton, Link } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import SectionHeading from '@/components/SectionHeading';
+
+const cardSx = {
+  background: 'rgba(255, 255, 255, 0.025)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '16px',
+  p: { xs: 3, md: 4 },
+  transition: 'border-color 0.3s ease, background 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+    background: 'rgba(255, 255, 255, 0.035)',
+  },
 };
 
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, sm: 3, md: 6 },
+        py: { xs: 8, md: 12 },
       }}
     >
+      <SectionHeading sectionName="About" />
+
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 1fr' },
+          gridTemplateRows: { xs: 'auto', md: 'auto auto' },
+          gap: 2.5,
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Photo + Name card */}
+        <Box
+          sx={{
+            ...cardSx,
+            gridColumn: { xs: '1', md: '1' },
+            gridRow: { xs: 'auto', md: '1 / 3' },
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            gap: 3,
+          }}
+        >
+          <Box
+            sx={{
+              width: 160,
+              height: 160,
+              borderRadius: '20px',
+              overflow: 'hidden',
+              border: '2px solid rgba(255, 255, 255, 0.08)',
+              flexShrink: 0,
+            }}
+          >
+            <Image
+              alt="Photo of David Riva"
+              src="/images/headshot.webp"
+              width={160}
+              height={160}
+              style={{ objectFit: 'cover' }}
+              priority={true}
+            />
+          </Box>
+
+          <Box>
+            <Typography
+              variant="h3"
+              sx={{ fontSize: '1.5rem', fontWeight: 700, mb: 0.5 }}
+            >
+              David Riva
+            </Typography>
+            <Typography sx={{ color: '#818cf8', fontSize: '0.9rem', fontWeight: 500, mb: 1 }}>
+              Training Engineer, Generative AI
+            </Typography>
+            <Typography sx={{ color: 'rgba(255, 255, 255, 0.4)', fontSize: '0.85rem' }}>
+              Bay Area, CA
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+              <IconButton
+                aria-label="GitHub Profile"
+                sx={{
+                  color: 'rgba(255,255,255,0.5)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '10px',
+                  width: 40,
+                  height: 40,
+                  transition: 'all 0.2s ease',
+                  '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.25)', background: 'rgba(255,255,255,0.05)' },
+                }}
+              >
+                <GitHubIcon sx={{ fontSize: '1.2rem' }} />
+              </IconButton>
+            </Link>
+            <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+              <IconButton
+                aria-label="LinkedIn Profile"
+                sx={{
+                  color: 'rgba(255,255,255,0.5)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '10px',
+                  width: 40,
+                  height: 40,
+                  transition: 'all 0.2s ease',
+                  '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.25)', background: 'rgba(255,255,255,0.05)' },
+                }}
+              >
+                <LinkedInIcon sx={{ fontSize: '1.2rem' }} />
+              </IconButton>
+            </Link>
+            <Link href="mailto:davidjriva@gmail.com">
+              <IconButton
+                aria-label="Email"
+                sx={{
+                  color: 'rgba(255,255,255,0.5)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '10px',
+                  width: 40,
+                  height: 40,
+                  transition: 'all 0.2s ease',
+                  '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.25)', background: 'rgba(255,255,255,0.05)' },
+                }}
+              >
+                <EmailOutlinedIcon sx={{ fontSize: '1.2rem' }} />
+              </IconButton>
+            </Link>
+          </Box>
+
+          <Button
+            variant="outlined"
+            onClick={() => window.open('/documents/resume.pdf', '_blank')}
+            endIcon={<OpenInNewIcon sx={{ fontSize: '0.85rem !important' }} />}
+            sx={{
+              color: 'rgba(255,255,255,0.6)',
+              borderColor: 'rgba(255,255,255,0.12)',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '0.82rem',
+              fontWeight: 500,
+              px: 2.5,
+              py: 0.8,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                borderColor: 'rgba(255,255,255,0.3)',
+                color: '#fafafa',
+                background: 'rgba(255,255,255,0.04)',
+              },
+            }}
+          >
+            View Resume
+          </Button>
         </Box>
-      </Box>
 
-      <AboutTextSection />
+        {/* Bio card */}
+        <Box sx={{ ...cardSx, gridColumn: { xs: '1', md: '2 / 4' } }}>
+          <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.35)', mb: 2, display: 'block' }}>
+            BIOGRAPHY
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.7)', mb: 2 }}>
+            Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado State
+            University, where I received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m
+            incredibly passionate about software &amp; applied AI engineering.
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.7)', mb: 2 }}>
+            I&apos;m experienced in full-stack development, data engineering, and big data visualization.
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.7)' }}>
+            I have a strong background in data structures, algorithms, and mathematical applications. I pride myself on
+            elegant problem-solving and my dedication to maintaining high standards of excellence.
+          </Typography>
+        </Box>
 
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
+        {/* Awards card */}
+        <Box sx={{ ...cardSx, gridColumn: { xs: '1', md: '2 / 4' } }}>
+          <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.35)', mb: 2.5, display: 'block' }}>
+            RECOGNITION
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {[
+              { title: '1st Place — C3 Agentic AI Hackathon', meta: 'May 2025 · 400+ participants' },
+              { title: 'Summa Cum Laude', meta: 'May 2024 · 4.0 GPA' },
+              { title: 'Excellence in Data Science Award', meta: 'April 2023 · CSU Research Competition' },
+              { title: "Dean's List", meta: 'Fall 2021 – Spring 2024 · All semesters' },
+            ].map((award) => (
+              <Box
+                key={award.title}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 1.5,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    background: '#818cf8',
+                    mt: 1,
+                    flexShrink: 0,
+                  }}
+                />
+                <Box>
+                  <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', color: '#fafafa', lineHeight: 1.4 }}>
+                    {award.title}
+                  </Typography>
+                  <Typography sx={{ color: 'rgba(255,255,255,0.35)', fontSize: '0.8rem' }}>{award.meta}</Typography>
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -12,14 +12,14 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
-        borderRadius: '999px',
+        p: '6px 8px',
+        borderRadius: '14px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        border: '1px solid rgba(255,255,255,0.1)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.2)' },
+        '&:focus-within': { borderColor: 'rgba(129, 140, 248, 0.5)' },
       }}
     >
       <InputBase
@@ -34,24 +34,29 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontSize: '0.9rem',
+          fontFamily: 'var(--font-inter), system-ui, sans-serif',
+          '& input::placeholder': { color: 'rgba(255,255,255,0.3)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          ml: 0.5,
+          width: 34,
+          height: 34,
+          borderRadius: '10px',
+          background: '#818cf8',
+          transition: 'all 0.15s ease',
+          '&:hover': { background: '#6366f1' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.06)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <ArrowUpwardIcon sx={{ color: '#fff', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,59 +7,58 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#fafafa',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
           px: 2.5,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(129, 140, 248, 0.1)' : 'rgba(255,255,255,0.04)',
+          border: isUser ? '1px solid rgba(129, 140, 248, 0.18)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={7} dotColor="#818cf8" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
+                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 600 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#a5b4fc',
+                      backgroundColor: 'rgba(129, 140, 248, 0.08)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
                       display: 'inline',
+                      fontSize: '0.85rem',
                     }}
                     {...props}
                   />
@@ -67,18 +66,27 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.4)',
+                      color: '#fafafa',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.85rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a style={{ color: '#a5b4fc', textDecoration: 'none' }} target="_blank" rel="noopener" {...props} />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { Box } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
@@ -7,33 +6,17 @@ const Contact = () => {
   return (
     <Box
       sx={{
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, sm: 3, md: 6 },
+        py: { xs: 8, md: 12 },
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
-        <ContactForm />
-      </Box>
+      <SectionHeading sectionName="Contact" subtitle="Have a question or want to work together? Reach out." />
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,17 +3,21 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.35)', fontSize: '0.9rem' },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    borderRadius: '12px',
+    backgroundColor: 'rgba(255, 255, 255, 0.025)',
+    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.18)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(129, 140, 248, 0.5)' },
   },
+  '& .MuiInputLabel-root.Mui-focused': { color: '#818cf8' },
 };
 
 const ContactForm = () => {
@@ -49,21 +53,40 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
+        maxWidth: '640px',
+        background: 'rgba(255, 255, 255, 0.025)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        color: '#fafafa',
+        p: { xs: 3, sm: 4, md: 5 },
+        borderRadius: '20px',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2, mb: 2 }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField
+            fullWidth
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            sx={inputSx}
+          />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField
+          fullWidth
+          label="Message"
+          name="message"
+          multiline
+          rows={5}
+          value={formData.message}
+          onChange={handleChange}
+          required
+          sx={inputSx}
+        />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +101,25 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '1rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            py: 1.5,
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            background: '#818cf8',
+            color: '#fff',
+            borderRadius: '12px',
+            textTransform: 'none',
+            boxShadow: 'none',
+            transition: 'all 0.2s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: '#6366f1',
+              boxShadow: '0 4px 20px rgba(129, 140, 248, 0.25)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255, 255, 255, 0.06)',
+              color: 'rgba(255, 255, 255, 0.25)',
             },
           }}
         >
@@ -103,9 +131,10 @@ const ContactForm = () => {
         <Typography
           variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2.5,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            color: status.includes('success') ? '#34d399' : '#f87171',
+            fontSize: '0.85rem',
           }}
         >
           {status}

--- a/next-app/src/components/Experience/Experience.js
+++ b/next-app/src/components/Experience/Experience.js
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const cardSx = {
+  background: 'rgba(255, 255, 255, 0.025)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '16px',
+  p: { xs: 3, md: 4 },
+  transition: 'border-color 0.3s ease, background 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+    background: 'rgba(255, 255, 255, 0.035)',
+  },
+};
+
+const SKILLS_DATA = [
+  { category: 'Languages', items: ['Python', 'TypeScript', 'Java', 'HTML5', 'CSS3'] },
+  {
+    category: 'AI & ML',
+    items: ['LangChain', 'LangGraph', 'LangSmith', 'RAG Pipelines', 'Pinecone', 'TensorFlow'],
+  },
+  { category: 'Web', items: ['React', 'Next.js', 'Node.js', 'Express.js'] },
+  { category: 'Data', items: ['Apache Spark', 'PySpark', 'Databricks', 'AWS Redshift'] },
+  { category: 'Databases', items: ['MongoDB', 'PostgreSQL', 'Redis'] },
+  { category: 'Testing', items: ['Pytest', 'RAGAS', 'DeepEval', 'Jest', 'JUnit'] },
+];
+
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, location, startDate, endDate, bulletPoints }) => {
+  const isCurrent = endDate === 'Present' || new Date(endDate) > new Date('2026-01-01');
+  const isGraduation = title.startsWith('Graduated');
+
+  return (
+    <Box sx={{ ...cardSx, position: 'relative' }} className="exp-card">
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 2.5 }}>
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            borderRadius: '12px',
+            overflow: 'hidden',
+            border: '1px solid rgba(255,255,255,0.08)',
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#fff',
+          }}
+        >
+          <Image
+            src={`/images/${logoImage}`}
+            alt={`${company} logo`}
+            width={32}
+            height={32}
+            style={{ objectFit: 'contain' }}
+          />
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '1rem', color: '#fafafa', lineHeight: 1.3 }}>
+              {isGraduation ? 'B.S. Computer Science, Summa Cum Laude' : title.split(',')[0]}
+            </Typography>
+            {isCurrent && !isGraduation && (
+              <Chip
+                label="Current"
+                size="small"
+                sx={{
+                  height: 22,
+                  bgcolor: 'rgba(52, 211, 153, 0.1)',
+                  color: '#34d399',
+                  border: '1px solid rgba(52, 211, 153, 0.2)',
+                  fontSize: '0.7rem',
+                  fontWeight: 600,
+                }}
+              />
+            )}
+          </Box>
+          <Typography
+            component="a"
+            href={companyWebsiteLink}
+            target="_blank"
+            rel="noopener"
+            sx={{
+              color: '#818cf8',
+              textDecoration: 'none',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              display: 'inline-block',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            {company}
+          </Typography>
+          <Typography sx={{ color: 'rgba(255,255,255,0.35)', fontSize: '0.78rem', mt: 0.25 }}>
+            {location} · {isGraduation ? startDate : `${startDate} – ${isCurrent ? 'Present' : endDate}`}
+          </Typography>
+        </Box>
+      </Box>
+
+      {bulletPoints && bulletPoints.length > 0 && (
+        <Box component="ul" sx={{ m: 0, pl: 2.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {bulletPoints.slice(0, 3).map((point, i) => (
+            <Box component="li" key={i} sx={{ color: 'rgba(255,255,255,0.55)', fontSize: '0.85rem', lineHeight: 1.6 }}>
+              {point}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const Experience = () => {
+  const [experienceData, setExperienceData] = useState([]);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setExperienceData(sorted);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current || experienceData.length === 0) return;
+    const cards = containerRef.current.querySelectorAll('.exp-card');
+    gsap.fromTo(
+      cards,
+      { y: 30, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.6,
+        stagger: 0.1,
+        ease: 'power2.out',
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
+      }
+    );
+    return () => ScrollTrigger.getAll().forEach((t) => t.kill());
+  }, [experienceData]);
+
+  return (
+    <Box
+      sx={{
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, sm: 3, md: 6 },
+        py: { xs: 8, md: 12 },
+      }}
+    >
+      <SectionHeading sectionName="Experience" />
+
+      <Box
+        ref={containerRef}
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr' },
+          gap: 2.5,
+          mb: 6,
+        }}
+      >
+        {experienceData.map((exp) => (
+          <ExperienceCard key={exp.title} {...exp} />
+        ))}
+      </Box>
+
+      {/* Skills */}
+      <Box sx={{ ...cardSx }}>
+        <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.35)', mb: 3, display: 'block' }}>
+          TECHNICAL SKILLS
+        </Typography>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr 1fr', sm: '1fr 1fr 1fr' },
+            gap: { xs: 3, md: 4 },
+          }}
+        >
+          {SKILLS_DATA.map((group) => (
+            <Box key={group.category}>
+              <Typography sx={{ fontWeight: 600, fontSize: '0.82rem', color: '#818cf8', mb: 1.5, letterSpacing: '0.02em' }}>
+                {group.category}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.75}>
+                {group.items.map((item) => (
+                  <Chip
+                    key={item}
+                    label={item}
+                    size="small"
+                    sx={{
+                      height: 26,
+                      bgcolor: 'rgba(255,255,255,0.04)',
+                      color: 'rgba(255,255,255,0.6)',
+                      border: '1px solid rgba(255,255,255,0.07)',
+                      fontSize: '0.75rem',
+                      fontWeight: 500,
+                      '& .MuiChip-label': { px: 1.2 },
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,58 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, IconButton, Link } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
 import ReturnToTopButton from './ReturnToTopButton';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        position: 'relative',
         width: '100%',
-        height: '10vh',
+        py: 6,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        gap: 3,
+        borderTop: '1px solid rgba(255,255,255,0.06)',
       }}
     >
       <ReturnToTopButton />
+
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        {[
+          { icon: <GitHubIcon sx={{ fontSize: '1.1rem' }} />, href: 'https://github.com/davidjriva', label: 'GitHub' },
+          { icon: <LinkedInIcon sx={{ fontSize: '1.1rem' }} />, href: 'https://www.linkedin.com/in/david-j-riva', label: 'LinkedIn' },
+          { icon: <EmailOutlinedIcon sx={{ fontSize: '1.1rem' }} />, href: 'mailto:davidjriva@gmail.com', label: 'Email' },
+        ].map((social) => (
+          <Link key={social.label} href={social.href} target={social.label !== 'Email' ? '_blank' : undefined} rel="noopener">
+            <IconButton
+              aria-label={social.label}
+              sx={{
+                color: 'rgba(255,255,255,0.3)',
+                width: 36,
+                height: 36,
+                transition: 'color 0.2s ease',
+                '&:hover': { color: 'rgba(255,255,255,0.7)' },
+              }}
+            >
+              {social.icon}
+            </IconButton>
+          </Link>
+        ))}
+      </Box>
+
       <Typography
-        variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
+          color: 'rgba(255, 255, 255, 0.2)',
+          fontSize: '0.78rem',
           textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        David Riva &copy; {new Date().getFullYear()}
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Footer/ReturnToTopButton.js
+++ b/next-app/src/components/Footer/ReturnToTopButton.js
@@ -2,13 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { IconButton, Box } from '@mui/material';
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const ReturnToTopButton = () => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 200);
+    const onScroll = () => setVisible(window.scrollY > 300);
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
@@ -18,27 +18,31 @@ const ReturnToTopButton = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#38c0f2',
-        borderRadius: '8px',
-        padding: '4px',
-        maxWidth: '50px',
-        margin: '0 auto',
-        '@keyframes jump': {
-          '0%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-5px)' },
-          '100%': { transform: 'translateY(0)' },
-        },
-        '&:hover': { animation: 'jump 1s infinite' },
+        position: 'fixed',
+        bottom: 24,
+        right: 24,
+        zIndex: 50,
       }}
     >
       <IconButton
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        sx={{ color: 'white', fontSize: '1.5rem', padding: '4px' }}
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: '10px',
+          background: 'rgba(255,255,255,0.06)',
+          border: '1px solid rgba(255,255,255,0.1)',
+          color: 'rgba(255,255,255,0.5)',
+          backdropFilter: 'blur(12px)',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            background: 'rgba(255,255,255,0.1)',
+            borderColor: 'rgba(255,255,255,0.2)',
+            color: '#fafafa',
+          },
+        }}
       >
-        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 'inherit' }} />
+        <KeyboardArrowUpIcon sx={{ fontSize: '1.2rem' }} />
       </IconButton>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -6,78 +6,67 @@ import { Typography } from '@mui/material';
 const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
     const currentRole = `${ROLES[roleIndex]}.`;
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
-      timer = setTimeout(() => {
-        setText((prev) => prev + currentRole[index]);
-        setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev + currentRole[index]);
+          setIndex((prev) => prev + 1);
+        },
+        80 + Math.random() * 40
+      );
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 1400);
     } else if (deleting && index > 0) {
-      // Deleting logic
-      timer = setTimeout(() => {
-        setText((prev) => prev.slice(0, -1));
-        setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      timer = setTimeout(
+        () => {
+          setText((prev) => prev.slice(0, -1));
+          setIndex((prev) => prev - 1);
+        },
+        35 + Math.random() * 25
+      );
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
+    const blinkCursor = setInterval(() => setCursorVisible((prev) => !prev), 400);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontFamily: 'var(--font-inter), system-ui, sans-serif',
+        fontSize: { xs: '1.1rem', sm: '1.3rem', md: '1.5rem' },
+        fontWeight: 400,
+        color: 'rgba(255, 255, 255, 0.5)',
+        lineHeight: 1.4,
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      I&apos;m {getArticle(ROLES[roleIndex])}{' '}
+      <span style={{ color: 'rgba(255, 255, 255, 0.8)' }}>{text}</span>
+      <span style={{ color: '#818cf8', opacity: cursorVisible ? 1 : 0, transition: 'opacity 0.1s' }}>|</span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -42,30 +42,27 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 const CHIPS = [
   {
     label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
+    bg: 'rgba(129, 140, 248, 0.1)',
+    border: 'rgba(129, 140, 248, 0.3)',
+    color: '#a5b4fc',
+    hoverBg: 'rgba(129, 140, 248, 0.18)',
+    hoverBorder: 'rgba(129, 140, 248, 0.6)',
   },
   {
     label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
+    bg: 'rgba(52, 211, 153, 0.08)',
+    border: 'rgba(52, 211, 153, 0.25)',
+    color: '#6ee7b7',
+    hoverBg: 'rgba(52, 211, 153, 0.16)',
+    hoverBorder: 'rgba(52, 211, 153, 0.5)',
   },
   {
     label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
+    bg: 'rgba(255, 255, 255, 0.05)',
+    border: 'rgba(255, 255, 255, 0.15)',
+    color: 'rgba(255, 255, 255, 0.6)',
+    hoverBg: 'rgba(255, 255, 255, 0.1)',
+    hoverBorder: 'rgba(255, 255, 255, 0.35)',
   },
 ];
 
@@ -79,7 +76,7 @@ const HeroChat = () => {
     const section = document.getElementById('about');
     if (!section) return;
     const elementPosition = section.getBoundingClientRect().top + window.scrollY;
-    window.scrollTo({ top: elementPosition - 70, behavior: 'smooth' });
+    window.scrollTo({ top: elementPosition - 80, behavior: 'smooth' });
   };
 
   const handleSend = () => {
@@ -89,8 +86,8 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#fafafa', zIndex: 1 }}>
+      {/* Pre-chat hero */}
       <Box
         sx={{
           position: 'absolute',
@@ -99,46 +96,71 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease-out, transform 400ms ease-out',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
-        <Typography
-          variant="h1"
-          sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
-            textAlign: 'center',
-          }}
-        >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
-        </Typography>
+        <Box sx={{ textAlign: 'center', mb: 1 }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: '#818cf8',
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              letterSpacing: '0.12em',
+              mb: 2,
+              display: 'block',
+            }}
+          >
+            SOFTWARE ENGINEER
+          </Typography>
 
-        <AnimatedTypingTypography />
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: { xs: 'clamp(2.2rem, 8vw, 3.5rem)', md: 'clamp(3rem, 5vw, 4.5rem)' },
+              fontWeight: 800,
+              lineHeight: 1.05,
+              mb: 1.5,
+            }}
+          >
+            Hello, I&apos;m{' '}
+            <Box
+              component="span"
+              sx={{
+                background: 'linear-gradient(135deg, #818cf8 0%, #a78bfa 50%, #c084fc 100%)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+              }}
+            >
+              David
+            </Box>
+          </Typography>
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+          <AnimatedTypingTypography />
+        </Box>
+
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask my AI anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="body2" sx={{ color: 'rgba(248, 113, 113, 0.85)', fontSize: '0.8rem' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ gap: 1 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -154,29 +176,26 @@ const HeroChat = () => {
                 height: 'auto',
                 background: chip.bg,
                 border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
+                borderRadius: '8px',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.75,
                 },
                 '&:hover': {
                   background: chip.hoverBg,
                   borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +208,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +224,29 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.5,
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: 'none',
+            color: 'rgba(255,255,255,0.35)',
+            fontFamily: 'var(--font-inter), system-ui, sans-serif',
+            fontWeight: 500,
+            fontSize: '0.8rem',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            flexDirection: 'column',
+            '&:hover': { color: 'rgba(255,255,255,0.7)' },
+            '@keyframes gentleBounce': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(4px)' },
+            },
+            animation: 'gentleBounce 2s ease-in-out infinite',
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Scroll to explore
+          <KeyboardArrowDownIcon sx={{ fontSize: '1.2rem' }} />
         </Box>
       </Box>
 
@@ -233,11 +258,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease-out 100ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +270,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #818cf8, #a78bfa)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.9rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,31 +291,35 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.9rem', lineHeight: 1.2 }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
+            <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
               Knows David&apos;s experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              color: 'rgba(255,255,255,0.25)',
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            scroll down for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+            background: 'rgba(9, 9, 11, 0.6)',
             backdropFilter: 'blur(12px)',
           }}
         >
@@ -300,7 +328,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -9,44 +9,39 @@ const Logo = () => {
   const container = useRef();
   const [hovered, setHovered] = useState(false);
 
-  useGSAP(() => {
-    if (hovered) {
-      // Brackets expand outward and disappear
-      gsap.to(".bracket-left", { x: -20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      gsap.to(".bracket-right", { x: 20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      
-      // Slash disappears as it "transforms" into the stand
-      gsap.to(".code-slash", { opacity: 0, scale: 0, duration: 0.3 });
-
-      // Monitor Screen assembles
-      gsap.fromTo(".monitor-screen", 
-        { opacity: 0, scale: 0.5 },
-        { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.5)" }
-      );
-
-      // Code appearance on screen
-      gsap.to(".monitor-code", { opacity: 1, duration: 0.3, delay: 0.4 });
-      gsap.fromTo(".code-line", 
-        { scaleX: 0 },
-        { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: "left center", ease: "power1.out" }
-      );
-      
-      // Monitor Stand slides up
-      gsap.fromTo(".monitor-stand-all",
-        { opacity: 0, y: 5 },
-        { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: "power2.out" }
-      );
-    } else {
-      // Restore to initial state
-      gsap.to(".bracket-left", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".bracket-right", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".code-slash", { opacity: 1, scale: 1, duration: 0.4 });
-      
-      gsap.to(".monitor-screen", { opacity: 0, scale: 0.5, duration: 0.3 });
-      gsap.to(".monitor-code", { opacity: 0, duration: 0.2 });
-      gsap.to(".monitor-stand-all", { opacity: 0, y: 5, duration: 0.3 });
-    }
-  }, { scope: container, dependencies: [hovered] });
+  useGSAP(
+    () => {
+      if (hovered) {
+        gsap.to('.bracket-left', { x: -20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.bracket-right', { x: 20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.code-slash', { opacity: 0, scale: 0, duration: 0.3 });
+        gsap.fromTo(
+          '.monitor-screen',
+          { opacity: 0, scale: 0.5 },
+          { opacity: 1, scale: 1, duration: 0.5, ease: 'back.out(1.5)' }
+        );
+        gsap.to('.monitor-code', { opacity: 1, duration: 0.3, delay: 0.4 });
+        gsap.fromTo(
+          '.code-line',
+          { scaleX: 0 },
+          { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: 'left center', ease: 'power1.out' }
+        );
+        gsap.fromTo(
+          '.monitor-stand-all',
+          { opacity: 0, y: 5 },
+          { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: 'power2.out' }
+        );
+      } else {
+        gsap.to('.bracket-left', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.bracket-right', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.code-slash', { opacity: 1, scale: 1, duration: 0.4 });
+        gsap.to('.monitor-screen', { opacity: 0, scale: 0.5, duration: 0.3 });
+        gsap.to('.monitor-code', { opacity: 0, duration: 0.2 });
+        gsap.to('.monitor-stand-all', { opacity: 0, y: 5, duration: 0.3 });
+      }
+    },
+    { scope: container, dependencies: [hovered] }
+  );
 
   return (
     <Box
@@ -57,41 +52,29 @@ const Logo = () => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        mr: 2,
         cursor: 'pointer',
-        width: 40,
-        height: 40,
+        width: 36,
+        height: 36,
       }}
     >
-      <svg width="40" height="40" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-        {/* Left Bracket */}
+      <svg width="36" height="36" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           className="bracket-left"
           d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {/* Right Bracket */}
         <path
           className="bracket-right"
           d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="6"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {/* The Slash */}
-        <path
-          className="code-slash"
-          d="M56 35L44 65"
-          stroke="currentColor"
-          strokeWidth="5"
-          strokeLinecap="round"
-        />
-        
-        {/* Monitor Screen Frame - Higher and More Compact */}
+        <path className="code-slash" d="M56 35L44 65" stroke="currentColor" strokeWidth="5" strokeLinecap="round" />
         <rect
           className="monitor-screen"
           x="30"
@@ -99,23 +82,19 @@ const Logo = () => {
           width="40"
           height="26"
           rx="2"
-          stroke="#38c0f2"
+          stroke="#818cf8"
           strokeWidth="4"
           opacity="0"
           style={{ transformOrigin: 'center' }}
         />
-
-        {/* Code Content on Screen - Adjusted for new rectangle position */}
         <g className="monitor-code" opacity="0">
           <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
+          <path className="code-line" d="M35 45H60" stroke="#818cf8" strokeWidth="2.5" strokeLinecap="round" />
           <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
         </g>
-        
-        {/* Monitor Stand Group - More Compact Stand */}
         <g className="monitor-stand-all" opacity="0">
-          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Shortened Stem */}
-          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Sized Base */}
+          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
         </g>
       </svg>
     </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,154 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
+import { Toolbar, Box, AppBar, Typography, IconButton, Drawer, List, ListItem } from '@mui/material';
 import { useState } from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
 import Logo from './Logo';
-import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const pages = ['About', 'Experience', 'Projects', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
+const NavLink = ({ page, active, setActivePage, onClick }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-80}
+    duration={600}
+    onSetActive={() => setActivePage(page)}
+    onClick={onClick}
+    style={{ textDecoration: 'none', cursor: 'pointer' }}
+  >
+    <Typography
+      sx={{
+        fontSize: '0.85rem',
+        fontWeight: active ? 600 : 400,
+        color: active ? '#fafafa' : 'rgba(255, 255, 255, 0.45)',
+        letterSpacing: '0.02em',
+        transition: 'color 0.2s ease',
+        position: 'relative',
+        px: 1.5,
+        py: 0.5,
+        '&:hover': { color: '#fafafa' },
+        '&::after': active
+          ? {
+              content: '""',
+              position: 'absolute',
+              bottom: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '16px',
+              height: '2px',
+              borderRadius: '1px',
+              background: '#818cf8',
+            }
+          : {},
       }}
     >
       {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+    </Typography>
+  </ScrollLink>
+);
 
 const NavBar = () => {
   const [activePage, setActivePage] = useState('About');
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <AppBar
-      position="fixed"
-      sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
-      }}
-    >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    <>
+      <AppBar
+        position="fixed"
+        sx={{
+          top: 0,
+          zIndex: 1100,
+          width: '100%',
+          bgcolor: 'rgba(9, 9, 11, 0.8)',
+          backdropFilter: 'blur(20px) saturate(1.4)',
+          height: '64px',
+          color: '#fafafa',
+          transition: 'all 0.3s ease',
+          borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+          boxShadow: 'none',
+        }}
+      >
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: { xs: 2, md: 4 },
+            maxWidth: '1400px',
+            width: '100%',
+            mx: 'auto',
+          }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
-            sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
-            }}
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 1.5 }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
+            <Logo />
+            <Typography
+              sx={{
+                fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+                fontWeight: 700,
+                fontSize: '1.1rem',
+                letterSpacing: '-0.02em',
+                color: '#fafafa',
+              }}
+            >
+              David Riva
+            </Typography>
+          </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 1 }}>
+            {pages.map((page) => (
+              <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            ))}
+          </Box>
+
+          <IconButton
+            onClick={() => setMobileOpen(true)}
+            sx={{ display: { xs: 'flex', md: 'none' }, color: '#fafafa' }}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        anchor="right"
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        PaperProps={{
+          sx: {
+            bgcolor: 'rgba(9, 9, 11, 0.95)',
+            backdropFilter: 'blur(24px)',
+            width: '75vw',
+            maxWidth: 320,
+            pt: 2,
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, mb: 2 }}>
+          <IconButton onClick={() => setMobileOpen(false)} sx={{ color: '#fafafa' }}>
+            <CloseIcon />
+          </IconButton>
         </Box>
-      </Toolbar>
-    </AppBar>
+        <List>
+          {pages.map((page) => (
+            <ListItem key={page} sx={{ py: 1.5 }}>
+              <NavLink
+                page={page}
+                active={activePage === page}
+                setActivePage={setActivePage}
+                onClick={() => setMobileOpen(false)}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+    </>
   );
 };
 

--- a/next-app/src/components/ParticleBackground.js
+++ b/next-app/src/components/ParticleBackground.js
@@ -5,7 +5,6 @@ import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import baseOptions from '../particles-options/parallax-bubble.json';
 
-// Start engine initialization immediately on module load, not on component mount
 const engineReady = initParticlesEngine(async (engine) => {
   await loadSlim(engine);
 });
@@ -26,7 +25,7 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.background,
         color: {
           ...baseOptions.background?.color,
-          value: isTransparent ? '#000000' : (backgroundColor || '#0b0920'),
+          value: isTransparent ? '#000000' : backgroundColor || '#09090b',
         },
         opacity: isTransparent ? 0 : (baseOptions.background?.opacity ?? 1),
       },
@@ -34,12 +33,17 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.particles,
         color: {
           ...baseOptions.particles?.color,
-          value: '#ffffff',
+          value: '#818cf8',
+        },
+        opacity: {
+          ...baseOptions.particles?.opacity,
+          value: 0.15,
         },
         links: baseOptions.particles?.links
           ? {
               ...baseOptions.particles.links,
-              color: { ...baseOptions.particles.links.color, value: '#ffffff' },
+              color: { ...baseOptions.particles.links.color, value: '#818cf8' },
+              opacity: 0.08,
             }
           : baseOptions.particles?.links,
       },

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -4,23 +4,23 @@ import Image from 'next/image';
 import { forwardRef } from 'react';
 import CardContent from '@mui/material/CardContent';
 import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
-import LaunchIcon from '@mui/icons-material/Launch';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const ProjectImage = ({ coverImage, title, featured }) => {
   return (
     <Box
       sx={{
         position: 'relative',
-        height: featured ? '220px' : '180px',
+        height: featured ? 200 : 170,
         width: '100%',
-        bgcolor: 'background.paper',
         overflow: 'hidden',
+        bgcolor: 'rgba(255,255,255,0.02)',
       }}
     >
       <Image
         src={`/images/${coverImage}`}
         alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+        style={{ objectFit: 'cover', transition: 'transform 0.6s ease' }}
         className="project-image"
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -29,7 +29,7 @@ const ProjectImage = ({ coverImage, title, featured }) => {
         sx={{
           position: 'absolute',
           inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
+          background: 'linear-gradient(to bottom, transparent 40%, rgba(9, 9, 11, 0.8) 100%)',
         }}
       />
     </Box>
@@ -40,26 +40,31 @@ const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, f
   return (
     <Box sx={{ mb: 2 }}>
       <Typography
-        variant={featured ? 'h6' : 'body1'}
         component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
+        sx={{
+          fontWeight: 600,
+          mb: 0.5,
+          color: '#fafafa',
+          lineHeight: 1.3,
+          fontSize: featured ? '0.95rem' : '0.88rem',
+        }}
       >
         {title}
       </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
+      <Typography sx={{ color: 'rgba(255, 255, 255, 0.3)', fontSize: '0.75rem', fontWeight: 500, display: 'block', mb: 1.5 }}>
         {dateStarted} – {dateCompleted}
       </Typography>
       <Typography
         variant="body2"
         sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
+          color: 'rgba(255, 255, 255, 0.5)',
           lineHeight: 1.6,
           mb: 2,
           display: '-webkit-box',
           WebkitLineClamp: 3,
           WebkitBoxOrient: 'vertical',
           overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
+          fontSize: '0.82rem',
         }}
       >
         {short_description}
@@ -71,23 +76,37 @@ const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, f
 const ProjectTech = ({ technologies }) => {
   const allTools = technologies.flatMap((t) => t.tools);
   return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
+    <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
+      {allTools.slice(0, 6).map((tool, index) => (
         <Chip
           key={index}
           label={tool}
           size="small"
           sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
+            bgcolor: 'rgba(255, 255, 255, 0.04)',
+            color: 'rgba(255, 255, 255, 0.5)',
+            border: '1px solid rgba(255, 255, 255, 0.07)',
+            fontSize: '0.68rem',
             height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
+            fontWeight: 500,
+            '& .MuiChip-label': { px: 1 },
           }}
         />
       ))}
+      {allTools.length > 6 && (
+        <Chip
+          label={`+${allTools.length - 6}`}
+          size="small"
+          sx={{
+            bgcolor: 'transparent',
+            color: 'rgba(255, 255, 255, 0.3)',
+            fontSize: '0.68rem',
+            height: '22px',
+            fontWeight: 500,
+            '& .MuiChip-label': { px: 0.75 },
+          }}
+        />
+      )}
     </Stack>
   );
 };
@@ -95,23 +114,26 @@ const ProjectTech = ({ technologies }) => {
 const ProjectFooter = ({ link }) => {
   return (
     <Button
-      variant="outlined"
+      variant="text"
       href={link}
       target="_blank"
       rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
+      endIcon={<ArrowOutwardIcon sx={{ fontSize: '0.85rem !important' }} />}
       fullWidth
       sx={{
         mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
+        color: 'rgba(255,255,255,0.5)',
+        borderRadius: '10px',
         textTransform: 'none',
         fontSize: '0.8rem',
+        fontWeight: 500,
         py: 0.75,
+        border: '1px solid rgba(255,255,255,0.08)',
+        transition: 'all 0.2s ease',
         '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
+          borderColor: 'rgba(129, 140, 248, 0.3)',
+          color: '#a5b4fc',
+          bgcolor: 'rgba(129, 140, 248, 0.05)',
         },
       }}
     >
@@ -121,10 +143,7 @@ const ProjectFooter = ({ link }) => {
 };
 
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id }, ref) => {
     return (
       <Card
         ref={ref}
@@ -133,28 +152,25 @@ const ProjectCard = forwardRef(
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: featured ? 'rgba(129, 140, 248, 0.03)' : 'rgba(255, 255, 255, 0.02)',
+          color: '#fafafa',
+          border: featured ? '1px solid rgba(129, 140, 248, 0.12)' : '1px solid rgba(255,255,255,0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+          transition: 'all 0.3s ease',
           cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          boxShadow: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: featured ? 'rgba(129, 140, 248, 0.3)' : 'rgba(255,255,255,0.14)',
+            bgcolor: featured ? 'rgba(129, 140, 248, 0.05)' : 'rgba(255, 255, 255, 0.035)',
+            '& .project-image': { transform: 'scale(1.04)' },
           },
         }}
         onClick={onClick}
       >
         <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 2.5, '&:last-child': { pb: 2.5 } }}>
           <ProjectHeader
             title={title}
             dateStarted={dateStarted}

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,17 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, sm: 3, md: 6 },
+        py: { xs: 8, md: 12 },
       }}
     >
       <SectionHeading sectionName="Projects" />
-
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,14 +18,14 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        duration: 0.6,
+        stagger: 0.1,
+        ease: 'power2.out',
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
       }
     );
     ScrollTrigger.refresh();
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -52,16 +52,12 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.5, stagger: 0.06, ease: 'power2.out' });
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,22 +88,28 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box
+                sx={{
+                  p: 2.5,
+                  bgcolor: 'rgba(255,255,255,0.025)',
+                  borderRadius: '16px',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                }}
+              >
+                <Skeleton variant="rectangular" height={180} sx={{ borderRadius: '12px', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.2rem', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <Box>
           <FeaturedProjects projects={featuredProjects} />
 
           <Box sx={{ mt: 4, textAlign: 'center' }}>
@@ -115,22 +117,20 @@ const ProjectsContainer = () => {
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
+                color: 'rgba(255,255,255,0.45)',
+                borderColor: 'rgba(255,255,255,0.1)',
                 border: '1px solid',
-                borderRadius: '50px',
+                borderRadius: '10px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.82rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
+                transition: 'all 0.2s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  borderColor: 'rgba(255,255,255,0.2)',
+                  color: '#fafafa',
                 },
               }}
             >
@@ -139,7 +139,7 @@ const ProjectsContainer = () => {
           </Box>
 
           <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
+            <Box sx={{ mt: 3 }}>
               <AllProjects projects={otherProjects} />
             </Box>
           </Collapse>

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,41 +1,51 @@
 import { Box, Typography } from '@mui/material';
 
-const SectionHeading = ({ sectionName }) => {
+const SectionHeading = ({ sectionName, subtitle }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
+    <Box
+      sx={{
+        mb: { xs: 6, md: 8 },
+        display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        pt: '40px'
+        textAlign: 'center',
       }}
     >
       <Typography
+        variant="caption"
+        sx={{
+          color: '#818cf8',
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          letterSpacing: '0.12em',
+          mb: 1.5,
+        }}
+      >
+        {sectionName.toUpperCase()}
+      </Typography>
+      <Typography
         variant="h2"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
+          fontWeight: 700,
+          fontSize: { xs: '2rem', sm: '2.5rem', md: '3rem' },
           lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          color: '#fafafa',
         }}
       >
         {sectionName}
       </Typography>
+      {subtitle && (
+        <Typography
+          sx={{
+            mt: 2,
+            color: 'rgba(255, 255, 255, 0.4)',
+            fontSize: '1rem',
+            maxWidth: '500px',
+          }}
+        >
+          {subtitle}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,49 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: 'rgba(255, 255, 255, 0.5)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#818cf8',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#34d399',
     },
+    divider: 'rgba(255, 255, 255, 0.06)',
+  },
+  shape: {
+    borderRadius: 12,
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
+    h1: {
+      fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+      fontWeight: 800,
+      letterSpacing: '-0.03em',
+      lineHeight: 1.05,
+    },
+    h2: {
+      fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+      lineHeight: 1.1,
+    },
+    h3: {
+      fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+      fontWeight: 700,
+      letterSpacing: '-0.02em',
+    },
+    h4: { fontWeight: 600, letterSpacing: '-0.015em' },
+    h5: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7, fontSize: '1rem' },
+    body2: { fontWeight: 400, lineHeight: 1.6, fontSize: '0.875rem' },
+    caption: { fontWeight: 500, letterSpacing: '0.06em', textTransform: 'uppercase', fontSize: '0.75rem' },
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual redesign of the portfolio website with a refined, modern aesthetic inspired by 2026 UI/UX trends.

- **New design system**: Zinc-black (`#09090b`) background with indigo (`#818cf8`) primary accent and emerald secondary, replacing the previous cyan/purple palette. Inter for body text, Montserrat for display headings.
- **Bento-grid About section**: Consolidated photo, bio, awards, social links, and resume into a cohesive card-based grid layout — replaces the old About + separate Skills/Awards sections that had mismatched gray styling.
- **New Experience section**: Combined timeline and skills into a single section with GSAP scroll-reveal cards, company logos, and a categorized skills grid with chip-style tags.
- **Modernized all components**: NavBar with mobile hamburger drawer, hero with gradient text and refined typing animation, project cards with softer hover states, contact form with 2-column layout, minimal footer with fixed return-to-top button.
- **Consistent card treatment**: Every card uses the same visual language — `rgba(255,255,255,0.025)` background, `rgba(255,255,255,0.06)` border, `16px` radius, subtle hover brightening.

### Key design changes
| Area | Before | After |
|------|--------|-------|
| Colors | Cyan `#38c0f2` + Purple `#6e40c9` | Indigo `#818cf8` + Emerald `#34d399` |
| Typography | Montserrat only | Inter (body) + Montserrat (headings) |
| Background | Dark purple `#0b0920` | True dark `#09090b` |
| Skills/Awards | Gray `#565859` bg, disconnected styling | Integrated into About + Experience sections |
| Mobile nav | No hamburger menu | Full slide-out drawer |
| Particles | White, high opacity | Indigo-tinted, subtle opacity |

### Files changed (20 files, ~1180 additions)
- `src/theme.js` — New design tokens
- `src/app/layout.js` — Added Inter font, updated metadata
- `src/app/page.js` — New section structure with Experience section
- `src/components/Experience/Experience.js` — **New** combined timeline + skills section
- All component files updated for new palette and design language

## Test plan

- [ ] Verify hero section renders with gradient "David" text and typing animation
- [ ] Test AI chat flow: pre-chat chips, chat input, message streaming
- [ ] Confirm About bento grid is responsive (stacks on mobile, grid on desktop)
- [ ] Verify Experience section loads data from `/data/experiences.json` and animates on scroll
- [ ] Test Projects section: featured cards, "View all" expand/collapse, hover states
- [ ] Check Contact form fields, CAPTCHA, and submit flow
- [ ] Test mobile hamburger menu opens/closes and navigates correctly
- [ ] Verify return-to-top button appears on scroll and works
- [ ] Cross-browser check (Chrome, Safari, Firefox)
- [ ] Mobile viewport check (375px, 768px, 1024px+)

https://claude.ai/code/session_01VQLLjYVfRBMHPGKgfaWhGX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQLLjYVfRBMHPGKgfaWhGX)_