### PR TITLE
Redesign portfolio with modern 2026 UI/UX

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -4,38 +4,48 @@ import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
 import { Montserrat } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const montserrat = Montserrat({
-  weight: ['400', '700'],
+  weight: ['400', '500', '600', '700', '800'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-montserrat',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    'Software engineer specializing in applied AI, full-stack development, and data engineering. Building production RAG pipelines, agentic systems, and modern web applications.',
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'AI Engineer',
+    'Full Stack Developer',
+    'React',
+    'Next.js',
+    'LangChain',
+    'Portfolio',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI and full-stack engineer building production-grade systems.',
     url: 'https://davidriva.dev',
-    siteName: 'David Riva Portfolio',
+    siteName: 'David Riva',
     images: [
       {
         url: 'https://davidriva.dev/images/website_preview.png',
         width: 1200,
         height: 630,
-        alt: "David Riva's headshot",
+        alt: 'David Riva — Software Engineer',
       },
     ],
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva — Software Engineer',
+    description: 'Applied AI and full-stack engineer building production-grade systems.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +53,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={montserrat.variable} style={{ overflowX: 'hidden' }}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,84 +2,116 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
-
-const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
-const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
-const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
 import HeroChat from '@/components/Greeting-Page/HeroChat';
 import ParticleBackground from '@/components/ParticleBackground';
 import NavBar from '@/components/Navbar/NavBar';
 import Footer from '@/components/Footer/Footer';
 
+const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/Experience/Experience'), { ssr: false });
+const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
+const Skills = dynamic(() => import('@/components/Skills/Skills'), { ssr: false });
+const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
+
 const MainPage = () => {
   return (
-    <Box
-      sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
-        position: 'relative',
-        minHeight: '100vh',
-      }}
-    >
+    <Box sx={{ bgcolor: '#09090b', color: '#fafafa', position: 'relative', minHeight: '100vh' }}>
       <NavBar />
 
       <Box
         sx={{
           position: 'relative',
           height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
-          },
+          background: 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(59,130,246,0.08) 0%, transparent 60%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(139,92,246,0.06) 0%, transparent 50%), #09090b',
         }}
       >
         <ParticleBackground backgroundColor="transparent" />
         <HeroChat />
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box id="about" sx={{ position: 'relative' }}>
         <Box
-          id="about"
           sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: 600,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(59,130,246,0.3), transparent)',
           }}
-        >
-          <About />
-        </Box>
+        />
+        <About />
+      </Box>
 
+      <Box id="experience" sx={{ position: 'relative' }}>
         <Box
-          id="projects"
           sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: 600,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(139,92,246,0.3), transparent)',
           }}
-        >
-          <Projects />
-        </Box>
+        />
+        <Experience />
+      </Box>
 
+      <Box id="projects" sx={{ position: 'relative' }}>
         <Box
-          id="contact"
           sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: 600,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(59,130,246,0.3), transparent)',
           }}
-        >
-          <Contact />
-        </Box>
+        />
+        <Projects />
+      </Box>
+
+      <Box id="skills" sx={{ position: 'relative' }}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: 600,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(139,92,246,0.3), transparent)',
+          }}
+        />
+        <Skills />
+      </Box>
+
+      <Box id="contact" sx={{ position: 'relative' }}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '80%',
+            maxWidth: 600,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(59,130,246,0.3), transparent)',
+          }}
+        />
+        <Contact />
       </Box>
 
       <Footer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/About-Page/About.js
+++ b/next-app/src/components/About-Page/About.js
@@ -1,77 +1,189 @@
-import { Box } from '@mui/material';
-import HeadShotImage from './HeadshotImage';
-import AboutHeader from './AboutHeader';
-import AboutFooter from './AboutFooter';
-import Biography from './Biography';
-import SimpleTimeline from './SimpleTimeline';
+'use client';
 
-const AboutTextSection = () => {
-  return (
-    <Box
-      sx={{
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
-        p: { xs: 3, md: 4 },
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        textAlign: 'left',
-        maxWidth: '600px',
-      }}
-    >
-      <AboutHeader />
-      <Biography />
-      <AboutFooter />
-    </Box>
-  );
-};
+import { Box, Typography, Grid, IconButton, Link } from '@mui/material';
+import Image from 'next/image';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
+import SectionHeading from '@/components/SectionHeading';
+
+const BentoCard = ({ children, sx = {} }) => (
+  <Box
+    sx={{
+      background: 'rgba(255,255,255,0.02)',
+      border: '1px solid rgba(255,255,255,0.06)',
+      borderRadius: '16px',
+      p: { xs: 2.5, md: 3 },
+      height: '100%',
+      transition: 'border-color 0.3s ease, background 0.3s ease',
+      '&:hover': {
+        borderColor: 'rgba(255,255,255,0.1)',
+        background: 'rgba(255,255,255,0.03)',
+      },
+      ...sx,
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const StatItem = ({ value, label }) => (
+  <Box sx={{ textAlign: 'center' }}>
+    <Typography sx={{ fontSize: { xs: '1.8rem', md: '2.2rem' }, fontWeight: 700, color: '#fafafa', lineHeight: 1 }}>
+      {value}
+    </Typography>
+    <Typography sx={{ fontSize: '0.7rem', color: '#52525b', fontWeight: 500, letterSpacing: '0.08em', mt: 0.5, textTransform: 'uppercase' }}>
+      {label}
+    </Typography>
+  </Box>
+);
 
 const About = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'column', md: 'row' },
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: { xs: 4, md: 6 },
-        width: '100%',
-        minHeight: '750px',
-        pt: '60px',
-        pb: '60px',
-        px: { xs: 3, md: 6 },
-      }}
-    >
-      <Box
-        sx={{
-          p: '3px',
-          borderRadius: '50%',
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          flexShrink: 0,
-          width: 286,
-          height: 286,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Box sx={{ borderRadius: '50%', overflow: 'hidden', bgcolor: '#0b0920', width: 280, height: 280 }}>
-          <HeadShotImage width={280} height={280} />
-        </Box>
-      </Box>
+    <Box sx={{ maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="About" subtitle="A bit about me" />
 
-      <AboutTextSection />
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 5 }}>
+          <BentoCard sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2.5 }}>
+            <Box
+              sx={{
+                width: { xs: 140, md: 180 },
+                height: { xs: 140, md: 180 },
+                borderRadius: '20px',
+                overflow: 'hidden',
+                border: '2px solid rgba(255,255,255,0.06)',
+                flexShrink: 0,
+              }}
+            >
+              <Image
+                alt="David Riva"
+                src="/images/headshot.webp"
+                width={180}
+                height={180}
+                style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+                priority
+              />
+            </Box>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography sx={{ fontSize: '1.5rem', fontWeight: 700, color: '#fafafa', letterSpacing: '-0.02em' }}>
+                David Riva
+              </Typography>
+              <Typography sx={{ fontSize: '0.85rem', color: '#3b82f6', fontWeight: 500, mt: 0.25 }}>
+                Software Engineer
+              </Typography>
+              <Typography sx={{ fontSize: '0.75rem', color: '#52525b', mt: 0.5 }}>
+                Bay Area, CA
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Link href="https://github.com/davidjriva" target="_blank" rel="noopener">
+                <IconButton
+                  size="small"
+                  sx={{
+                    color: '#52525b',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    borderRadius: '10px',
+                    width: 36,
+                    height: 36,
+                    transition: 'all 0.2s ease',
+                    '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.15)' },
+                  }}
+                >
+                  <GitHubIcon sx={{ fontSize: '1rem' }} />
+                </IconButton>
+              </Link>
+              <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener">
+                <IconButton
+                  size="small"
+                  sx={{
+                    color: '#52525b',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    borderRadius: '10px',
+                    width: 36,
+                    height: 36,
+                    transition: 'all 0.2s ease',
+                    '&:hover': { color: '#3b82f6', borderColor: 'rgba(59,130,246,0.3)' },
+                  }}
+                >
+                  <LinkedInIcon sx={{ fontSize: '1rem' }} />
+                </IconButton>
+              </Link>
+              <Link href="mailto:davidjriva@gmail.com">
+                <IconButton
+                  size="small"
+                  sx={{
+                    color: '#52525b',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    borderRadius: '10px',
+                    width: 36,
+                    height: 36,
+                    transition: 'all 0.2s ease',
+                    '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.15)' },
+                  }}
+                >
+                  <EmailOutlinedIcon sx={{ fontSize: '1rem' }} />
+                </IconButton>
+              </Link>
+              <IconButton
+                size="small"
+                onClick={() => window.open('/documents/resume.pdf', '_blank')}
+                sx={{
+                  color: '#52525b',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                  borderRadius: '10px',
+                  width: 36,
+                  height: 36,
+                  transition: 'all 0.2s ease',
+                  '&:hover': { color: '#8b5cf6', borderColor: 'rgba(139,92,246,0.3)' },
+                }}
+              >
+                <DescriptionOutlinedIcon sx={{ fontSize: '1rem' }} />
+              </IconButton>
+            </Box>
+          </BentoCard>
+        </Grid>
 
