### PR TITLE
Redesign portfolio with modern 2026 UI/UX

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,38 +4,47 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['300', '400', '500', '600', '700', '800', '900'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in applied AI, full-stack development, and data visualization. View projects involving React, Next.js, LangChain, and more.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'Full Stack Developer',
+    'AI Engineer',
+    'React Developer',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva - Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: "David Riva's portfolio",
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva - Software Engineer',
+    description: 'Software engineer specializing in applied AI and full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
 
 const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
 const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
 const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
@@ -11,14 +12,28 @@ import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
 
+const noiseOverlay = {
+  '&::before': {
+    content: '""',
+    position: 'fixed',
+    inset: 0,
+    backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E")`,
+    backgroundRepeat: 'repeat',
+    backgroundSize: '256px 256px',
+    pointerEvents: 'none',
+    zIndex: 0,
+  },
+};
+
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
+        bgcolor: '#06060b',
+        color: '#e8e6e3',
         position: 'relative',
         minHeight: '100vh',
+        ...noiseOverlay,
       }}
     >
       <NavBar />
@@ -27,40 +42,41 @@ const MainPage = () => {
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(167,139,250,0.08) 0%, transparent 60%), #06060b',
         }}
       >
         <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', position: 'relative', zIndex: 1 }}>
         <Box
           id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
+            background: 'radial-gradient(ellipse 70% 50% at 30% 50%, rgba(167,139,250,0.04) 0%, transparent 60%), #06060b',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
           }}
         >
           <About />
         </Box>
 
         <Box
+          id="experience"
+          sx={{
+            background: 'radial-gradient(ellipse 70% 50% at 70% 50%, rgba(56,189,248,0.03) 0%, transparent 60%), #06060b',
+            width: '100%',
+            borderTop: '1px solid rgba(255,255,255,0.04)',
+          }}
+        >
+          <Experience />
+        </Box>
+
+        <Box
           id="projects"
           sx={{
-            bgcolor: '#0b0920',
+            background: '#06060b',
             width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            borderTop: '1px solid rgba(255,255,255,0.04)',
           }}
         >
           <Projects />
@@ -69,9 +85,9 @@ const MainPage = () => {
         <Box
           id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
+            background: 'radial-gradient(ellipse 60% 40% at 50% 80%, rgba(167,139,250,0.04) 0%, transparent 60%), #06060b',
             width: '100%',
-            color: '#ffffff',
+            borderTop: '1px solid rgba(255,255,255,0.04)',
           }}
         >
           <Contact />
@@ -82,4 +98,5 @@ const MainPage = () => {
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,76 +1,232 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
+import { Box, Typography, IconButton, Link, Button } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+
+const card = {
+  bgcolor: 'rgba(255,255,255,0.02)',
+  border: '1px solid rgba(255,255,255,0.06)',
+  borderRadius: '16px',
+  p: { xs: 3, md: 4 },
+  transition: 'border-color 0.3s ease, background 0.3s ease',
+  '&:hover': {
+    borderColor: 'rgba(255,255,255,0.1)',
+    bgcolor: 'rgba(255,255,255,0.03)',
+  },
 };
 
 const About = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
       }}
     >
+      <SectionHeading label="About" />
+
       <Box
         sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 1fr' },
+          gridTemplateRows: 'auto',
+          gap: 2.5,
         }}
       >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
+        {/* Bio card — spans 2 cols */}
+        <Box sx={{ ...card, gridColumn: { xs: '1', md: '1 / 3' } }}>
+          <Box sx={{ display: 'flex', gap: 3, alignItems: { xs: 'flex-start', sm: 'center' }, flexDirection: { xs: 'column', sm: 'row' } }}>
+            <Box
+              sx={{
+                width: 90,
+                height: 90,
+                borderRadius: '16px',
+                overflow: 'hidden',
+                flexShrink: 0,
+                border: '2px solid rgba(167,139,250,0.2)',
+              }}
+            >
+              <Image
+                alt="David Riva"
+                src="/images/headshot.webp"
+                width={90}
+                height={90}
+                style={{ objectFit: 'cover' }}
+                priority
+              />
+            </Box>
+            <Box>
+              <Typography sx={{ fontWeight: 700, fontSize: '1.5rem', letterSpacing: '-0.02em', mb: 0.5 }}>
+                David Riva
+              </Typography>
+              <Typography sx={{ color: '#a78bfa', fontSize: '0.9rem', fontWeight: 500, mb: 0.25 }}>
+                Software Engineer
+              </Typography>
+              <Typography sx={{ color: 'rgba(255,255,255,0.35)', fontSize: '0.82rem' }}>Bay Area, CA</Typography>
+            </Box>
+          </Box>
+
+          <Typography sx={{ color: 'rgba(255,255,255,0.55)', mt: 3, lineHeight: 1.7, fontSize: '0.95rem' }}>
+            I&apos;m a software engineer with a passion for applied AI and full-stack development. I graduated from
+            Colorado State University with a B.S. in Computer Science, Summa Cum Laude. I build production systems that
+            combine modern web technologies with AI — from RAG pipelines to agentic workflows.
+          </Typography>
+          <Typography sx={{ color: 'rgba(255,255,255,0.55)', mt: 2, lineHeight: 1.7, fontSize: '0.95rem' }}>
+            I have a strong background in data structures, algorithms, and mathematical applications. I pride myself on
+            elegant problem-solving and a dedication to high standards of engineering excellence.
+          </Typography>
         </Box>
-      </Box>
 