-      <Box
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          '@media (max-width: 1250px)': { display: 'none' },
-        }}
-      >
-        <SimpleTimeline />
-      </Box>
+        <Grid size={{ xs: 12, md: 7 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
+            <BentoCard sx={{ flex: 1 }}>
+              <Typography sx={{ fontSize: '0.7rem', color: '#3b82f6', fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', mb: 1.5 }}>
+                Background
+              </Typography>
+              <Typography sx={{ fontSize: '0.9rem', color: '#a1a1aa', lineHeight: 1.75 }}>
+                Software engineer based in the Bay Area with a B.S. in Computer Science from Colorado State University, graduated Summa Cum Laude. I specialize in applied AI engineering, full-stack development, and building production-grade systems that solve real problems.
+              </Typography>
+              <Typography sx={{ fontSize: '0.9rem', color: '#a1a1aa', lineHeight: 1.75, mt: 1.5 }}>
+                Most recently at C3 AI, I built internal tooling and training infrastructure serving 8,000+ learners globally, and won 1st place at their Agentic AI Hackathon. I&apos;m passionate about the intersection of AI and software engineering — from RAG pipelines and agentic systems to clean, performant web applications.
+              </Typography>
+            </BentoCard>
+
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 6, sm: 3 }}>
+                <BentoCard sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <StatItem value="3+" label="Years Exp." />
+                </BentoCard>
+              </Grid>
+              <Grid size={{ xs: 6, sm: 3 }}>
+                <BentoCard sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <StatItem value="11" label="Projects" />
+                </BentoCard>
+              </Grid>
+              <Grid size={{ xs: 6, sm: 3 }}>
+                <BentoCard sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <StatItem value="4.0" label="GPA" />
+                </BentoCard>
+              </Grid>
+              <Grid size={{ xs: 6, sm: 3 }}>
+                <BentoCard sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <StatItem value="4" label="Awards" />
+                </BentoCard>
+              </Grid>
+            </Grid>
+          </Box>
+        </Grid>
+      </Grid>
     </Box>
   );
 };

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { InputBase, IconButton, Paper } from '@mui/material';
-import SendIcon from '@mui/icons-material/Send';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
-const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything…' }) => {
+const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder = 'Ask anything...' }) => {
   return (
     <Paper
       component="form"
@@ -12,14 +12,15 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
       sx={{
         display: 'flex',
         alignItems: 'center',
-        p: '4px 8px',
-        borderRadius: '999px',
-        backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        p: '4px 6px 4px 16px',
+        borderRadius: '14px',
+        backgroundColor: 'rgba(255,255,255,0.03)',
+        border: '1px solid rgba(255,255,255,0.08)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        transition: 'border-color 0.2s ease',
+        '&:hover': { borderColor: 'rgba(255,255,255,0.15)' },
+        '&:focus-within': { borderColor: 'rgba(59,130,246,0.4)' },
       }}
     >
       <InputBase
@@ -34,24 +35,27 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           }
         }}
         sx={{
-          ml: 1,
           flex: 1,
-          color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-          '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
+          color: '#fafafa',
+          fontSize: '0.9rem',
+          fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+          '& input::placeholder': { color: '#52525b' },
         }}
       />
       <IconButton
         type="submit"
         disabled={!input.trim() || disabled}
         sx={{
-          ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-          '&:hover': { opacity: 0.85 },
-          '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
+          width: 32,
+          height: 32,
+          borderRadius: '10px',
+          background: input.trim() && !disabled ? '#3b82f6' : 'rgba(255,255,255,0.06)',
+          transition: 'all 0.2s ease',
+          '&:hover': { background: '#2563eb' },
+          '&.Mui-disabled': { background: 'rgba(255,255,255,0.04)' },
         }}
       >
-        <SendIcon sx={{ color: '#fff', fontSize: '1.1rem' }} />
+        <ArrowUpwardIcon sx={{ color: input.trim() && !disabled ? '#fff' : '#52525b', fontSize: '1rem' }} />
       </IconButton>
     </Paper>
   );

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,58 +7,57 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
     fontWeight: 400,
-    lineHeight: 1.6,
-    fontSize: '0.95rem',
-    color: '#fff',
+    lineHeight: 1.65,
+    fontSize: '0.88rem',
+    color: '#d4d4d8',
     marginBottom: '4px',
   };
 
   return (
-    <Box
-      sx={{
-        mb: 2,
-        display: 'flex',
-        justifyContent: isUser ? 'flex-end' : 'flex-start',
-      }}
-    >
+    <Box sx={{ mb: 2, display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
       <Box
         sx={{
-          maxWidth: '80%',
-          px: 2.5,
-          py: 1.5,
-          borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
-          border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+          maxWidth: '82%',
+          px: 2,
+          py: 1.25,
+          borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+          background: isUser ? 'rgba(59,130,246,0.1)' : 'rgba(255,255,255,0.03)',
+          border: isUser ? '1px solid rgba(59,130,246,0.2)' : '1px solid rgba(255,255,255,0.06)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={6} dotColor="#3b82f6" spacing={3} />
             </Box>
           ) : (
             <ReactMarkdown
               components={{
                 p: (props) => <Typography sx={mdStyles} {...props} />,
-                li: (props) => <li style={{ ...mdStyles, marginBottom: '6px' }} {...props} />,
-                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 700 }} {...props} />,
+                li: (props) => <li style={{ ...mdStyles, marginBottom: '4px' }} {...props} />,
+                strong: (props) => <strong style={{ ...mdStyles, fontWeight: 600, color: '#fafafa' }} {...props} />,
                 em: (props) => <em style={mdStyles} {...props} />,
-                h1: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.4rem', mt: 2, mb: 1 }} {...props} />,
-                h2: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.2rem', mt: 1.5, mb: 0.8 }} {...props} />,
-                h3: (props) => <Typography sx={{ ...mdStyles, fontWeight: 700, fontSize: '1.05rem', mt: 1.2, mb: 0.6 }} {...props} />,
+                h1: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.2rem', color: '#fafafa', mt: 1.5, mb: 0.5 }} {...props} />
+                ),
+                h2: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '1.05rem', color: '#fafafa', mt: 1, mb: 0.5 }} {...props} />
+                ),
+                h3: (props) => (
+                  <Typography sx={{ ...mdStyles, fontWeight: 600, fontSize: '0.95rem', color: '#fafafa', mt: 1, mb: 0.5 }} {...props} />
+                ),
                 code: (props) => (
                   <Box
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
-                      p: '0 4px',
-                      borderRadius: 1,
+                      color: '#3b82f6',
+                      backgroundColor: 'rgba(59,130,246,0.08)',
+                      p: '1px 5px',
+                      borderRadius: '4px',
+                      fontSize: '0.82rem',
                       display: 'inline',
                     }}
                     {...props}
@@ -67,18 +66,32 @@ const MessageItem = ({ msg }) => {
                 pre: (props) => (
                   <Box
                     component="pre"
-                    sx={{ backgroundColor: 'rgba(0,0,0,0.3)', color: '#fff', p: 1, borderRadius: 1, overflowX: 'auto' }}
+                    sx={{
+                      backgroundColor: 'rgba(0,0,0,0.3)',
+                      color: '#d4d4d8',
+                      p: 1.5,
+                      borderRadius: '8px',
+                      overflowX: 'auto',
+                      fontSize: '0.82rem',
+                    }}
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => (
+                  <a
+                    style={{ color: '#3b82f6', textDecoration: 'none', fontWeight: 500 }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    {...props}
+                  />
+                ),
               }}
             >
               {msg.text}
             </ReactMarkdown>
           )
         ) : (
-          <Typography sx={{ ...mdStyles, color: '#fff' }}>{msg.text}</Typography>
+          <Typography sx={{ ...mdStyles, color: '#fafafa' }}>{msg.text}</Typography>
         )}
       </Box>
     </Box>

--- a/next-app/src/components/Contact-Page/Contact.js
+++ b/next-app/src/components/Contact-Page/Contact.js
@@ -1,39 +1,15 @@
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import ContactForm from './ContactForm';
 import SectionHeading from '../SectionHeading';
 
 const Contact = () => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        pt: '60px',
-        pb: '60px',
-      }}
-    >
-      <SectionHeading sectionName="Contact Me" />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: {
-            xs: '75%', // mobile
-            sm: '70%', // tablets
-            md: '70%', // small desktops
-            lg: '70%', // large desktops
-          },
-        }}
-      >
-        <ContactForm />
-      </Box>
+    <Box sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Contact" subtitle="Get in touch" />
+      <Typography sx={{ textAlign: 'center', color: '#52525b', fontSize: '0.85rem', mb: 5, mt: -4 }}>
+        Have a question or want to work together? Send me a message.
+      </Typography>
+      <ContactForm />
     </Box>
   );
 };

--- a/next-app/src/components/Contact-Page/ContactForm.js
+++ b/next-app/src/components/Contact-Page/ContactForm.js
@@ -5,14 +5,16 @@ import { Box, TextField, Button, Typography } from '@mui/material';
 import { Turnstile } from '@marsidev/react-turnstile';
 
 const inputSx = {
-  marginBottom: 2,
-  '& .MuiInputLabel-root': { color: 'rgba(255, 255, 255, 0.55)' },
+  mb: 2,
+  '& .MuiInputLabel-root': { color: '#52525b', fontSize: '0.85rem' },
   '& .MuiOutlinedInput-root': {
-    color: '#ffffff',
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-    '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.25)' },
-    '&.Mui-focused fieldset': { borderColor: '#38c0f2' },
+    color: '#fafafa',
+    fontSize: '0.9rem',
+    borderRadius: '12px',
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    '& fieldset': { borderColor: 'rgba(255,255,255,0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.15)' },
+    '&.Mui-focused fieldset': { borderColor: 'rgba(59,130,246,0.5)' },
   },
 };
 
@@ -40,7 +42,7 @@ const ContactForm = () => {
       } else {
         setStatus('Failed to send message.');
       }
-    } catch (error) {
+    } catch {
       setStatus('Error sending message.');
     }
   };
@@ -49,21 +51,19 @@ const ContactForm = () => {
     <Box
       sx={{
         width: '100%',
-        height: 'fit-content',
-        maxWidth: '800px',
-        bgcolor: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.09)',
-        color: '#ffffff',
-        padding: { xs: 2, sm: 3, md: 4 },
+        bgcolor: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        p: { xs: 3, md: 4 },
         borderRadius: '16px',
-        backdropFilter: 'blur(12px)',
       }}
     >
       <form onSubmit={handleSubmit}>
-        <TextField fullWidth label="Your Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Your Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+          <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleChange} required sx={inputSx} />
+          <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleChange} required sx={inputSx} />
+        </Box>
         <TextField fullWidth label="Subject" name="subject" value={formData.subject} onChange={handleChange} required sx={inputSx} />