-      <AboutTextSection />
+        {/* Links card */}
+        <Box sx={{ ...card, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+          <Box>
+            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)', letterSpacing: '0.1em', textTransform: 'uppercase', mb: 2.5 }}>
+              Connect
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              {[
+                { icon: <GitHubIcon />, label: 'GitHub', href: 'https://github.com/davidjriva' },
+                { icon: <LinkedInIcon />, label: 'LinkedIn', href: 'https://www.linkedin.com/in/david-j-riva' },
+                { icon: <EmailIcon />, label: 'Email', href: 'mailto:davidjriva@gmail.com' },
+              ].map((link) => (
+                <Link
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener"
+                  underline="none"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    color: 'rgba(255,255,255,0.5)',
+                    py: 1,
+                    px: 1.5,
+                    borderRadius: '10px',
+                    transition: 'all 0.2s ease',
+                    '&:hover': {
+                      color: '#e8e6e3',
+                      bgcolor: 'rgba(255,255,255,0.04)',
+                    },
+                  }}
+                >
+                  <Box sx={{ fontSize: '1.2rem', display: 'flex' }}>{link.icon}</Box>
+                  <Typography sx={{ fontSize: '0.88rem', fontWeight: 500 }}>{link.label}</Typography>
+                </Link>
+              ))}
+            </Box>
+          </Box>
 
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
+          <Button
+            variant="outlined"
+            onClick={() => window.open('/documents/resume.pdf', '_blank')}
+            endIcon={<OpenInNewIcon sx={{ fontSize: '0.85rem !important' }} />}
+            sx={{
+              mt: 3,
+              color: '#a78bfa',
+              borderColor: 'rgba(167,139,250,0.25)',
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              py: 1,
+              '&:hover': {
+                borderColor: 'rgba(167,139,250,0.5)',
+                bgcolor: 'rgba(167,139,250,0.06)',
+              },
+            }}
+          >
+            View Resume
+          </Button>
+        </Box>
+
+        {/* Awards card — spans 1 col */}
+        <Box sx={{ ...card }}>
+          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)', letterSpacing: '0.1em', textTransform: 'uppercase', mb: 2 }}>
+            Recognition
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {[
+              { title: '1st Place, C3 AI Hackathon', sub: 'Agentic AI tools — 400+ participants', date: '2025' },
+              { title: 'Summa Cum Laude', sub: 'Colorado State University — 4.0 GPA', date: '2024' },
+              { title: 'Excellence in Data Science', sub: 'CSU Undergraduate Research', date: '2023' },
+            ].map((award) => (
+              <Box key={award.title}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <Typography sx={{ fontSize: '0.88rem', fontWeight: 600, color: '#e8e6e3', lineHeight: 1.3 }}>
+                    {award.title}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.25)', flexShrink: 0, ml: 1 }}>
+                    {award.date}
+                  </Typography>
+                </Box>
+                <Typography sx={{ fontSize: '0.78rem', color: 'rgba(255,255,255,0.35)', mt: 0.25 }}>
+                  {award.sub}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* Skills card — spans 2 cols */}
+        <Box sx={{ ...card, gridColumn: { xs: '1', md: '2 / 4' } }}>
+          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)', letterSpacing: '0.1em', textTransform: 'uppercase', mb: 2.5 }}>
+            Technical Skills
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {[
+              { label: 'Python', accent: true },
+              { label: 'TypeScript', accent: true },
+              { label: 'Java', accent: true },
+              { label: 'React' },
+              { label: 'Next.js' },
+              { label: 'Node.js' },
+              { label: 'LangChain' },
+              { label: 'LangGraph' },
+              { label: 'RAG Pipelines' },
+              { label: 'Pinecone' },
+              { label: 'OpenAI API' },
+              { label: 'TensorFlow' },
+              { label: 'FastAPI' },
+              { label: 'Docker' },
+              { label: 'PostgreSQL' },
+              { label: 'MongoDB' },
+              { label: 'AWS' },
+              { label: 'Git' },
+              { label: 'Claude Code' },
+              { label: 'Apache Spark' },
+            ].map((skill) => (
+              <Box
+                key={skill.label}
+                sx={{
+                  px: 1.5,
+                  py: 0.6,
+                  borderRadius: '8px',
+                  bgcolor: skill.accent ? 'rgba(167,139,250,0.08)' : 'rgba(255,255,255,0.04)',
+                  border: skill.accent ? '1px solid rgba(167,139,250,0.15)' : '1px solid rgba(255,255,255,0.06)',
+                  color: skill.accent ? '#a78bfa' : 'rgba(255,255,255,0.5)',
+                  fontSize: '0.78rem',
+                  fontWeight: 500,
+                  transition: 'all 0.2s ease',
+                  '&:hover': {
+                    borderColor: skill.accent ? 'rgba(167,139,250,0.35)' : 'rgba(255,255,255,0.15)',
+                    bgcolor: skill.accent ? 'rgba(167,139,250,0.12)' : 'rgba(255,255,255,0.06)',
+                  },
+                }}
+              >
+                {skill.label}
+              </Box>
+            ))}
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -13,13 +13,13 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         display: 'flex',
         alignItems: 'center',
         p: '4px 8px',
-        borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
-        backdropFilter: 'blur(12px)',
+        borderRadius: '14px',
+        backgroundColor: 'rgba(255,255,255,0.03)',
+        border: '1px solid rgba(255,255,255,0.08)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.12)' },
+        '&:focus-within': { borderColor: 'rgba(167,139,250,0.4)' },
       }}
     >
       <InputBase
@@ -34,24 +34,28 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
+          ml: 1.5,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#e8e6e3',
+          fontSize: '0.9rem',
+          fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+          '& input::placeholder': { color: 'rgba(255,255,255,0.25)' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          ml: 0.5,
+          width: 34,
+          height: 34,
+          borderRadius: '10px',
+          background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
           '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.04)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <SendIcon sx={{ color: '#fff', fontSize: '0.95rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,38 +7,30 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.9rem',
+    color: '#e8e6e3',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
           maxWidth: '80%',
           px: 2.5,
           py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(167,139,250,0.1)' : 'rgba(255,255,255,0.03)',
+          border: isUser ? '1px solid rgba(167,139,250,0.18)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={7} dotColor="#a78bfa" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -47,18 +39,18 @@ const MessageItem = ({ msg }) => {
                 li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
                 strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.3rem', mt: 2, mb: 1 }} {...props} />,
+                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.15rem', mt: 1.5, mb: 0.8 }} {...props} />,
+                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1rem', mt: 1.2, mb: 0.6 }} {...props} />,
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
+                      color: '#a78bfa',
+                      backgroundColor: 'rgba(167,139,250,0.08)',
                       p: '0 4px',
-                      borderRadius: 1,
+                      borderRadius: '4px',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +59,18 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#e8e6e3', p: 1.5, borderRadius: '8px', overflowX: 'auto', fontSize: '0.85rem' }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => <a style={{ color: '#a78bfa', textDecoration: 'none' }} {...props} />,
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#e8e6e3' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,5 +1,4 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
 
@@ -7,33 +6,20 @@ const Contact = () => {
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
+        maxWidth: '700px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
       }}
     >
-      <SectionHeading sectionName="Contact Me" />
+      <SectionHeading label="Contact" />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
-        <ContactForm />
-      </Box>
+      <Typography sx={{ color: 'rgba(255,255,255,0.45)', fontSize: '0.95rem', lineHeight: 1.7, mb: 4, maxWidth: 480 }}>
+        Interested in working together or have a question? Send me a message and I&apos;ll get back to you.
+      </Typography>
+
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -3,16 +3,19 @@
 import { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
+import SendIcon from '@mui/icons-material/Send';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': { color: 'rgba(255,255,255,0.3)', fontSize: '0.88rem' },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#e8e6e3',
+    fontSize: '0.92rem',
+    borderRadius: '12px',
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    '& fieldset': { borderColor: 'rgba(255,255,255,0.06)' },
+    '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.12)' },
+    '&.Mui-focused fieldset': { borderColor: '#a78bfa', borderWidth: '1px' },
   },
 };
 
@@ -49,21 +52,19 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        bgcolor: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        padding: { xs: 3, md: 4 },
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField fullWidth label="Message" name="message" multiline rows={5} value={formData.message} onChange={handleChange} required sx={inputSx} />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +79,22 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          endIcon={<SendIcon sx={{ fontSize: '0.9rem !important' }} />}
           sx={{
             width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
+            py: 1.4,
+            fontSize: '0.88rem',
+            fontWeight: 600,
+            background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
+            borderRadius: '12px',
+            textTransform: 'none',
+            letterSpacing: '0.02em',
             '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
+              background: 'linear-gradient(135deg, #b89cfc, #5fc8f8)',
             },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255,255,255,0.06)',
+              color: 'rgba(255,255,255,0.2)',
             },
           }}
         >