-        <TextField fullWidth label="Message" name="message" multiline rows={4} value={formData.message} onChange={handleChange} required sx={inputSx} />
+        <TextField fullWidth label="Message" name="message" multiline rows={5} value={formData.message} onChange={handleChange} required sx={inputSx} />
 
         {!captchaToken && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
@@ -78,20 +78,20 @@ const ContactForm = () => {
           type="submit"
           variant="contained"
           disabled={!captchaToken}
+          fullWidth
           sx={{
-            width: '100%',
-            padding: '12px 0',
-            fontSize: '16px',
-            background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
-            color: '#ffffff',
-            borderRadius: '8px',
-            border: 'none',
-            '&:hover': {
-              background: 'linear-gradient(135deg, #5bcff5, #8660d4)',
-            },
+            py: 1.5,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            background: '#3b82f6',
+            color: '#fff',
+            borderRadius: '12px',
+            textTransform: 'none',
+            letterSpacing: '0.02em',
+            '&:hover': { background: '#2563eb' },
             '&.Mui-disabled': {
-              background: 'rgba(255, 255, 255, 0.12)',
-              color: 'rgba(255, 255, 255, 0.3)',
+              background: 'rgba(255,255,255,0.06)',
+              color: '#3f3f46',
             },
           }}
         >
@@ -101,11 +101,12 @@ const ContactForm = () => {
 
       {status && (
         <Typography
-          variant="body2"
           sx={{
-            marginTop: 2,
+            mt: 2,
             textAlign: 'center',
-            color: status.includes('success') ? '#4caf50' : '#f44336',
+            fontSize: '0.8rem',
+            fontWeight: 500,
+            color: status.includes('success') ? '#22c55e' : '#ef4444',
           }}
         >
           {status}

--- a/next-app/src/components/Experience/Experience.js
+++ b/next-app/src/components/Experience/Experience.js
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack, Grid } from '@mui/material';
+import Image from 'next/image';
+import SectionHeading from '@/components/SectionHeading';
+
+const ExperienceCard = ({ title, company, companyWebsiteLink, logoImage, location, startDate, endDate, bulletPoints, isActive }) => {
+  const isCurrent = endDate === 'Present';
+  const isGraduation = title.startsWith('Graduated');
+  const displayTitle = isGraduation ? 'Graduated Summa Cum Laude' : title;
+  const dateRange = isGraduation ? startDate : `${startDate} — ${endDate}`;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: { xs: 2, md: 3 },
+        p: { xs: 2.5, md: 3 },
+        borderRadius: '16px',
+        background: isActive ? 'rgba(59,130,246,0.04)' : 'rgba(255,255,255,0.02)',
+        border: isActive ? '1px solid rgba(59,130,246,0.15)' : '1px solid rgba(255,255,255,0.06)',
+        transition: 'all 0.3s ease',
+        '&:hover': {
+          background: 'rgba(255,255,255,0.03)',
+          borderColor: 'rgba(255,255,255,0.1)',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: '12px',
+          overflow: 'hidden',
+          border: '1px solid rgba(255,255,255,0.08)',
+          flexShrink: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: 'rgba(255,255,255,0.04)',
+        }}
+      >
+        <Image
+          src={`/images/${logoImage}`}
+          alt={`${company} logo`}
+          width={28}
+          height={28}
+          style={{ objectFit: 'contain' }}
+        />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
+          <Box>
+            <Typography sx={{ fontSize: '0.9rem', fontWeight: 600, color: '#fafafa', lineHeight: 1.3 }}>
+              {displayTitle}
+            </Typography>
+            <Typography
+              component="a"
+              href={companyWebsiteLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                fontSize: '0.8rem',
+                color: '#3b82f6',
+                textDecoration: 'none',
+                fontWeight: 500,
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              {company}
+            </Typography>
+          </Box>
+          <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+            <Typography sx={{ fontSize: '0.72rem', color: isCurrent ? '#3b82f6' : '#52525b', fontWeight: isCurrent ? 600 : 400 }}>
+              {dateRange}
+            </Typography>
+            <Typography sx={{ fontSize: '0.68rem', color: '#3f3f46' }}>
+              {location}
+            </Typography>
+          </Box>
+        </Box>
+
+        {bulletPoints && bulletPoints.length > 0 && (
+          <Box component="ul" sx={{ m: 0, mt: 1.5, pl: 2, listStyleType: 'none' }}>
+            {bulletPoints.slice(0, 3).map((point, idx) => (
+              <Box
+                component="li"
+                key={idx}
+                sx={{
+                  fontSize: '0.78rem',
+                  color: '#71717a',
+                  lineHeight: 1.6,
+                  mb: 0.75,
+                  position: 'relative',
+                  pl: 1.5,
+                  '&::before': {
+                    content: '""',
+                    position: 'absolute',
+                    left: 0,
+                    top: '0.5em',
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(59,130,246,0.4)',
+                  },
+                }}
+              >
+                {point}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const Experience = () => {
+  const [experiences, setExperiences] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+        setExperiences(sorted);
+      });
+  }, []);
+
+  return (
+    <Box sx={{ maxWidth: 900, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Experience" subtitle="Where I've worked" />
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        {experiences.map((exp, index) => (
+          <ExperienceCard key={exp.title} {...exp} isActive={index === 0} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/Footer/Footer.js
+++ b/next-app/src/components/Footer/Footer.js
@@ -1,38 +1,49 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
-import ReturnToTopButton from './ReturnToTopButton';
+import { Box, Typography, IconButton, Link } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 const Footer = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#060514',
-        color: 'rgba(255, 255, 255, 0.35)',
-        width: '100%',
-        height: '10vh',
+        borderTop: '1px solid rgba(255,255,255,0.06)',
+        py: 4,
+        px: { xs: 2, md: 4 },
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-        bottom: 0,
-        mt: 0,
-        pt: '1rem',
-        pb: '1rem',
+        gap: 2,
       }}
     >
-      <ReturnToTopButton />
-      <Typography
-        variant="body2"
+      <IconButton
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         sx={{
-          color: 'rgba(255, 255, 255, 0.35)',
-          textAlign: 'center',
-          marginTop: '1rem',
-          marginBottom: 10,
+          color: '#52525b',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: '10px',
+          width: 36,
+          height: 36,
+          transition: 'all 0.2s ease',
+          '&:hover': { color: '#a1a1aa', borderColor: 'rgba(255,255,255,0.15)' },
         }}
       >
-        David Riva © {new Date().getFullYear()}. All Rights Reserved.
+        <KeyboardArrowUpIcon sx={{ fontSize: '1.1rem' }} />
+      </IconButton>
+
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        <Link href="https://github.com/davidjriva" target="_blank" rel="noopener" sx={{ color: '#3f3f46', transition: 'color 0.2s', '&:hover': { color: '#a1a1aa' } }}>
+          <GitHubIcon sx={{ fontSize: '1.1rem' }} />
+        </Link>
+        <Link href="https://www.linkedin.com/in/david-j-riva" target="_blank" rel="noopener" sx={{ color: '#3f3f46', transition: 'color 0.2s', '&:hover': { color: '#3b82f6' } }}>
+          <LinkedInIcon sx={{ fontSize: '1.1rem' }} />
+        </Link>
+      </Box>
+
+      <Typography sx={{ color: '#27272a', fontSize: '0.7rem', fontWeight: 500, letterSpacing: '0.05em' }}>
+        {new Date().getFullYear()} David Riva
       </Typography>
     </Box>
   );

--- a/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
+++ b/next-app/src/components/Greeting-Page/AnimatedTypingTypography.js
@@ -3,81 +3,72 @@
 import { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 
-const ROLES = ['forward deployed engineer', 'applied AI engineer', 'full-stack developer'];
+const ROLES = ['applied AI engineer', 'full-stack developer', 'forward deployed engineer'];
 
 const AnimatedTypingTypography = () => {
-  const baseTypingSpeed = 100; // Base speed for typing (in ms)
-  const baseDeletingSpeed = 50; // Base speed for deleting (in ms)
-  const delayBeforeDeleting = 1200; // Shorter delay before starting to delete (in ms)
-  const delayBetweenRoles = 500; // Short delay between deleting and typing new role
+  const [text, setText] = useState('');
+  const [index, setIndex] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [roleIndex, setRoleIndex] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
 
-  const [text, setText] = useState(''); // Text that will be typed
-  const [index, setIndex] = useState(0); // Tracks the current character index
-  const [deleting, setDeleting] = useState(false); // Whether we are deleting the text
-  const [roleIndex, setRoleIndex] = useState(0); // Tracks the current role being typed
-  const [cursorVisible, setCursorVisible] = useState(true); // Cursor visibility for blinking effect
-
-  // Determine the appropriate article ("a" or "an") based on the role
   const getArticle = (role) => {
     const vowels = ['a', 'e', 'i', 'o', 'u'];
     return vowels.includes(role[0].toLowerCase()) ? 'an' : 'a';
   };
 
-  // Function to randomize typing and deleting speed slightly for a more natural feel
-  const getRandomSpeed = (baseSpeed) => {
-    return baseSpeed + Math.random() * 50;
-  };
-
-  // Typing and deleting effect logic
   useEffect(() => {
-    const currentRole = `${ROLES[roleIndex]}.`;
+    const currentRole = ROLES[roleIndex];
     let timer;
 
     if (!deleting && index < currentRole.length) {
-      // Typing logic
       timer = setTimeout(() => {
         setText((prev) => prev + currentRole[index]);
         setIndex((prev) => prev + 1);
-      }, getRandomSpeed(baseTypingSpeed)); // Typing with slight speed randomness
+      }, 80 + Math.random() * 40);
     } else if (!deleting && index === currentRole.length) {
-      // Pause before deleting
-      timer = setTimeout(() => {
-        setDeleting(true);
-      }, delayBeforeDeleting);
+      timer = setTimeout(() => setDeleting(true), 2000);
     } else if (deleting && index > 0) {
-      // Deleting logic
       timer = setTimeout(() => {
         setText((prev) => prev.slice(0, -1));
         setIndex((prev) => prev - 1);
-      }, getRandomSpeed(baseDeletingSpeed)); // Deleting with slight speed randomness
+      }, 40 + Math.random() * 20);
     } else if (deleting && index === 0) {
-      // Switch to the next role after deletion is done
       timer = setTimeout(() => {
         setDeleting(false);
-        setRoleIndex((prev) => (prev + 1) % ROLES.length); // Move to the next role in the array
-      }, delayBetweenRoles); // Small pause before typing the next role
+        setRoleIndex((prev) => (prev + 1) % ROLES.length);
+      }, 400);
     }
 
     return () => clearTimeout(timer);
   }, [index, deleting, roleIndex]);
 
-  // Blinking cursor effect
   useEffect(() => {
-    const blinkCursor = setInterval(() => {
-      setCursorVisible((prev) => !prev);
-    }, 300);
+    const blinkCursor = setInterval(() => setCursorVisible((prev) => !prev), 530);
     return () => clearInterval(blinkCursor);
   }, []);
 
   return (
     <Typography
-      variant="h1"
       sx={{
-        fontSize: { xs: '1.5rem', sm: '2rem', md: '2.5rem' },
+        fontSize: { xs: '1.1rem', sm: '1.4rem', md: '1.6rem' },
+        fontWeight: 400,
+        color: '#a1a1aa',
+        letterSpacing: '-0.01em',
+        minHeight: '2em',
       }}
     >
-      I&apos;m {getArticle(ROLES[roleIndex])} {text}
-      <span style={{ color: '#38c0f2', opacity: cursorVisible ? 1 : 0 }}>|</span>{' '}
+      {getArticle(ROLES[roleIndex])} {text}
+      <span
+        style={{
+          color: '#3b82f6',
+          opacity: cursorVisible ? 1 : 0,
+          transition: 'opacity 0.1s',
+          marginLeft: '1px',
+        }}
+      >
+        |
+      </span>
     </Typography>
   );
 };

--- a/next-app/src/components/Greeting-Page/HeroChat.jsx
+++ b/next-app/src/components/Greeting-Page/HeroChat.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Box, Typography, Chip, Stack } from '@mui/material';
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Turnstile } from '@marsidev/react-turnstile';
 import AnimatedTypingTypography from '@/components/Greeting-Page/AnimatedTypingTypography';
 import ChatInput from '@/components/Chat-Page/ChatInput';
@@ -40,33 +40,9 @@ David graduated from Colorado State University in May 2024 with a B.S. in Comput
 };
 
 const CHIPS = [
-  {
-    label: 'What AI have you built?',
-    bg: 'rgba(56,192,242,0.14)',
-    border: 'rgba(56,192,242,0.55)',
-    color: '#38c0f2',
-    hoverBg: 'rgba(56,192,242,0.26)',
-    hoverBorder: 'rgba(56,192,242,0.9)',
-    glow: '0 0 14px rgba(56,192,242,0.35)',
-  },
-  {
-    label: 'Tell me about your experience',
-    bg: 'rgba(110,64,201,0.14)',
-    border: 'rgba(110,64,201,0.55)',
-    color: '#b894ff',
-    hoverBg: 'rgba(110,64,201,0.28)',
-    hoverBorder: 'rgba(110,64,201,0.9)',
-    glow: '0 0 14px rgba(110,64,201,0.35)',
-  },
-  {
-    label: 'Featured projects',
-    bg: 'rgba(255,255,255,0.08)',
-    border: 'rgba(255,255,255,0.3)',
-    color: 'rgba(255,255,255,0.85)',
-    hoverBg: 'rgba(255,255,255,0.16)',
-    hoverBorder: 'rgba(255,255,255,0.6)',
-    glow: 'none',
-  },
+  { label: 'What AI have you built?' },
+  { label: 'Tell me about your experience' },
+  { label: 'Featured projects' },
 ];
 
 const HeroChat = () => {
@@ -89,8 +65,7 @@ const HeroChat = () => {
   };
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#ffffff', zIndex: 1 }}>
-      {/* Pre-chat view */}
+    <Box sx={{ position: 'relative', width: '100%', height: '100%', color: '#fafafa', zIndex: 1 }}>
       <Box
         sx={{
           position: 'absolute',
@@ -99,46 +74,44 @@ const HeroChat = () => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 2,
+          gap: 2.5,
           px: 3,
           opacity: started ? 0 : 1,
-          transform: started ? 'translateY(-10px)' : 'translateY(0)',
-          transition: 'opacity 300ms ease-out, transform 300ms ease-out',
+          transform: started ? 'translateY(-12px)' : 'translateY(0)',
+          transition: 'opacity 350ms ease-out, transform 350ms ease-out',
           pointerEvents: started ? 'none' : 'auto',
         }}
       >
         <Typography
           variant="h1"
           sx={{
-            fontSize: 'clamp(2rem, 6vw, 3.5rem)',
-            fontWeight: 900,
-            lineHeight: 1.1,
+            fontSize: 'clamp(2.5rem, 8vw, 5rem)',
             textAlign: 'center',
+            color: '#fafafa',
           }}
         >
-          <span style={{ color: '#ffffff' }}>Hello, I&apos;m </span>
-          <span style={{ color: '#38c0f2' }}>David</span>
+          David Riva
         </Typography>
 
         <AnimatedTypingTypography />
 
-        <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Box sx={{ width: '100%', maxWidth: 480, mt: 1 }}>
           <ChatInput
             input={input}
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={turnstileError ? 'Verification failed' : !hasToken ? 'Verifying...' : 'Ask me anything...'}
           />
         </Box>
 
         {turnstileError && (
-          <Typography variant="caption" sx={{ color: 'rgba(255,100,100,0.85)', minHeight: '1.2em' }}>
+          <Typography variant="caption" sx={{ color: '#ef4444', fontSize: '0.75rem' }}>
             Verification failed — chat is temporarily unavailable.
           </Typography>
         )}
 
-        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+        <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center" sx={{ mt: 0.5 }}>
           {CHIPS.map((chip) => (
             <Chip
               key={chip.label}
@@ -152,31 +125,28 @@ const HeroChat = () => {
               }}
               sx={{
                 height: 'auto',
-                background: chip.bg,
-                border: `1px solid ${chip.border}`,
-                backdropFilter: 'blur(8px)',
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
                 cursor: 'pointer',
                 transition: 'all 0.2s ease',
                 '& .MuiChip-label': {
-                  color: chip.color,
-                  fontFamily: 'Montserrat, sans-serif',
-                  fontSize: '0.9rem',
-                  fontWeight: 600,
-                  px: 2,
-                  py: 1,
+                  color: '#71717a',
+                  fontSize: '0.8rem',
+                  fontWeight: 500,
+                  px: 1.5,
+                  py: 0.75,
                 },
                 '&:hover': {
-                  background: chip.hoverBg,
-                  borderColor: chip.hoverBorder,
-                  boxShadow: chip.glow,
+                  background: 'rgba(59,130,246,0.08)',
+                  borderColor: 'rgba(59,130,246,0.3)',
+                  '& .MuiChip-label': { color: '#3b82f6' },
                 },
-                '&.Mui-disabled': { opacity: 0.4 },
+                '&.Mui-disabled': { opacity: 0.3 },
               }}
             />
           ))}
         </Stack>
 
-        {/* Turnstile — runs silently; only shows UI if Cloudflare requires a challenge */}
         {!hasToken && !turnstileError && (
           <Box
             sx={{
@@ -189,7 +159,10 @@ const HeroChat = () => {
           >
             <Turnstile
               siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
-              onSuccess={(captchaToken) => { fetchToken(captchaToken); setNeedsChallenge(false); }}
+              onSuccess={(captchaToken) => {
+                fetchToken(captchaToken);
+                setNeedsChallenge(false);
+              }}
               onError={() => setTurnstileError(true)}
               onBeforeInteractive={() => setNeedsChallenge(true)}
               options={{ appearance: 'interaction-only' }}
@@ -202,30 +175,32 @@ const HeroChat = () => {
           onClick={scrollToAbout}
           sx={{
             position: 'absolute',
-            bottom: 32,
+            bottom: 40,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 1,
-            px: 3,
-            py: 1.25,
-            borderRadius: '50px',
+            gap: 0.5,
             background: 'transparent',
-            border: '1px solid rgba(255,255,255,0.4)',
-            color: 'rgba(255,255,255,0.85)',
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: '0.9rem',
+            border: 'none',
+            color: '#52525b',
+            fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+            fontWeight: 500,
+            fontSize: '0.8rem',
             cursor: 'pointer',
-            transition: 'all 0.3s ease',
-            '&:hover': { borderColor: 'rgba(255,255,255,0.7)', color: '#fff', background: 'rgba(255,255,255,0.07)' },
+            letterSpacing: '0.05em',
+            transition: 'color 0.2s ease',
+            '&:hover': { color: '#a1a1aa' },
+            '@keyframes float': {
+              '0%, 100%': { transform: 'translateY(0)' },
+              '50%': { transform: 'translateY(4px)' },
+            },
+            animation: 'float 2.5s ease-in-out infinite',
           }}
         >
-          <KeyboardDoubleArrowDownIcon fontSize="small" />
-          View my work
+          <KeyboardArrowDownIcon sx={{ fontSize: '1rem' }} />
+          Explore
         </Box>
       </Box>
 
-      {/* Chat-active view */}
       <Box
         sx={{
           position: 'absolute',
@@ -233,11 +208,10 @@ const HeroChat = () => {
           display: 'flex',
           flexDirection: 'column',
           opacity: started ? 1 : 0,
-          transition: 'opacity 300ms ease-out 100ms',
+          transition: 'opacity 350ms ease-out 100ms',
           pointerEvents: started ? 'auto' : 'none',
         }}
       >
-        {/* Agent header */}
         <Box
           sx={{
             flexShrink: 0,
@@ -246,20 +220,20 @@ const HeroChat = () => {
             gap: 1.5,
             px: 3,
             py: 1.5,
-            borderBottom: '1px solid rgba(255,255,255,0.07)',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           <Box
             sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+              width: 32,
+              height: 32,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontWeight: 800,
-              fontSize: '1rem',
+              fontWeight: 700,
+              fontSize: '0.85rem',
               color: '#fff',
               flexShrink: 0,
             }}
@@ -267,32 +241,27 @@ const HeroChat = () => {
             D
           </Box>
           <Box sx={{ flex: 1 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', lineHeight: 1.2, color: '#fafafa' }}>
               David&apos;s AI Agent
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.2 }}>
-              Knows David&apos;s experience, projects &amp; skills
+            <Typography sx={{ fontSize: '0.7rem', color: '#52525b', lineHeight: 1.2 }}>
+              RAG-powered — knows experience, projects &amp; skills
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.3)' }}>
-            ↓ scroll for portfolio
-          </Typography>
         </Box>
 
-        {/* Messages list — minHeight: 0 forces flex to respect overflow boundary */}
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 2, pt: 1 }}>
           <MessagesList messages={messages} />
         </Box>
 
-        {/* Input bar */}
         <Box
           sx={{
             flexShrink: 0,
             px: 3,
             py: 1.5,
-            borderTop: '1px solid rgba(255,255,255,0.07)',
-            background: 'rgba(0,0,0,0.2)',
-            backdropFilter: 'blur(12px)',
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+            background: 'rgba(9,9,11,0.6)',
+            backdropFilter: 'blur(16px)',
           }}
         >
           <ChatInput
@@ -300,7 +269,7 @@ const HeroChat = () => {
             setInput={setInput}
             sendMessage={handleSend}
             disabled={!hasToken}
-            placeholder={!hasToken ? 'Verifying...' : 'Ask anything…'}
+            placeholder={!hasToken ? 'Verifying...' : 'Ask anything...'}
           />
         </Box>
       </Box>

--- a/next-app/src/components/Navbar/NavBar.js
+++ b/next-app/src/components/Navbar/NavBar.js
@@ -1,92 +1,159 @@
 'use client';
 
 import { Link as ScrollLink } from 'react-scroll';
-import { Toolbar, Box, AppBar, Typography } from '@mui/material';
+import { Toolbar, Box, AppBar, IconButton, Drawer, List, ListItem, ListItemButton, ListItemText } from '@mui/material';
 import { useState } from 'react';
-import Logo from './Logo';
-import './ScrollLink.css';
+import MenuIcon from '@mui/icons-material/Menu';
+import CloseIcon from '@mui/icons-material/Close';
 
-const linkStyles = {
-  margin: '0 16px',
-  fontWeight: 700,
-  textDecoration: 'none',
-  cursor: 'pointer',
-  fontFamily: 'Montserrat, Arial, sans-serif',
-  transition: 'all 0.3s ease',
-};
+const pages = ['About', 'Experience', 'Projects', 'Skills', 'Contact'];
 
-const FormattedLink = ({ page, active, setActivePage }) => {
-  return (
-    <ScrollLink
-      to={page.toLowerCase()}
-      spy={true}
-      smooth={true}
-      offset={-70}
-      duration={500}
-      onSetActive={() => setActivePage(page)}
-      className="scroll-link"
-      style={{
-        ...linkStyles,
-        color: active ? '#38c0f2' : 'rgba(255, 255, 255, 0.55)',
-        fontWeight: active ? 'bold' : 'normal',
-        borderBottom: active ? '1.5px solid #38c0f2' : 'none',
-        padding: '4px 8px',
-      }}
-    >
-      {page}
-    </ScrollLink>
-  );
-};
-
-const pages = ['About', 'Projects', 'Contact'];
+const NavLink = ({ page, active, setActivePage, onClick }) => (
+  <ScrollLink
+    to={page.toLowerCase()}
+    spy={true}
+    smooth={true}
+    offset={-80}
+    duration={600}
+    onSetActive={() => setActivePage(page)}
+    onClick={onClick}
+    style={{
+      fontSize: '0.8rem',
+      fontWeight: active ? 600 : 500,
+      textDecoration: 'none',
+      cursor: 'pointer',
+      fontFamily: 'var(--font-montserrat), system-ui, sans-serif',
+      letterSpacing: '0.04em',
+      transition: 'color 0.2s ease',
+      color: active ? '#fafafa' : '#71717a',
+      padding: '6px 12px',
+      borderRadius: '8px',
+      background: active ? 'rgba(255,255,255,0.06)' : 'transparent',
+    }}
+    onMouseEnter={(e) => {
+      if (!active) e.currentTarget.style.color = '#a1a1aa';
+    }}
+    onMouseLeave={(e) => {
+      if (!active) e.currentTarget.style.color = '#71717a';
+    }}
+  >
+    {page}
+  </ScrollLink>
+);
 
 const NavBar = () => {
-  const [activePage, setActivePage] = useState('About');
+  const [activePage, setActivePage] = useState('');
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (
-    <AppBar
-      position="fixed"
-      sx={{
-        top: 0,
-        zIndex: 1100,
-        width: '100%',
-        bgcolor: 'rgba(10, 8, 28, 0.75)',
-        backdropFilter: 'blur(16px)',
-        height: '64px',
-        color: '#ffffff',
-        transition: 'all 0.3s ease',
-        borderBottom: '1px solid rgba(56, 192, 242, 0.15)',
-        boxShadow: 'none',
-      }}
-    >
-      <Toolbar sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    <>
+      <AppBar
+        position="fixed"
+        sx={{
+          top: { xs: 0, md: 16 },
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: { xs: '100%', md: 'auto' },
+          maxWidth: { md: '520px' },
+          zIndex: 1100,
+          bgcolor: 'rgba(9, 9, 11, 0.7)',
+          backdropFilter: 'blur(20px) saturate(1.5)',
+          WebkitBackdropFilter: 'blur(20px) saturate(1.5)',
+          height: { xs: '56px', md: '48px' },
+          color: '#fafafa',
+          border: { xs: 'none', md: '1px solid rgba(255,255,255,0.06)' },
+          borderBottom: { xs: '1px solid rgba(255,255,255,0.06)', md: undefined },
+          borderRadius: { xs: 0, md: '14px' },
+          boxShadow: '0 4px 30px rgba(0,0,0,0.3)',
+        }}
+      >
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: { xs: 'space-between', md: 'center' },
+            minHeight: { xs: '56px', md: '48px' },
+            px: { xs: 2, md: 1.5 },
+            gap: 0.5,
+          }}
         >
-          <Logo />
-          <Typography
-            variant="h6"
-            component="div"
+          <Box
             sx={{
-              fontWeight: 800,
-              letterSpacing: '-0.5px',
-              fontFamily: 'Montserrat, sans-serif',
-              fontSize: '1.25rem',
-              color: '#ffffff',
+              display: { xs: 'flex', md: 'none' },
+              alignItems: 'center',
+              cursor: 'pointer',
+              fontWeight: 700,
+              fontSize: '0.95rem',
+              letterSpacing: '-0.02em',
             }}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           >
-            DAVID<span style={{ color: '#38c0f2' }}>RIVA</span>
-          </Typography>
-        </Box>
+            DR
+          </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center' }}>
-          {pages.map((page) => (
-            <FormattedLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
-          ))}
+          <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 0.25 }}>
+            {pages.map((page) => (
+              <NavLink key={page} page={page} active={activePage === page} setActivePage={setActivePage} />
+            ))}
+          </Box>
+
+          <IconButton
+            sx={{ display: { xs: 'flex', md: 'none' }, color: '#a1a1aa' }}
+            onClick={() => setDrawerOpen(true)}
+          >
+            <MenuIcon fontSize="small" />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        anchor="right"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            bgcolor: '#09090b',
+            width: 240,
+            borderLeft: '1px solid rgba(255,255,255,0.06)',
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
+          <IconButton onClick={() => setDrawerOpen(false)} sx={{ color: '#a1a1aa' }}>
+            <CloseIcon />
+          </IconButton>
         </Box>
-      </Toolbar>
-    </AppBar>
+        <List>
+          {pages.map((page) => (
+            <ListItem key={page} disablePadding>
+              <ScrollLink
+                to={page.toLowerCase()}
+                spy={true}
+                smooth={true}
+                offset={-70}
+                duration={600}
+                onClick={() => setDrawerOpen(false)}
+                style={{ width: '100%', textDecoration: 'none' }}
+              >
+                <ListItemButton sx={{ px: 3, py: 1.5 }}>
+                  <ListItemText
+                    primary={page}
+                    primaryTypographyProps={{
+                      sx: {
+                        color: '#a1a1aa',
+                        fontSize: '0.9rem',
+                        fontWeight: 500,
+                        letterSpacing: '0.04em',
+                      },
+                    }}
+                  />
+                </ListItemButton>
+              </ScrollLink>
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+    </>
   );
 };
 

--- a/next-app/src/components/ParticleBackground.js
+++ b/next-app/src/components/ParticleBackground.js
@@ -5,7 +5,6 @@ import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import baseOptions from '../particles-options/parallax-bubble.json';
 
-// Start engine initialization immediately on module load, not on component mount
 const engineReady = initParticlesEngine(async (engine) => {
   await loadSlim(engine);
 });
@@ -26,7 +25,7 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
         ...baseOptions.background,
         color: {
           ...baseOptions.background?.color,
-          value: isTransparent ? '#000000' : (backgroundColor || '#0b0920'),
+          value: isTransparent ? '#000000' : (backgroundColor || '#09090b'),
         },
         opacity: isTransparent ? 0 : (baseOptions.background?.opacity ?? 1),
       },
@@ -36,10 +35,23 @@ const ParticleBackground = ({ interactive = true, backgroundColor }) => {
           ...baseOptions.particles?.color,
           value: '#ffffff',
         },
+        number: {
+          ...baseOptions.particles?.number,
+          value: 30,
+        },
+        opacity: {
+          ...baseOptions.particles?.opacity,
+          value: 0.15,
+        },
+        size: {
+          ...baseOptions.particles?.size,
+          value: { min: 1, max: 2 },
+        },
         links: baseOptions.particles?.links
           ? {
               ...baseOptions.particles.links,
               color: { ...baseOptions.particles.links.color, value: '#ffffff' },
+              opacity: 0.06,
             }
           : baseOptions.particles?.links,
       },

--- a/next-app/src/components/Projects-Page/ProjectCard.js
+++ b/next-app/src/components/Projects-Page/ProjectCard.js
@@ -2,168 +2,142 @@
 
 import Image from 'next/image';
 import { forwardRef } from 'react';
-import CardContent from '@mui/material/CardContent';
-import { Typography, Box, Card, Button, Chip, Stack } from '@mui/material';
+import { Typography, Box, Card, CardContent, Chip, Stack, IconButton } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
 
-const ProjectImage = ({ coverImage, title, featured }) => {
-  return (
-    <Box
-      sx={{
-        position: 'relative',
-        height: featured ? '220px' : '180px',
-        width: '100%',
-        bgcolor: 'background.paper',
-        overflow: 'hidden',
-      }}
-    >
-      <Image
-        src={`/images/${coverImage}`}
-        alt={`${title} cover`}
-        style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
-        className="project-image"
-        fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      />
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: 'linear-gradient(to bottom, transparent 0%, rgba(15, 12, 41, 0.65) 100%)',
-        }}
-      />
-    </Box>
-  );
-};
-
-const ProjectHeader = ({ title, dateStarted, dateCompleted, short_description, featured }) => {
-  return (
-    <Box sx={{ mb: 2 }}>
-      <Typography
-        variant={featured ? 'h6' : 'body1'}
-        component="h3"
-        sx={{ fontWeight: 700, mb: 0.5, color: '#ffffff', lineHeight: 1.3, fontSize: featured ? '1rem' : '0.9rem' }}
-      >
-        {title}
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'rgba(255, 255, 255, 0.35)', display: 'block', mb: 1.5 }}>
-        {dateStarted} – {dateCompleted}
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: 'rgba(255, 255, 255, 0.55)',
-          lineHeight: 1.6,
-          mb: 2,
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          fontSize: featured ? '0.85rem' : '0.8rem',
-        }}
-      >
-        {short_description}
-      </Typography>
-    </Box>
-  );
-};
-
-const ProjectTech = ({ technologies }) => {
-  const allTools = technologies.flatMap((t) => t.tools);
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2.5 }}>
-      {allTools.map((tool, index) => (
-        <Chip
-          key={index}
-          label={tool}
-          size="small"
-          sx={{
-            bgcolor: 'rgba(56, 192, 242, 0.08)',
-            color: '#38c0f2',
-            border: '1px solid rgba(56, 192, 242, 0.2)',
-            backdropFilter: 'blur(4px)',
-            fontSize: '0.7rem',
-            height: '22px',
-            '&:hover': { bgcolor: 'rgba(56, 192, 242, 0.15)' },
-          }}
-        />
-      ))}
-    </Stack>
-  );
-};
-
-const ProjectFooter = ({ link }) => {
-  return (
-    <Button
-      variant="outlined"
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      endIcon={<LaunchIcon fontSize="small" />}
-      fullWidth
-      sx={{
-        mt: 'auto',
-        color: '#38c0f2',
-        borderColor: 'rgba(56,192,242,0.4)',
-        borderRadius: '8px',
-        textTransform: 'none',
-        fontSize: '0.8rem',
-        py: 0.75,
-        '&:hover': {
-          borderColor: '#38c0f2',
-          bgcolor: 'rgba(56, 192, 242, 0.1)',
-        },
-      }}
-    >
-      View Project
-    </Button>
-  );
-};
-
 const ProjectCard = forwardRef(
-  (
-    { coverImage, title, author, dateStarted, dateCompleted, short_description, technologies, link, featured, onClick, id },
-    ref
-  ) => {
+  ({ coverImage, title, dateStarted, dateCompleted, short_description, technologies, link, featured }, ref) => {
+    const allTools = technologies.flatMap((t) => t.tools);
+
     return (
       <Card
         ref={ref}
-        id={id}
         sx={{
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: featured ? 'rgba(56,192,242,0.04)' : 'rgba(255, 255, 255, 0.03)',
-          color: '#ffffff',
-          backdropFilter: 'blur(10px)',
-          border: featured ? '1px solid rgba(56, 192, 242, 0.2)' : '1px solid rgba(255,255,255,0.07)',
+          bgcolor: 'rgba(255,255,255,0.02)',
+          color: '#fafafa',
+          border: '1px solid rgba(255,255,255,0.06)',
           borderRadius: '16px',
           overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          cursor: onClick ? 'pointer' : 'default',
-          boxShadow: featured ? '0 4px 24px rgba(56,192,242,0.06)' : '0 4px 16px rgba(0,0,0,0.15)',
+          transition: 'all 0.3s ease',
           '&:hover': {
-            transform: 'translateY(-6px)',
-            boxShadow: featured
-              ? '0 12px 30px rgba(0,0,0,0.3), 0 0 24px rgba(56, 192, 242, 0.15)'
-              : '0 10px 24px rgba(0,0,0,0.25)',
-            border: featured ? '1px solid rgba(56, 192, 242, 0.45)' : '1px solid rgba(255,255,255,0.15)',
-            '& .project-image': { transform: 'scale(1.05)' },
+            borderColor: featured ? 'rgba(59,130,246,0.3)' : 'rgba(255,255,255,0.12)',
+            background: 'rgba(255,255,255,0.03)',
+            '& .project-image': { transform: 'scale(1.03)' },
           },
         }}
-        onClick={onClick}
       >
-        <ProjectImage coverImage={coverImage} title={title} featured={featured} />
-        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: featured ? 3 : 2.5 }}>
-          <ProjectHeader
-            title={title}
-            dateStarted={dateStarted}
-            dateCompleted={dateCompleted}
-            short_description={short_description}
-            featured={featured}
+        <Box sx={{ position: 'relative', height: featured ? 200 : 160, width: '100%', overflow: 'hidden' }}>
+          <Image
+            src={`/images/${coverImage}`}
+            alt={`${title} cover`}
+            style={{ objectFit: 'cover', transition: 'transform 0.5s ease' }}
+            className="project-image"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
-          <ProjectTech technologies={technologies} />
-          <ProjectFooter link={link} />
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(to bottom, transparent 40%, rgba(9,9,11,0.9) 100%)',
+            }}
+          />
+          {featured && (
+            <Chip
+              label="Featured"
+              size="small"
+              sx={{
+                position: 'absolute',
+                top: 12,
+                right: 12,
+                height: 22,
+                fontSize: '0.65rem',
+                fontWeight: 600,
+                bgcolor: 'rgba(59,130,246,0.15)',
+                color: '#3b82f6',
+                border: '1px solid rgba(59,130,246,0.3)',
+                backdropFilter: 'blur(8px)',
+              }}
+            />
+          )}
+        </Box>
+
+        <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', p: 2.5, pt: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}>
+            <Typography sx={{ fontSize: '0.95rem', fontWeight: 600, color: '#fafafa', lineHeight: 1.3, flex: 1 }}>
+              {title}
+            </Typography>
+            <IconButton
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="small"
+              sx={{
+                color: '#52525b',
+                ml: 1,
+                flexShrink: 0,
+                width: 28,
+                height: 28,
+                transition: 'color 0.2s ease',
+                '&:hover': { color: '#3b82f6' },
+              }}
+            >
+              <LaunchIcon sx={{ fontSize: '0.85rem' }} />
+            </IconButton>
+          </Box>
+
+          <Typography sx={{ fontSize: '0.68rem', color: '#52525b', mb: 1.5 }}>
+            {dateStarted} — {dateCompleted}
+          </Typography>
+
+          <Typography
+            sx={{
+              fontSize: '0.8rem',
+              color: '#71717a',
+              lineHeight: 1.6,
+              mb: 2,
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {short_description}
+          </Typography>
+
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 'auto' }}>
+            {allTools.slice(0, 6).map((tool, index) => (
+              <Chip
+                key={index}
+                label={tool}
+                size="small"
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  color: '#71717a',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                  fontSize: '0.65rem',
+                  height: 22,
+                  fontWeight: 500,
+                }}
+              />
+            ))}
+            {allTools.length > 6 && (
+              <Chip
+                label={`+${allTools.length - 6}`}
+                size="small"
+                sx={{
+                  bgcolor: 'transparent',
+                  color: '#52525b',
+                  fontSize: '0.65rem',
+                  height: 22,
+                  fontWeight: 500,
+                }}
+              />
+            )}
+          </Stack>
         </CardContent>
       </Card>
     );