@@ -101,11 +104,11 @@ const ContactForm = () => {
 
       {status && (
         <Typography
-          variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.85rem',
+            color: status.includes('success') ? '#4ade80' : '#f87171',
           }}
         >
           {status}

--- a/next-app/src/components/Experience/Experience.js
+++ b/next-app/src/components/Experience/Experience.js
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, location, startDate, endDate, bulletPoints }) => {
+  const isGraduation = title.startsWith('Graduated');
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: { xs: 2, md: 3 },
+        py: 4,
+        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        '&:last-child': { borderBottom: 'none' },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: '12px',
+          overflow: 'hidden',
+          flexShrink: 0,
+          bgcolor: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          border: '1px solid rgba(255,255,255,0.08)',
+          mt: 0.5,
+        }}
+      >
+        <Image
+          src={`/images/${logoImage}`}
+          alt={`${company} logo`}
+          width={28}
+          height={28}
+          style={{ objectFit: 'contain' }}
+        />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 1, mb: 0.5 }}>
+          <Box>
+            <Typography sx={{ fontWeight: 600, fontSize: '1rem', color: '#e8e6e3', lineHeight: 1.3 }}>
+              {isGraduation ? title : title.split(',')[0].trim()}
+            </Typography>
+            <Typography
+              component="a"
+              href={companyWebsiteLink}
+              target="_blank"
+              rel="noopener"
+              sx={{
+                color: '#a78bfa',
+                textDecoration: 'none',
+                fontSize: '0.88rem',
+                fontWeight: 500,
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              {company}
+            </Typography>
+          </Box>
+          <Box sx={{ textAlign: { xs: 'left', md: 'right' }, flexShrink: 0 }}>
+            <Typography sx={{ fontSize: '0.78rem', color: 'rgba(255,255,255,0.35)' }}>
+              {isGraduation ? startDate : `${startDate} — ${endDate}`}
+            </Typography>
+            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.25)' }}>{location}</Typography>
+          </Box>
+        </Box>
+
+        {bulletPoints && bulletPoints.length > 0 && (
+          <Box component="ul" sx={{ m: 0, mt: 1.5, pl: 2.5, listStyle: 'none' }}>
+            {bulletPoints.map((point, i) => (
+              <Box
+                component="li"
+                key={i}
+                sx={{
+                  position: 'relative',
+                  pl: 1.5,
+                  mb: 1,
+                  '&::before': {
+                    content: '""',
+                    position: 'absolute',
+                    left: 0,
+                    top: '0.55em',
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(167,139,250,0.4)',
+                  },
+                }}
+              >
+                <Typography sx={{ fontSize: '0.85rem', color: 'rgba(255,255,255,0.5)', lineHeight: 1.65 }}>
+                  {point}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const Experience = () => {
+  const [experienceData, setExperienceData] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setExperienceData(sorted);
+      });
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        maxWidth: '900px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
+      }}
+    >
+      <SectionHeading label="Experience" />
+
+      <Box
+        sx={{
+          bgcolor: 'rgba(255,255,255,0.02)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          borderRadius: '16px',
+          px: { xs: 2.5, md: 4 },
+          py: 1,
+        }}
+      >
+        {experienceData.map((exp) => (
+          <ExperienceCard key={exp.title + exp.startDate} {...exp} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,39 +1,58 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, Link, IconButton } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
+        borderTop: '1px solid rgba(255,255,255,0.04)',
+        py: 5,
+        px: { xs: 3, md: 5 },
+        maxWidth: '1200px',
+        mx: 'auto',
         width: '100%',
-        height: '10vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <Box
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 2,
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
-      </Typography>
+        <Typography sx={{ color: 'rgba(255,255,255,0.2)', fontSize: '0.78rem' }}>
+          David Riva &copy; {new Date().getFullYear()}
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" sx={{ color: 'rgba(255,255,255,0.25)', '&:hover': { color: '#e8e6e3' }, display: 'flex' }}>
+            <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+          </Link>
+          <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" sx={{ color: 'rgba(255,255,255,0.25)', '&:hover': { color: '#e8e6e3' }, display: 'flex' }}>
+            <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+          </Link>
+          <IconButton
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            sx={{
+              ml: 1,
+              color: 'rgba(255,255,255,0.2)',
+              border: '1px solid rgba(255,255,255,0.06)',
+              borderRadius: '8px',
+              width: 32,
+              height: 32,
+              '&:hover': { color: '#e8e6e3', borderColor: 'rgba(255,255,255,0.15)' },
+            }}
+          >
+            <KeyboardArrowUpIcon sx={{ fontSize: '1rem' }} />
+          </IconButton>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -1,83 +1,72 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const baseTypingSpeed = 90;
+  const baseDeletingSpeed = 45;
+  const delayBeforeDeleting = 1400;
+  const delayBetweenRoles = 400;
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
 
-  // Determine the appropriate article ("a" or "an") based on the role
-  const getArticle = (role) => {
-    const vowels = ['a', 'e', 'i', 'o', 'u'];
-    return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
-  };
+  const getRandomSpeed = (baseSpeed) => baseSpeed + Math.random() * 40;
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = ROLES[roleIndex];
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, getRandomSpeed(baseTypingSpeed));
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), delayBeforeDeleting);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, getRandomSpeed(baseDeletingSpeed));
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, delayBetweenRoles);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
-  useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
-    return () => clearInterval(blinkCursor);
-  }, []);
-
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.4rem', md: '1.6rem' },
+        fontWeight: 300,
+        color: 'rgba(255,255,255,0.45)',
+        letterSpacing: '0.01em',
+        textAlign: 'center',
+        minHeight: '2em',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {text}
+      <Box
+        component="span"
+        sx={{
+          color: '#a78bfa',
+          fontWeight: 300,
+          animation: 'blink 1s step-end infinite',
+        }}
+      >
+        |
+      </Box>
+      <style>{`@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }`}</style>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -42,30 +42,27 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 const CHIPS = [
   {
     label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
+    bg: 'rgba(167,139,250,0.08)',
+    border: 'rgba(167,139,250,0.25)',
+    color: '#a78bfa',
+    hoverBg: 'rgba(167,139,250,0.15)',
+    hoverBorder: 'rgba(167,139,250,0.5)',
   },
   {
     label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
+    bg: 'rgba(56,189,248,0.08)',
+    border: 'rgba(56,189,248,0.25)',
+    color: '#38bdf8',
+    hoverBg: 'rgba(56,189,248,0.15)',
+    hoverBorder: 'rgba(56,189,248,0.5)',
   },
   {
     label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
+    bg: 'rgba(255,255,255,0.04)',
+    border: 'rgba(255,255,255,0.12)',
+    color: 'rgba(255,255,255,0.65)',
+    hoverBg: 'rgba(255,255,255,0.08)',
+    hoverBorder: 'rgba(255,255,255,0.3)',
   },
 ];
 
@@ -79,7 +76,7 @@ const HeroChat = () => {
     const section = document.getElementById('about');
     if (!section) return;
     const elementPosition = section.getBoundingClientRect().top + window.scrollY;
-    window.scrollTo({ top: elementPosition - 70, behavior: 'smooth' });
+    window.scrollTo({ top: elementPosition - 80, behavior: 'smooth' });
   };
 
   const handleSend = () => {
@@ -89,8 +86,8 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#e8e6e3', zIndex: 1 }}>
+      {/* Pre-chat hero */}
       <Box
         sx={{
           position: 'absolute',
@@ -99,46 +96,76 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 3,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 400ms ease-out, transform 400ms ease-out',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            py: 0.5,
+            borderRadius: '100px',
+            border: '1px solid rgba(167,139,250,0.2)',
+            bgcolor: 'rgba(167,139,250,0.06)',
+            mb: 1,
+          }}
+        >
+          <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: '#4ade80', animation: 'pulse 2s ease infinite' }} />
+          <Typography sx={{ fontSize: '0.78rem', color: 'rgba(255,255,255,0.55)', letterSpacing: '0.04em' }}>
+            Available for opportunities
+          </Typography>
+          <style>{`@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }`}</style>
+        </Box>
+
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
+            fontSize: 'clamp(2.2rem, 7vw, 4.5rem)',
+            fontWeight: 800,
+            lineHeight: 1.0,
             textAlign: 'center',
+            letterSpacing: '-0.04em',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          Hi, I&apos;m{' '}
+          <Box
+            component="span"
+            sx={{
+              background: 'linear-gradient(135deg, #a78bfa 0%, #38bdf8 100%)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
+            David
+          </Box>
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 520, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask my AI agent anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: 'rgba(248,113,113,0.85)', minHeight: '1.2em' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1.5} flexWrap="wrap" justifyContent="center" sx={{ mt: 0.5 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -156,27 +183,26 @@ const HeroChat = () => {
                 border: `1px solid ${chip.border}`,
                 backdropFilter: 'blur(8px)',
                 cursor: 'pointer',
-                transition: 'all 0.2s ease',
+                transition: 'all 0.25s ease',
+                borderRadius: '10px',
                 '& .MuiChip-label': {
                   color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.8,
                 },
                 '&:hover': {
                   background: chip.hoverBg,
                   borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
+                  transform: 'translateY(-1px)',
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +215,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,26 +231,32 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
-            background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            gap: 0.5,
+            px: 2.5,
+            py: 1,
+            borderRadius: '10px',
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            color: 'rgba(255,255,255,0.45)',
+            fontFamily: 'var(--font-montserrat), sans-serif',
+            fontWeight: 500,
+            fontSize: '0.82rem',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            letterSpacing: '0.04em',
+            '&:hover': {
+              borderColor: 'rgba(255,255,255,0.2)',
+              color: 'rgba(255,255,255,0.7)',
+              background: 'rgba(255,255,255,0.05)',
+            },
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          Explore my work
+          <KeyboardArrowDownIcon sx={{ fontSize: '1rem', animation: 'bobDown 2s ease infinite' }} />
+          <style>{`@keyframes bobDown { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(3px); } }`}</style>
         </Box>
       </Box>
 
@@ -233,11 +268,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 400ms ease-out 120ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +280,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.05)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #a78bfa, #38bdf8)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
               fontWeight: 800,
-              fontSize: '1rem',
+              fontSize: '0.9rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +301,34 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
-              David&apos;s AI Agent
-            </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
-              Knows David&apos;s experience, projects &amp; skills
+            <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2 }}>David&apos;s AI Agent</Typography>
+            <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.3)', lineHeight: 1.2 }}>
+              Knows my experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              color: 'rgba(255,255,255,0.25)',
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            scroll down for portfolio
           </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.05)',