--- a/next-app/src/components/Projects-Page/Projects.js
+++ b/next-app/src/components/Projects-Page/Projects.js
@@ -2,26 +2,10 @@ import { Box } from '@mui/material';
 import SectionHeading from '@/components/SectionHeading';
 import ProjectsContainer from './ProjectsContainer';
 
-export const metadata = {
-  title: 'David Riva | Projects',
-};
-
 const Projects = () => {
   return (
-    <Box
-      sx={{
-        pt: '60px',
-        pb: '60px',
-        pl: { xs: 0, sm: 0, md: '80px' },
-        pr: { xs: 0, sm: 0, md: '80px' },
-        margin: '0 auto',
-        textAlign: 'center',
-        // borderTop: '8px solid rgba(0,0,0,0.1)', // Removed border
-        // backgroundColor: '#565859', // Removed background to blend with main page
-      }}
-    >
-      <SectionHeading sectionName="Projects" />
-
+    <Box sx={{ maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 }, textAlign: 'center' }}>
+      <SectionHeading sectionName="Projects" subtitle="What I've built" />
       <ProjectsContainer />
     </Box>
   );

--- a/next-app/src/components/Projects-Page/ProjectsContainer.js
+++ b/next-app/src/components/Projects-Page/ProjectsContainer.js
@@ -18,14 +18,14 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
     const cards = containerRef.current.querySelectorAll('.featured-card-item');
     gsap.fromTo(
       cards,
-      { y: 40, opacity: 0 },
+      { y: 30, opacity: 0 },
       {
         y: 0,
         opacity: 1,
-        duration: 0.75,
-        stagger: 0.12,
-        ease: 'power3.out',
-        scrollTrigger: { trigger: containerRef.current, start: 'top 80%' },
+        duration: 0.6,
+        stagger: 0.1,
+        ease: 'power2.out',
+        scrollTrigger: { trigger: containerRef.current, start: 'top 85%' },
       }
     );
     ScrollTrigger.refresh();