+            background: 'rgba(6,6,11,0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +336,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/Logo.js
+++ b/next-app/src/components/Navbar/Logo.js
@@ -9,44 +9,27 @@ const Logo = () => {
   const container = useRef();
   const [hovered, setHovered] = useState(false);
 
-  useGSAP(() => {
-    if (hovered) {
-      // Brackets expand outward and disappear
-      gsap.to(".bracket-left", { x: -20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      gsap.to(".bracket-right", { x: 20, opacity: 0, duration: 0.4, ease: "power2.inOut" });
-      
-      // Slash disappears as it "transforms" into the stand
-      gsap.to(".code-slash", { opacity: 0, scale: 0, duration: 0.3 });
-
-      // Monitor Screen assembles
-      gsap.fromTo(".monitor-screen", 
-        { opacity: 0, scale: 0.5 },
-        { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.5)" }
-      );
-
-      // Code appearance on screen
-      gsap.to(".monitor-code", { opacity: 1, duration: 0.3, delay: 0.4 });
-      gsap.fromTo(".code-line", 
-        { scaleX: 0 },
-        { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: "left center", ease: "power1.out" }
-      );
-      
-      // Monitor Stand slides up
-      gsap.fromTo(".monitor-stand-all",
-        { opacity: 0, y: 5 },
-        { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: "power2.out" }
-      );
-    } else {
-      // Restore to initial state
-      gsap.to(".bracket-left", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".bracket-right", { x: 0, opacity: 1, duration: 0.4 });
-      gsap.to(".code-slash", { opacity: 1, scale: 1, duration: 0.4 });
-      
-      gsap.to(".monitor-screen", { opacity: 0, scale: 0.5, duration: 0.3 });
-      gsap.to(".monitor-code", { opacity: 0, duration: 0.2 });
-      gsap.to(".monitor-stand-all", { opacity: 0, y: 5, duration: 0.3 });
-    }
-  }, { scope: container, dependencies: [hovered] });
+  useGSAP(
+    () => {
+      if (hovered) {
+        gsap.to('.bracket-left', { x: -20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.bracket-right', { x: 20, opacity: 0, duration: 0.4, ease: 'power2.inOut' });
+        gsap.to('.code-slash', { opacity: 0, scale: 0, duration: 0.3 });
+        gsap.fromTo('.monitor-screen', { opacity: 0, scale: 0.5 }, { opacity: 1, scale: 1, duration: 0.5, ease: 'back.out(1.5)' });
+        gsap.to('.monitor-code', { opacity: 1, duration: 0.3, delay: 0.4 });
+        gsap.fromTo('.code-line', { scaleX: 0 }, { scaleX: 1, stagger: 0.1, duration: 0.4, delay: 0.4, transformOrigin: 'left center', ease: 'power1.out' });
+        gsap.fromTo('.monitor-stand-all', { opacity: 0, y: 5 }, { opacity: 1, y: 0, duration: 0.4, delay: 0.2, ease: 'power2.out' });
+      } else {
+        gsap.to('.bracket-left', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.bracket-right', { x: 0, opacity: 1, duration: 0.4 });
+        gsap.to('.code-slash', { opacity: 1, scale: 1, duration: 0.4 });
+        gsap.to('.monitor-screen', { opacity: 0, scale: 0.5, duration: 0.3 });
+        gsap.to('.monitor-code', { opacity: 0, duration: 0.2 });
+        gsap.to('.monitor-stand-all', { opacity: 0, y: 5, duration: 0.3 });
+      }
+    },
+    { scope: container, dependencies: [hovered] }
+  );
 
   return (
     <Box
@@ -57,65 +40,24 @@ const Logo = () => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        mr: 2,
         cursor: 'pointer',
-        width: 40,
-        height: 40,
+        width: 34,
+        height: 34,
       }}
     >
-      <svg width="40" height="40" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-        {/* Left Bracket */}
-        <path
-          className="bracket-left"
-          d="M32 38L22 50L32 62"
-          stroke="#38c0f2"
-          strokeWidth="6"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {/* Right Bracket */}
-        <path
-          className="bracket-right"
-          d="M68 38L78 50L68 62"
-          stroke="#38c0f2"
-          strokeWidth="6"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {/* The Slash */}
-        <path
-          className="code-slash"
-          d="M56 35L44 65"
-          stroke="currentColor"
-          strokeWidth="5"
-          strokeLinecap="round"
-        />
-        
-        {/* Monitor Screen Frame - Higher and More Compact */}
-        <rect
-          className="monitor-screen"
-          x="30"
-          y="32"
-          width="40"
-          height="26"
-          rx="2"
-          stroke="#38c0f2"
-          strokeWidth="4"
-          opacity="0"
-          style={{ transformOrigin: 'center' }}
-        />
-
-        {/* Code Content on Screen - Adjusted for new rectangle position */}
+      <svg width="34" height="34" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path className="bracket-left" d="M32 38L22 50L32 62" stroke="#a78bfa" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round" />
+        <path className="bracket-right" d="M68 38L78 50L68 62" stroke="#a78bfa" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round" />
+        <path className="code-slash" d="M56 35L44 65" stroke="currentColor" strokeWidth="5" strokeLinecap="round" />
+        <rect className="monitor-screen" x="30" y="32" width="40" height="26" rx="2" stroke="#a78bfa" strokeWidth="4" opacity="0" style={{ transformOrigin: 'center' }} />
         <g className="monitor-code" opacity="0">
           <path className="code-line" d="M35 38H50" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-          <path className="code-line" d="M35 45H60" stroke="#38c0f2" strokeWidth="2.5" strokeLinecap="round" />
+          <path className="code-line" d="M35 45H60" stroke="#a78bfa" strokeWidth="2.5" strokeLinecap="round" />
           <path className="code-line" d="M35 52H42" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
         </g>
-        
-        {/* Monitor Stand Group - More Compact Stand */}
         <g className="monitor-stand-all" opacity="0">
-          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Shortened Stem */}
-          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" /> {/* Sized Base */}
+          <path d="M50 58V68" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+          <path d="M42 68H58" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
         </g>
       </svg>
     </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,156 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
+import { Toolbar, Box, AppBar, Typography, IconButton, Drawer, List, ListItem } from '@mui/material';
 import { useState } from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
 import Logo from './Logo';
-import './ScrollLink.css';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const pages = ['About', 'Experience', 'Projects', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
+const NavLink = ({ page, active, setActivePage, onClick }) => {
   return (
     <ScrollLink
       to={page.toLowerCase()}
       spy={true}
       smooth={true}
-      offset={-70}
-      duration={500}
+      offset={-80}
+      duration={600}
       onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
+      onClick={onClick}
+      style={{ textDecoration: 'none', cursor: 'pointer' }}
     >
-      {page}
+      <Typography
+        sx={{
+          fontSize: '0.82rem',
+          fontWeight: active ? 600 : 400,
+          color: active ? '#a78bfa' : 'rgba(255,255,255,0.5)',
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          transition: 'color 0.2s ease',
+          position: 'relative',
+          py: 0.5,
+          '&:hover': { color: '#e8e6e3' },
+          '&::after': active
+            ? {
+                content: '""',
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: '1.5px',
+                background: '#a78bfa',
+                borderRadius: '1px',
+              }
+            : {},
+        }}
+      >
+        {page}
+      </Typography>
     </ScrollLink>
   );
 };
 
-const pages = ['About', 'Projects', 'Contact'];
-
 const NavBar = () => {
   const [activePage, setActivePage] = useState('About');
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <AppBar
-      position="fixed"
-      sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
-      }}
-    >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    <>
+      <AppBar
+        position="fixed"
+        sx={{
+          top: 0,
+          zIndex: 1100,
+          width: '100%',
+          bgcolor: 'rgba(6,6,11,0.6)',
+          backdropFilter: 'blur(20px) saturate(1.4)',
+          height: '60px',
+          color: '#e8e6e3',
+          borderBottom: '1px solid rgba(255,255,255,0.04)',
+          boxShadow: 'none',
+        }}
+      >
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: { xs: 2, md: 5 },
+            minHeight: '60px !important',
+            maxWidth: '1400px',
+            width: '100%',
+            mx: 'auto',
+          }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
-            sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
-            }}
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 1.5 }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
+            <Logo />
+            <Typography
+              sx={{
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                fontSize: '1.1rem',
+                color: '#e8e6e3',
+              }}
+            >
+              david
+              <Box component="span" sx={{ color: '#a78bfa' }}>
+                riva
+              </Box>
+            </Typography>
+          </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 4 }}>
+            {pages.map((page) => (
+              <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            ))}
+          </Box>
+
+          <IconButton
+            sx={{ display: { xs: 'flex', md: 'none' }, color: '#e8e6e3' }}
+            onClick={() => setMobileOpen(true)}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        anchor="right"
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        PaperProps={{
+          sx: {
+            bgcolor: 'rgba(6,6,11,0.95)',
+            backdropFilter: 'blur(24px)',
+            width: 280,
+            pt: 2,
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, mb: 2 }}>
+          <IconButton onClick={() => setMobileOpen(false)} sx={{ color: '#e8e6e3' }}>
+            <CloseIcon />
+          </IconButton>
         </Box>
-      </Toolbar>
-    </AppBar>
+        <List>
+          {pages.map((page) => (
+            <ListItem key={page} sx={{ px: 4, py: 1.5 }}>
+              <NavLink
+                page={page}
+                active={activePage === page}
+                setActivePage={setActivePage}
+                onClick={() => setMobileOpen(false)}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+    </>
   );
 };
 

--- a/next-app/src/components/ParticleBackground.js
+++ b/next-app/src/components/ParticleBackground.js
@@ -5,7 +5,6 @@ import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import baseOptions from '../particles-options/parallax-bubble.json';
 
-// Start engine initialization immediately on module load, not on component mount
 const engineReady = initParticlesEngine(async (engine) => {
   await loadSlim(engine);
 });
@@ -26,7 +25,7 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.background,
         color: {
           ...baseOptions.background?.color,
-          value: isTransparent ? '#000000' : (backgroundColor || '#0b0920'),
+          value: isTransparent ? '#000000' : (backgroundColor || '#06060b'),
         },
         opacity: isTransparent ? 0 : (baseOptions.background?.opacity ?? 1),
       },
@@ -36,10 +35,19 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
           ...baseOptions.particles?.color,
           value: '#ffffff',
         },
+        number: {
+          ...baseOptions.particles?.number,
+          value: 30,
+        },
+        opacity: {
+          ...baseOptions.particles?.opacity,
+          value: 0.15,
+        },
         links: baseOptions.particles?.links
           ? {
               ...baseOptions.particles.links,
               color: { ...baseOptions.particles.links.color, value: '#ffffff' },
+              opacity: 0.06,
             }
           : baseOptions.particles?.links,
       },

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,168 +2,140 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Card, CardContent, Chip, Stack } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
         id={id}
+        component="a"
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: featured ? 'rgba(167,139,250,0.03)' : 'rgba(255,255,255,0.02)',
+          color: '#e8e6e3',
+          border: featured ? '1px solid rgba(167,139,250,0.12)' : '1px solid rgba(255,255,255,0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
+          cursor: 'pointer',
+          boxShadow: 'none',
+          textDecoration: 'none',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            transform: 'translateY(-4px)',
+            borderColor: featured ? 'rgba(167,139,250,0.3)' : 'rgba(255,255,255,0.12)',
+            bgcolor: featured ? 'rgba(167,139,250,0.05)' : 'rgba(255,255,255,0.03)',
+            '& .project-image': { transform: 'scale(1.04)' },
+            '& .launch-icon': { opacity: 1, transform: 'translate(2px, -2px)' },
           },
         }}
         onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        <Box
+          sx={{
+            position: 'relative',
+            height: featured ? 200 : 170,
+            width: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 30%, rgba(6,6,11,0.85) 100%)',
+            }}
+          />
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 3 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}>
+            <Typography
+              component="h3"
+              sx={{ fontWeight: 600, color: '#e8e6e3', lineHeight: 1.3, fontSize: '0.95rem', flex: 1 }}
+            >
+              {title}
+            </Typography>
+            <LaunchIcon
+              className="launch-icon"
+              sx={{
+                fontSize: '0.9rem',
+                color: 'rgba(255,255,255,0.25)',
+                opacity: 0.5,
+                transition: 'all 0.3s ease',
+                ml: 1,
+                flexShrink: 0,
+              }}
+            />
+          </Box>
+
+          <Typography sx={{ color: 'rgba(255,255,255,0.3)', fontSize: '0.75rem', mb: 1.5 }}>
+            {dateStarted} — {dateCompleted}
+          </Typography>
+
+          <Typography
+            sx={{
+              color: 'rgba(255,255,255,0.45)',
+              lineHeight: 1.6,
+              mb: 2.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              fontSize: '0.84rem',
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 'auto' }}>
+            {allTools.slice(0, 6).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: featured ? 'rgba(167,139,250,0.08)' : 'rgba(255,255,255,0.04)',
+                  color: featured ? '#a78bfa' : 'rgba(255,255,255,0.45)',
+                  border: featured ? '1px solid rgba(167,139,250,0.15)' : '1px solid rgba(255,255,255,0.06)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            ))}
+            {allTools.length > 6 && (
+              <Chip
+                label={`+${allTools.length - 6}`}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  color: 'rgba(255,255,255,0.3)',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                  fontSize: '0.68rem',
+                  height: '22px',
+                  '& .MuiChip-label': { px: 1 },
+                }}
+              />
+            )}
+          </Stack>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,18 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
     <Box
       sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
+        maxWidth: '1200px',
+        mx: 'auto',
+        px: { xs: 2, md: 5 },
+        pt: { xs: 10, md: 14 },
+        pb: { xs: 8, md: 12 },
       }}
     >