@@ -34,7 +34,7 @@ const FeaturedProjects = memo(function FeaturedProjects({ projects }) {
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.title} className="featured-card-item">
             <ProjectCard {...project} featured />
@@ -52,16 +52,12 @@ const AllProjects = ({ projects }) => {
   useEffect(() => {
     if (!containerRef.current || projects.length === 0) return;
     const cards = containerRef.current.querySelectorAll('.all-card-item');
-    gsap.fromTo(
-      cards,
-      { y: 30, opacity: 0 },
-      { y: 0, opacity: 1, duration: 0.6, stagger: 0.08, ease: 'power2.out' }
-    );
+    gsap.fromTo(cards, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.5, stagger: 0.06, ease: 'power2.out' });
   }, [projects]);
 
   return (
     <Box ref={containerRef}>
-      <Grid container spacing={3} sx={{ width: '100%', margin: 0 }}>
+      <Grid container spacing={2.5} sx={{ width: '100%', margin: 0 }}>
         {projects.map((project) => (
           <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={project.title} className="all-card-item">
             <ProjectCard {...project} />
@@ -92,45 +88,41 @@ const ProjectsContainer = () => {
   const otherProjects = useMemo(() => projectData.filter((p) => !p.featured), [projectData]);
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '1400px', margin: '0 auto', px: { xs: 2, md: 4, lg: 6 } }}>
+    <Box sx={{ width: '100%' }}>
       {loading ? (
-        <Grid container spacing={3}>
+        <Grid container spacing={2.5}>
           {[1, 2, 3].map((item) => (
             <Grid key={item} size={{ xs: 12, sm: 6, md: 4 }}>
-              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}>
-                <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 1 }} />
-                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.5rem' }} />
-                <Skeleton variant="text" width="60%" />
-                <Skeleton variant="text" sx={{ mt: 1 }} height={60} />
+              <Box sx={{ p: 2, bgcolor: 'rgba(255,255,255,0.02)', borderRadius: '16px', border: '1px solid rgba(255,255,255,0.06)' }}>
+                <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" sx={{ mt: 2, fontSize: '1.2rem', bgcolor: 'rgba(255,255,255,0.04)' }} />
+                <Skeleton variant="text" width="60%" sx={{ bgcolor: 'rgba(255,255,255,0.04)' }} />
               </Box>
             </Grid>
           ))}
         </Grid>
       ) : (
-        <Box sx={{ py: 3 }}>
+        <>
           <FeaturedProjects projects={featuredProjects} />
 
-          <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <Box sx={{ mt: 5, textAlign: 'center' }}>
             <Button
               onClick={() => setShowAll((prev) => !prev)}
               endIcon={showAll ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               sx={{
-                color: 'rgba(255,255,255,0.55)',
-                borderColor: 'rgba(255,255,255,0.15)',
-                border: '1px solid',
-                borderRadius: '50px',
+                color: '#71717a',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '10px',
                 px: 3,
                 py: 0.85,
                 textTransform: 'none',
-                fontSize: '0.85rem',
+                fontSize: '0.8rem',
                 fontWeight: 500,
-                backdropFilter: 'blur(8px)',
-                bgcolor: 'rgba(255,255,255,0.03)',
-                transition: 'all 0.25s ease',
+                transition: 'all 0.2s ease',
                 '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.07)',
-                  borderColor: 'rgba(255,255,255,0.3)',
-                  color: '#ffffff',
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  borderColor: 'rgba(255,255,255,0.15)',
+                  color: '#a1a1aa',
                 },
               }}
             >
@@ -139,11 +131,11 @@ const ProjectsContainer = () => {
           </Box>
 
           <Collapse in={showAll} timeout={400}>
-            <Box sx={{ mt: 4 }}>
+            <Box sx={{ mt: 3 }}>
               <AllProjects projects={otherProjects} />
             </Box>
           </Collapse>
-        </Box>
+        </>
       )}
     </Box>
   );

--- a/next-app/src/components/SectionHeading.js
+++ b/next-app/src/components/SectionHeading.js
@@ -1,41 +1,32 @@
 import { Box, Typography } from '@mui/material';
 
-const SectionHeading = ({ sectionName }) => {
+const SectionHeading = ({ sectionName, subtitle }) => {
   return (
-    <Box 
-      sx={{ 
-        mb: '100px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        pt: '40px'
-      }}
-    >
+    <Box sx={{ mb: { xs: 6, md: 8 }, textAlign: 'center' }}>
       <Typography
-        variant="h2"
+        variant="overline"
         sx={{
-          fontWeight: 800,
-          color: 'inherit',
-          fontSize: { xs: '2.5rem', md: '4rem' },
-          letterSpacing: '-0.02em',
-          lineHeight: 1.1,
-          textAlign: 'center',
-          position: 'relative',
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: '-15px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '50px',
-            height: '4px',
-            background: 'linear-gradient(90deg, #38c0f2 0%, #07a2f7 100%)',
-            borderRadius: '10px'
-          }
+          color: '#3b82f6',
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          letterSpacing: '0.2em',
+          mb: 1.5,
+          display: 'block',
         }}
       >
         {sectionName}
       </Typography>
+      {subtitle && (
+        <Typography
+          variant="h2"
+          sx={{
+            fontSize: { xs: '2rem', md: '3rem' },
+            color: '#fafafa',
+          }}
+        >
+          {subtitle}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/next-app/src/components/Skills/Skills.js
+++ b/next-app/src/components/Skills/Skills.js
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack, Grid } from '@mui/material';
+import SectionHeading from '@/components/SectionHeading';
+
+const categoryColors = {
+  Languages: '#3b82f6',
+  'AI Orchestration & Machine Learning': '#8b5cf6',
+  'Web Development': '#06b6d4',
+  'Big Data & Cloud': '#f59e0b',
+  'Databases & Tools': '#22c55e',
+  'Testing & Validation': '#ef4444',
+  'Data Science Libraries': '#ec4899',
+};
+
+const SkillCategory = ({ title, items }) => {
+  const color = categoryColors[title] || '#3b82f6';
+
+  return (
+    <Box
+      sx={{
+        p: 2.5,
+        borderRadius: '16px',
+        background: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        height: '100%',
+        transition: 'all 0.3s ease',
+        '&:hover': {
+          borderColor: `${color}20`,
+          background: `${color}05`,
+        },
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          fontWeight: 600,
+          color,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          mb: 1.5,
+        }}
+      >
+        {title}
+      </Typography>
+      <Stack direction="row" flexWrap="wrap" gap={0.75}>
+        {items.map((item) => (
+          <Chip
+            key={item}
+            label={item}
+            size="small"
+            sx={{
+              bgcolor: 'rgba(255,255,255,0.04)',
+              color: '#a1a1aa',
+              border: '1px solid rgba(255,255,255,0.06)',
+              fontSize: '0.72rem',
+              height: 26,
+              fontWeight: 500,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                bgcolor: `${color}12`,
+                borderColor: `${color}30`,
+                color: '#fafafa',
+              },
+            }}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+const Skills = () => {
+  const [skills, setSkills] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/skills.json')
+      .then((res) => res.json())
+      .then((data) => setSkills(data));
+  }, []);
+
+  return (
+    <Box sx={{ maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 8, md: 12 } }}>
+      <SectionHeading sectionName="Skills" subtitle="Technologies I work with" />
+
+      <Grid container spacing={2}>
+        {skills.map((category) => (
+          <Grid key={category.title} size={{ xs: 12, sm: 6, md: 4 }}>
+            <SkillCategory title={category.title} items={category.items} />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default Skills;

--- a/next-app/src/components/StyledButton.jsx
+++ b/next-app/src/components/StyledButton.jsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@mui/material';
+import { Button } from '@mui/material';
 
 const StyledButton = ({ href, onClick, text, icon, component, ...props }) => {
   return (
@@ -8,36 +8,26 @@ const StyledButton = ({ href, onClick, text, icon, component, ...props }) => {
       component={component}
       {...props}
       sx={{
-        marginTop: '20px',
-        backgroundColor: 'rgba(10, 115, 201, 0.15)',
-        border: '2px solid #38c0f2',
-        borderRadius: '50px',
-        padding: '12px 24px',
-        color: '#38c0f2',
-        display: 'flex',
+        backgroundColor: 'rgba(59, 130, 246, 0.08)',
+        border: '1px solid rgba(59, 130, 246, 0.25)',
+        borderRadius: '10px',
+        padding: '10px 20px',
+        color: '#3b82f6',
+        display: 'inline-flex',
         alignItems: 'center',
-        justifyContent: 'center',
-        gap: '10px',
-        fontWeight: 'bold',
-        boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
-        transition: 'all 0.3s ease-in-out',
+        gap: '8px',
+        fontWeight: 600,
+        fontSize: '0.85rem',
+        letterSpacing: '0.02em',
+        transition: 'all 0.2s ease',
         textTransform: 'none',
         '&:hover': {
-          backgroundColor: 'rgba(10, 115, 201, 0.3)',
-          transform: 'scale(1.05)',
-          boxShadow: '0px 6px 8px rgba(0, 0, 0, 0.15)',
+          backgroundColor: 'rgba(59, 130, 246, 0.15)',
+          borderColor: 'rgba(59, 130, 246, 0.5)',
         },
       }}
     >
-      <Typography
-        sx={{
-          color: '#38c0f2',
-          fontSize: { xs: '0.9rem', sm: '1rem', md: '1.1rem' },
-          fontWeight: '500',
-        }}
-      >
-        {text}
-      </Typography>
+      {text}
       {icon}
     </Button>
   );

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,34 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: 'rgba(255, 255, 255, 0.03)',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: '#a1a1aa',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#3b82f6',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#8b5cf6',
     },
   },
+  shape: {
+    borderRadius: 16,
+  },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-montserrat), system-ui, -apple-system, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.04em', lineHeight: 1.05 },
+    h2: { fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1.1 },
+    h3: { fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.15 },
+    h4: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7, color: '#a1a1aa' },
+    body2: { fontWeight: 400, lineHeight: 1.6, color: '#a1a1aa' },
+    caption: { color: '#71717a' },
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual overhaul of the portfolio site with a refined minimalist design language inspired by 2026 UI/UX trends.

- **New design system**: Deep charcoal background (#09090b) with blue (#3b82f6) and violet (#8b5cf6) accents, tighter typography with better weight hierarchy, and consistent spacing
- **Floating pill navigation**: Centered glassmorphism nav bar with mobile drawer support, replacing the full-width sticky header
- **Bento grid About section**: Photo card, bio, social links, and stat tiles (3+ years exp, 11 projects, 4.0 GPA, 4 awards) in a modern grid layout
- **New Experience section**: Dedicated timeline-style cards with company logos, bullet points, and date ranges — previously hidden behind a side panel on wide screens only
- **New Skills section**: Seven categorized skill groups with color-coded headers and hoverable tag chips
- **Redesigned project cards**: Cleaner layout with featured badges, external link icons, and tech stack chips
- **Subtler particle background**: Reduced density and opacity for a more refined feel
- **Updated chat UI**: Rounded input with arrow-up send button, cleaner message bubbles with updated color palette
- **Minimal footer**: Centered back-to-top button with social icons

### What's preserved
- All API routes (chat, token, contact, health) — zero backend changes
- Chat functionality (useChat hook, Turnstile auth, streaming SSE, cached chip responses)
- All data files (projects.json, experiences.json, skills.json, awards.json)
- Particle background engine (tsParticles)
- GSAP scroll-triggered animations on project cards

## Test plan

- [ ] Verify hero section renders with name, typing animation, chat input, and suggestion chips
- [ ] Verify chat works end-to-end: chip click shows cached response, typed message streams from API
- [ ] Verify About bento grid displays photo, bio text, social links (GitHub, LinkedIn, email, resume), and stat cards
- [ ] Verify Experience section loads all 5 entries from experiences.json with correct sorting
- [ ] Verify Projects section shows 3 featured cards, "View all" expands to show remaining projects
- [ ] Verify Skills section displays all 7 categories with correct items
- [ ] Verify Contact form submits with Turnstile CAPTCHA
- [ ] Verify floating nav scrolls to correct sections; mobile hamburger menu works
- [ ] Verify footer back-to-top and social links work
- [ ] Verify responsive layout on mobile (xs), tablet (sm/md), and desktop (lg)
- [ ] Run `npm run build` — passes cleanly
- [ ] Run `npm run lint` — no warnings or errors

https://claude.ai/code/session_01VdQCTSp1xxFWXbyhvmqS1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdQCTSp1xxFWXbyhvmqS1V)_