-      <SectionHeading sectionName="Projects" />
-
+      <SectionHeading label="Projects" />
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,14 +18,14 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
+        duration: 0.7,
+        stagger: 0.1,
         ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        scrollTrigger: { trigger: containerRef.current, start: 'top 82%' },
       }
     );
     ScrollTrigger.refresh();
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -52,16 +52,12 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.5, stagger: 0.07, ease: 'power2.out' });
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,58 +88,61 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box sx={{ bgcolor: 'rgba(255,255,255,0.02)', borderRadius: '16px', border: '1px solid rgba(255,255,255,0.06)', overflow: 'hidden' }}>
+                <Skeleton variant="rectangular" height={200} sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Box sx={{ p: 3 }}>
+                  <Skeleton variant="text" sx={{ fontSize: '1rem', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                  <Skeleton variant="text" width="40%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
+                  <Skeleton variant="text" sx={{ mt: 1, bgcolor: 'rgba(255,255,255,0.04)' }} height={50} />
+                </Box>
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
-            <Button
-              onClick={() => setShowAll((prev) => !prev)}
-              endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-              sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
-                px: 3,
-                py: 0.85,
-                textTransform: 'none',
-                fontSize: '0.85rem',
-                fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
-                },
-              }}
-            >
-              {showAll ? 'Show less' : `View all ${projectData.length} projects`}
-            </Button>
-          </Box>
+          {otherProjects.length > 0 && (
+            <>
+              <Box sx={{ mt: 5, textAlign: 'center' }}>
+                <Button
+                  onClick={() => setShowAll((prev) => !prev)}
+                  endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                  sx={{
+                    color: 'rgba(255,255,255,0.45)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    borderRadius: '10px',
+                    px: 3,
+                    py: 0.8,
+                    textTransform: 'none',
+                    fontSize: '0.82rem',
+                    fontWeight: 500,
+                    transition: 'all 0.25s ease',
+                    '&:hover': {
+                      bgcolor: 'rgba(255,255,255,0.04)',
+                      borderColor: 'rgba(255,255,255,0.15)',
+                      color: 'rgba(255,255,255,0.7)',
+                    },
+                  }}
+                >
+                  {showAll ? 'Show less' : `View all ${projectData.length} projects`}
+                </Button>
+              </Box>
 
-          <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
-              <AllProjects projects={otherProjects} />
-            </Box>
-          </Collapse>
-        </Box>
+              <Collapse in={showAll} timeout={400}>
+                <Box sx={{ mt: 3 }}>
+                  <AllProjects projects={otherProjects} />
+                </Box>
+              </Collapse>
+            </>
+          )}
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,41 +1,28 @@
 import { Box, Typography } from '@mui/material';
 
-const SectionHeading = ({ sectionName }) => {
+const SectionHeading = ({ label }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: { xs: 5, md: 7 } }}>
       <Typography
-        variant="h2"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          letterSpacing: '0.15em',
+          textTransform: 'uppercase',
+          color: '#a78bfa',
+          mb: 1.5,
         }}
       >
-        {sectionName}
+        {label}
       </Typography>
+      <Box
+        sx={{
+          width: 32,
+          height: 2,
+          borderRadius: '1px',
+          background: 'linear-gradient(90deg, #a78bfa, transparent)',
+        }}
+      />
     </Box>
   );
 };

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,33 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#06060b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#e8e6e3',
+      secondary: 'rgba(255, 255, 255, 0.45)',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#a78bfa',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#38bdf8',
     },
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-montserrat), "Inter", system-ui, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.04em', lineHeight: 1.0 },
+    h2: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.02em' },
+    h4: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7, letterSpacing: '0.01em' },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+  },
+  shape: {
+    borderRadius: 12,
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual overhaul of the portfolio site, shifting from a bright cyan/purple neon aesthetic to a refined, editorial dark theme inspired by 2026 UI/UX trends.

- **New color system**: muted violet (`#a78bfa`) + sky blue (`#38bdf8`) on near-black (`#06060b`) with subtle grain texture overlay and radial gradient accents per section
- **Bento-grid About section**: consolidates bio, headshot, skills tags, awards, social links, and resume button into a responsive CSS Grid layout — replaces the old headshot + text + timeline three-column layout
- **New dedicated Experience section**: full timeline-style cards with company logos, bullet points, and location/date metadata — previously this was a small sidebar timeline hidden on smaller screens
- **Redesigned project cards**: cleaner hover states (translateY + border glow), `<a>` tag wrapping for full-card clickability, chip overflow with `+N` indicator, gradient image overlays
- **Minimal section headings**: uppercase labels with letter-spacing and short gradient underlines replacing the old large centered headings with bottom bars
- **Mobile navigation**: hamburger menu with slide-out Drawer replacing the hidden-on-mobile nav links
- **Refined hero**: "Available for opportunities" status pill, gradient text for name, lighter-weight typing animation, softer CTA button
- **Reduced particle density** (30 particles, 0.15 opacity) for a cleaner, less busy hero backdrop
- **Typography refresh**: variable weight Montserrat (300–900) with tighter letter-spacing on headings
- **Contact form**: side-by-side name/email fields, rounded inputs, gradient submit button with send icon
- **Minimal footer**: inline social icons + scroll-to-top button, single copyright line

## Test plan

- [ ] Verify hero section renders with typing animation and AI chat input
- [ ] Test AI chat flow (chip click → cached response, free-text → streaming)
- [ ] Confirm About bento grid is responsive (1-col mobile, 3-col desktop)
- [ ] Verify Experience section loads data from `/data/experiences.json` and renders all entries
- [ ] Test Projects section: featured cards load, "View all" expands, cards link to GitHub
- [ ] Confirm Contact form renders with Turnstile CAPTCHA and submits
- [ ] Test mobile nav: hamburger opens drawer, links scroll to sections
- [ ] Verify scroll-spy highlights active nav link
- [ ] Check footer social links and scroll-to-top button
- [ ] Run `npm run build` — passes cleanly
- [ ] Run `npm run lint` — zero warnings/errors

https://claude.ai/code/session_016QSpAoQZ3Fb8tT6c1QtByP

---
_Generated by [Claude Code](https://claude.ai/code/session_016QSpAoQZ3Fb8tT6c1QtByP)_