### PR TITLE
Redesign portfolio with modern 2026 UI

### DIFF
--- a/next-app/src/app/layout.js
+++ b/next-app/src/app/layout.js
@@ -2,24 +2,33 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
-import { Montserrat } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
-const montserrat = Montserrat({
-  weight: ['400', '700'],
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-montserrat',
+  variable: '--font-inter',
 });
 
 export const metadata = {
-  title: 'David Riva | Full Stack Software Engineer Portfolio',
-  description: "Explore the portfolio of David Riva, a software engineer specializing in UI/UX, full-stack development, and data visualization. View projects involving React, Node.js, and Distributed Systems.",
-  keywords: ["David Riva", "Software Engineer", "Full Stack Developer", "UI/UX Design", "React Developer", "Node.js", "Portfolio", "Web Development"],
+  title: 'David Riva | Software Engineer',
+  description:
+    "Explore the portfolio of David Riva, a software engineer specializing in AI engineering, full-stack development, and data visualization. View projects involving React, Next.js, LangChain, and distributed systems.",
+  keywords: [
+    'David Riva',
+    'Software Engineer',
+    'AI Engineer',
+    'Full Stack Developer',
+    'React Developer',
+    'LangChain',
+    'Portfolio',
+    'Web Development',
+  ],
   openGraph: {
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and big data visualization.',
+    title: 'David Riva - Software Engineer',
+    description: 'Software engineer specializing in AI engineering and full-stack development.',
     url: 'https://davidriva.dev',
     siteName: 'David Riva Portfolio',
     images: [
@@ -34,8 +43,8 @@ export const metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'David Riva - Personal Portfolio',
-    description: 'Experienced software engineer specializing in UI/UX and data visualization.',
+    title: 'David Riva - Software Engineer',
+    description: 'Software engineer specializing in AI engineering and full-stack development.',
     images: ['https://davidriva.dev/images/website_preview.png'],
   },
 };
@@ -43,7 +52,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={montserrat.variable}>
+      <body className={inter.variable} style={{ margin: 0 }}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/next-app/src/app/page.js
+++ b/next-app/src/app/page.js
@@ -2,84 +2,51 @@
 
 import { Box } from '@mui/material';
 import dynamic from 'next/dynamic';
+import Nav from '@/components/layout/Nav';
+import Hero from '@/components/sections/Hero';
+import Footer from '@/components/layout/Footer';
 
-const About = dynamic(() => import('@/components/About-Page/About'), { ssr: false });
-const Projects = dynamic(() => import('@/components/Projects-Page/Projects'), { ssr: false });
-const Contact = dynamic(() => import('@/components/Contact-Page/Contact'), { ssr: false });
-import HeroChat from '@/components/Greeting-Page/HeroChat';
-import ParticleBackground from '@/components/ParticleBackground';
-import NavBar from '@/components/Navbar/NavBar';
-import Footer from '@/components/Footer/Footer';
+const About = dynamic(() => import('@/components/sections/About'), { ssr: false });
+const Experience = dynamic(() => import('@/components/sections/Experience'), { ssr: false });
+const Projects = dynamic(() => import('@/components/sections/Projects'), { ssr: false });
+const Skills = dynamic(() => import('@/components/sections/Skills'), { ssr: false });
+const Awards = dynamic(() => import('@/components/sections/Awards'), { ssr: false });
+const Contact = dynamic(() => import('@/components/sections/Contact'), { ssr: false });
+const ChatDrawer = dynamic(() => import('@/components/chat/ChatDrawer'), { ssr: false });
 
 const MainPage = () => {
   return (
     <Box
       sx={{
-        bgcolor: '#0b0920',
-        color: '#ffffff',
-        position: 'relative',
+        bgcolor: '#09090b',
+        color: '#fafafa',
         minHeight: '100vh',
+        position: 'relative',
       }}
     >
-      <NavBar />
+      <Nav />
+      <Hero />
 
       <Box
         sx={{
           position: 'relative',
-          height: '100vh',
-          background: 'linear-gradient(135deg, #0f0c29, #302b63, #0d1b2a, #1a0a2e)',
-          backgroundSize: '400% 400%',
-          animation: 'gradShift 16s ease infinite',
-          '@keyframes gradShift': {
-            '0%': { backgroundPosition: '0% 50%' },
-            '50%': { backgroundPosition: '100% 50%' },
-            '100%': { backgroundPosition: '0% 50%' },
+          '& > *:not(:last-child)': {
+            borderBottom: '1px solid rgba(255,255,255,0.04)',
           },
         }}
       >
-        <ParticleBackground backgroundColor="transparent" />
-        <HeroChat />
-      </Box>
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Box
-          id="about"
-          sx={{
-            background: 'linear-gradient(180deg, #12102a 0%, #0e0c22 100%)',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <About />
-        </Box>
-
-        <Box
-          id="projects"
-          sx={{
-            bgcolor: '#0b0920',
-            width: '100%',
-            color: '#ffffff',
-            borderBottom: '1.5px solid rgba(255, 255, 255, 0.08)',
-          }}
-        >
-          <Projects />
-        </Box>
-
-        <Box
-          id="contact"
-          sx={{
-            background: 'linear-gradient(180deg, #0e0c22 0%, #0a0818 100%)',
-            width: '100%',
-            color: '#ffffff',
-          }}
-        >
-          <Contact />
-        </Box>
+        <About />
+        <Experience />
+        <Projects />
+        <Skills />
+        <Awards />
+        <Contact />
       </Box>
 
       <Footer />
+      <ChatDrawer />
     </Box>
   );
 };
+
 export default MainPage;

--- a/next-app/src/components/Chat-Page/ChatInput.jsx
+++ b/next-app/src/components/Chat-Page/ChatInput.jsx
@@ -15,11 +15,11 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         p: '4px 8px',
         borderRadius: '999px',
         backgroundColor: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(56,192,242,0.3)',
+        border: '1px solid rgba(129,140,248,0.25)',
         backdropFilter: 'blur(12px)',
         boxShadow: 'none',
-        '&:hover': { borderColor: 'rgba(56,192,242,0.6)' },
-        '&:focus-within': { borderColor: '#38c0f2' },
+        '&:hover': { borderColor: 'rgba(129,140,248,0.5)' },
+        '&:focus-within': { borderColor: '#818cf8' },
       }}
     >
       <InputBase
@@ -37,7 +37,7 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
           ml: 1,
           flex: 1,
           color: '#fff',
-          fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+          fontFamily: 'var(--font-inter), system-ui, sans-serif',
           '& input::placeholder': { color: 'rgba(255,255,255,0.35)' },
         }}
       />
@@ -46,7 +46,7 @@ const ChatInput = ({ input, setInput, sendMessage, disabled = false, placeholder
         disabled={!input.trim() || disabled}
         sx={{
           ml: 1,
-          background: 'linear-gradient(135deg, #38c0f2, #6e40c9)',
+          background: 'linear-gradient(135deg, #6366f1, #818cf8)',
           '&:hover': { opacity: 0.85 },
           '&.Mui-disabled': { background: 'rgba(255,255,255,0.08)' },
         }}

--- a/next-app/src/components/Chat-Page/MessageItem.jsx
+++ b/next-app/src/components/Chat-Page/MessageItem.jsx
@@ -7,7 +7,7 @@ const MessageItem = ({ msg }) => {
   const showDots = msg.role === 'assistant' && (!msg.text || msg.text.length === 0);
 
   const mdStyles = {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
     fontWeight: 400,
     lineHeight: 1.6,
     fontSize: '0.95rem',
@@ -29,16 +29,16 @@ const MessageItem = ({ msg }) => {
           px: 2.5,
           py: 1.5,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-          background: isUser ? 'rgba(56,192,242,0.12)' : 'rgba(255,255,255,0.05)',
+          background: isUser ? 'rgba(99,102,241,0.1)' : 'rgba(255,255,255,0.04)',
           border: isUser
-            ? '1px solid rgba(56,192,242,0.22)'
-            : '1px solid rgba(255,255,255,0.09)',
+            ? '1px solid rgba(129,140,248,0.2)'
+            : '1px solid rgba(255,255,255,0.07)',
         }}
       >
         {msg.role === 'assistant' ? (
           showDots ? (
             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
-              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#38c0f2" spacing={4} />
+              <BouncingDotsLoadingAnimation dotSize={8} dotColor="#818cf8" spacing={4} />
             </Box>
           ) : (
             <ReactMarkdown
@@ -55,8 +55,8 @@ const MessageItem = ({ msg }) => {
                     component="code"
                     sx={{
                       fontFamily: 'monospace',
-                      color: '#38c0f2',
-                      backgroundColor: 'rgba(56,192,242,0.08)',
+                      color: '#818cf8',
+                      backgroundColor: 'rgba(129,140,248,0.08)',
                       p: '0 4px',
                       borderRadius: 1,
                       display: 'inline',
@@ -71,7 +71,7 @@ const MessageItem = ({ msg }) => {
                     {...props}
                   />
                 ),
-                a: (props) => <a style={{ color: '#38c0f2', textDecoration: 'none' }} {...props} />,
+                a: (props) => <a style={{ color: '#a5b4fc', textDecoration: 'none' }} {...props} />,
               }}
             >
               {msg.text}

--- a/next-app/src/components/chat/ChatDrawer.jsx
+++ b/next-app/src/components/chat/ChatDrawer.jsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, IconButton, Fab, Chip, Stack, Drawer, Fade } from '@mui/material';
+import SmartToyIcon from '@mui/icons-material/SmartToy';
+import CloseIcon from '@mui/icons-material/Close';
+import { Turnstile } from '@marsidev/react-turnstile';
+import ChatInput from '@/components/Chat-Page/ChatInput';
+import MessagesList from '@/components/Chat-Page/MessagesList';
+import useChat from '@/components/Chat-Page/hooks/useChat';
+
+const CHIP_CACHE = {
+  'What AI have you built?': `David has built several impressive AI projects.
+
+**[Production RAG Pipeline](https://github.com/davidjriva/Production_RAG_Pipeline)** is a production-grade system for answering natural language questions over PDFs. It uses hybrid retrieval (Pinecone + BM25), cross-encoder reranking, and automated RAGAS quality gates to ensure faithfulness and relevancy. The pipeline is orchestrated with a LangGraph state machine and traced via LangSmith.
+
+**[Agentic AI News Summary Service](https://github.com/davidjriva/Agentic_AI_News_Summary_Service)** is a fully automated newsletter that runs twice daily. It fetches from 10+ RSS feeds, scores each article with Claude using ephemeral prompt caching, and emails a ranked digest — all with zero manual intervention.
+
+**[This portfolio's chat agent](https://github.com/davidjriva/Personal-Portfolio)** is the one you're talking to right now — a RAG agent built with Next.js and GPT-4o-mini, with streaming responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval eval suite.
+
+David also took **1st place at C3 AI's Agentic AI Hackathon 2025**, building agentic developer tooling with React, TypeScript, and an in-house LLM.`,
+
+  'Tell me about your experience': `Here's a quick overview of David's background.
+
+Most recently he was a **Training Engineer, Generative AI at C3 AI** (Sept 2024 – Apr 2026), where he built and maintained their core training platform serving 8,000+ learners, created internal automation tools that cut feedback turnaround time by 80%, and won 1st place at the C3 Agentic AI Hackathon 2025.
+
+Before that, he was a **Full-Stack Developer on a university research team at Colorado State University** (Dec 2022 – Jan 2024), building an accessible interface to 20TB+ environmental datasets using React, TypeScript, Python/Flask, and MongoDB. That project won the Excellence in Data Science Award at CSU's Celebrating Undergraduate Research Competition.
+
+In between, he interned as a **Machine Learning Engineer at Hewlett Packard Inc.** (May – Aug 2023), building ETL pipelines on AWS and developing ML forecasting models with Scikit-Learn and Facebook Prophet.
+
+David graduated from Colorado State University in May 2024 with a B.S. in Computer Science, *Summa Cum Laude*.`,
+
+  'Featured projects': `Here are three of David's featured projects.
+
+**[Production RAG Pipeline](https://github.com/davidjriva/Production_RAG_Pipeline)** *(Mar – Apr 2025)* — a production-grade RAG system for answering natural language questions over PDFs. It combines dense and BM25 retrieval, cross-encoder reranking, and RAGAS quality gates to keep responses accurate and grounded. Built with LangChain, LangGraph, Pinecone, and FastAPI.
+
+**[Agentic AI News Summary Service](https://github.com/davidjriva/Agentic_AI_News_Summary_Service)** *(Feb – Mar 2025)* — an automated newsletter pipeline that fetches from 10+ RSS feeds, scores articles with Claude (using prompt caching), and emails a ranked daily digest. Runs on a launchd schedule with a FastAPI dashboard — no infrastructure needed.
+
+**[This portfolio](https://github.com/davidjriva/Personal-Portfolio)** *(Nov 2024 – Apr 2025)* — the site you're on now. It has an embedded GPT-4o-mini RAG agent, streaming SSE responses, JWT + Turnstile auth, Redis rate limiting, and a DeepEval automated eval suite. Built with Next.js, React, and MUI.`,
+};
+
+const PRESET_CHIPS = [
+  { label: 'What AI have you built?', color: '#818cf8' },
+  { label: 'Tell me about your experience', color: '#a78bfa' },
+  { label: 'Featured projects', color: '#a1a1aa' },
+];
+
+const ChatDrawer = () => {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState('');
+  const [turnstileError, setTurnstileError] = useState(false);
+  const [needsChallenge, setNeedsChallenge] = useState(false);
+  const { messages, started, sendMessage, addCachedExchange, fetchToken, hasToken } = useChat();
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    sendMessage(input);
+    setInput('');
+  };
+
+  const handleChip = (label) => {
+    const cached = CHIP_CACHE[label];
+    if (cached) addCachedExchange(label, cached);
+    else sendMessage(label);
+  };
+
+  return (
+    <>
+      {/* Floating Action Button */}
+      <Fade in={!open}>
+        <Fab
+          onClick={() => setOpen(true)}
+          aria-label="Chat with AI"
+          sx={{
+            position: 'fixed',
+            bottom: { xs: 20, md: 28 },
+            right: { xs: 20, md: 28 },
+            zIndex: 1050,
+            width: 56,
+            height: 56,
+            background: 'linear-gradient(135deg, #6366f1, #818cf8)',
+            boxShadow: '0 4px 24px rgba(99,102,241,0.35)',
+            transition: 'all 0.3s ease',
+            '&:hover': {
+              background: 'linear-gradient(135deg, #4f46e5, #6366f1)',
+              boxShadow: '0 4px 32px rgba(99,102,241,0.5)',
+              transform: 'scale(1.08)',
+            },
+          }}
+        >
+          <SmartToyIcon sx={{ color: '#fff', fontSize: 26 }} />
+        </Fab>
+      </Fade>
+
+      {/* Chat Drawer */}
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={() => setOpen(false)}
+        PaperProps={{
+          sx: {
+            width: { xs: '100%', sm: 420 },
+            maxWidth: '100vw',
+            bgcolor: '#0e0e12',
+            borderLeft: '1px solid rgba(255,255,255,0.06)',
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+          {/* Header */}
+          <Box
+            sx={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2.5,
+              py: 2,
+              borderBottom: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            <Box
+              sx={{
+                width: 36,
+                height: 36,
+                borderRadius: '10px',
+                background: 'linear-gradient(135deg, #6366f1, #818cf8)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <SmartToyIcon sx={{ color: '#fff', fontSize: 20 }} />
+            </Box>
+            <Box sx={{ flex: 1 }}>
+              <Typography sx={{ fontWeight: 700, fontSize: '0.95rem', lineHeight: 1.2, color: '#fafafa' }}>
+                David&apos;s AI Agent
+              </Typography>
+              <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.35)', lineHeight: 1.3 }}>
+                Knows about experience, projects & skills
+              </Typography>
+            </Box>
+            <IconButton onClick={() => setOpen(false)} sx={{ color: 'text.secondary' }}>
+              <CloseIcon sx={{ fontSize: 20 }} />
+            </IconButton>
+          </Box>
+
+          {/* Turnstile + Messages area */}
+          <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+            {/* Verification state */}
+            {!hasToken && !turnstileError && (
+              <Box sx={{ px: 2.5, pt: 3 }}>
+                <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2, textAlign: 'center' }}>
+                  {needsChallenge ? 'Please complete the verification below.' : 'Verifying...'}
+                </Typography>
+                <Box
+                  sx={{
+                    visibility: needsChallenge ? 'visible' : 'hidden',
+                    height: needsChallenge ? 'auto' : 0,
+                    overflow: 'hidden',
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Turnstile
+                    siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
+                    onSuccess={(captchaToken) => {
+                      fetchToken(captchaToken);
+                      setNeedsChallenge(false);
+                    }}
+                    onError={() => setTurnstileError(true)}
+                    onBeforeInteractive={() => setNeedsChallenge(true)}
+                    options={{ appearance: 'interaction-only' }}
+                  />
+                </Box>
+              </Box>
+            )}
+
+            {turnstileError && (
+              <Box sx={{ px: 2.5, pt: 3 }}>
+                <Typography variant="body2" sx={{ color: 'rgba(239,68,68,0.8)', textAlign: 'center' }}>
+                  Verification failed. Chat is temporarily unavailable.
+                </Typography>
+              </Box>
+            )}
+
+            {/* Preset chips (show before first message) */}
+            {!started && hasToken && (
+              <Box sx={{ px: 2.5, pt: 3 }}>
+                <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+                  Ask me anything about David, or try one of these:
+                </Typography>
+                <Stack direction="column" spacing={1}>
+                  {PRESET_CHIPS.map((chip) => (
+                    <Chip
+                      key={chip.label}
+                      label={chip.label}
+                      onClick={() => handleChip(chip.label)}
+                      sx={{
+                        height: 'auto',
+                        py: 1,
+                        justifyContent: 'flex-start',
+                        bgcolor: 'rgba(255,255,255,0.04)',
+                        border: '1px solid rgba(255,255,255,0.08)',
+                        cursor: 'pointer',
+                        transition: 'all 0.2s',
+                        '& .MuiChip-label': {
+                          color: chip.color,
+                          fontWeight: 500,
+                          fontSize: '0.85rem',
+                          whiteSpace: 'normal',
+                        },
+                        '&:hover': {
+                          bgcolor: 'rgba(129,140,248,0.08)',
+                          borderColor: 'rgba(129,140,248,0.2)',
+                        },
+                      }}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            )}
+
+            {/* Messages */}
+            {started && (
+              <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', px: 1, pt: 1 }}>
+                <MessagesList messages={messages} />
+              </Box>
+            )}
+          </Box>
+
+          {/* Input */}
+          <Box
+            sx={{
+              flexShrink: 0,
+              px: 2,
+              py: 1.5,
+              borderTop: '1px solid rgba(255,255,255,0.06)',
+              bgcolor: 'rgba(0,0,0,0.2)',
+            }}
+          >
+            <ChatInput
+              input={input}
+              setInput={setInput}
+              sendMessage={handleSend}
+              disabled={!hasToken}
+              placeholder={turnstileError ? 'Unavailable' : !hasToken ? 'Verifying...' : 'Ask anything...'}
+            />
+          </Box>
+        </Box>
+      </Drawer>
+    </>
+  );
+};
+
+export default ChatDrawer;

--- a/next-app/src/components/layout/Footer.jsx
+++ b/next-app/src/components/layout/Footer.jsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Box, Typography, IconButton, Stack } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+
+const Footer = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        borderTop: '1px solid rgba(255,255,255,0.06)',
+        py: 5,
+        px: { xs: 3, md: 6 },
+      }}
+    >
+      <Box
+        sx={{
+          maxWidth: 1200,
+          mx: 'auto',
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+        }}
+      >
+        <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.3)', fontSize: '0.8rem' }}>
+          &copy; {new Date().getFullYear()} David Riva. Built with Next.js & MUI.
+        </Typography>
+
+        <Stack direction="row" spacing={1} alignItems="center">
+          <IconButton
+            component="a"
+            href="https://github.com/davidjriva"
+            target="_blank"
+            rel="noopener"
+            size="small"
+            sx={{ color: 'rgba(255,255,255,0.3)', '&:hover': { color: '#fafafa' } }}
+          >
+            <GitHubIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+          <IconButton
+            component="a"
+            href="https://www.linkedin.com/in/david-j-riva"
+            target="_blank"
+            rel="noopener"
+            size="small"
+            sx={{ color: 'rgba(255,255,255,0.3)', '&:hover': { color: '#fafafa' } }}
+          >
+            <LinkedInIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+          <IconButton
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            size="small"
+            sx={{
+              color: 'rgba(255,255,255,0.3)',
+              ml: 1,
+              border: '1px solid rgba(255,255,255,0.08)',
+              '&:hover': { color: '#fafafa', borderColor: 'rgba(255,255,255,0.15)' },
+            }}
+          >
+            <KeyboardArrowUpIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+export default Footer;

--- a/next-app/src/components/layout/Nav.jsx
+++ b/next-app/src/components/layout/Nav.jsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Typography, Stack } from '@mui/material';
+
+const NAV_LINKS = [
+  { label: 'About', id: 'about' },
+  { label: 'Experience', id: 'experience' },
+  { label: 'Projects', id: 'projects' },
+  { label: 'Skills', id: 'skills' },
+  { label: 'Contact', id: 'contact' },
+];
+
+const Nav = () => {
+  const [scrolled, setScrolled] = useState(false);
+  const [activeSection, setActiveSection] = useState('');
+
+  const handleScroll = useCallback(() => {
+    setScrolled(window.scrollY > 50);
+
+    const sections = NAV_LINKS.map((link) => document.getElementById(link.id)).filter(Boolean);
+    const scrollPos = window.scrollY + 120;
+
+    let current = '';
+    for (const section of sections) {
+      if (section.offsetTop <= scrollPos) {
+        current = section.id;
+      }
+    }
+    setActiveSection(current);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const scrollTo = (id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      const y = el.getBoundingClientRect().top + window.scrollY - 80;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <Box
+      component="nav"
+      sx={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 1100,
+        px: { xs: 2, md: 4 },
+        py: 1.5,
+        transition: 'all 0.3s ease',
+        bgcolor: scrolled ? 'rgba(9,9,11,0.82)' : 'transparent',
+        backdropFilter: scrolled ? 'blur(20px) saturate(180%)' : 'none',
+        borderBottom: scrolled ? '1px solid rgba(255,255,255,0.06)' : '1px solid transparent',
+      }}
+    >
+      <Box
+        sx={{
+          maxWidth: 1200,
+          mx: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {/* Logo */}
+        <Box
+          component="button"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          sx={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            p: 0,
+          }}
+        >
+          <Box
+            sx={{
+              width: 34,
+              height: 34,
+              borderRadius: '10px',
+              background: 'linear-gradient(135deg, #6366f1, #818cf8)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography sx={{ color: '#fff', fontWeight: 800, fontSize: '0.9rem', lineHeight: 1 }}>DR</Typography>
+          </Box>
+          <Typography
+            sx={{
+              color: '#fafafa',
+              fontWeight: 700,
+              fontSize: '1rem',
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            David Riva
+          </Typography>
+        </Box>
+
+        {/* Nav links */}
+        <Stack direction="row" spacing={{ xs: 0.5, sm: 1, md: 2 }} alignItems="center">
+          {NAV_LINKS.map((link) => (
+            <Box
+              key={link.id}
+              component="button"
+              onClick={() => scrollTo(link.id)}
+              sx={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                px: { xs: 1, sm: 1.5 },
+                py: 1,
+                borderRadius: '8px',
+                transition: 'all 0.2s ease',
+                position: 'relative',
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  bottom: 4,
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  width: activeSection === link.id ? 16 : 0,
+                  height: 2,
+                  borderRadius: 1,
+                  bgcolor: 'primary.main',
+                  transition: 'width 0.3s ease',
+                },
+                '&:hover': {
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                },
+              }}
+            >
+              <Typography
+                sx={{
+                  color: activeSection === link.id ? '#fafafa' : 'text.secondary',
+                  fontSize: { xs: '0.75rem', sm: '0.82rem' },
+                  fontWeight: activeSection === link.id ? 600 : 400,
+                  transition: 'color 0.2s',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {link.label}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+export default Nav;

--- a/next-app/src/components/sections/About.jsx
+++ b/next-app/src/components/sections/About.jsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Box, Typography, Button, IconButton, Stack } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import DownloadIcon from '@mui/icons-material/Download';
+import FadeIn from '@/components/sections/FadeIn';
+
+const stats = [
+  { value: '2+', label: 'Years Experience' },
+  { value: '11', label: 'Projects Built' },
+  { value: '4.0', label: 'GPA' },
+];
+
+const About = () => {
+  return (
+    <Box
+      id="about"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 1100,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+          ABOUT
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 6 }}>
+          Get to know me
+        </Typography>
+      </FadeIn>
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          gap: { xs: 5, md: 8 },
+          alignItems: { xs: 'center', md: 'flex-start' },
+        }}
+      >
+        {/* Headshot */}
+        <FadeIn delay={0.1} direction="right">
+          <Box
+            sx={{
+              width: { xs: 220, sm: 260, md: 280 },
+              height: { xs: 220, sm: 260, md: 280 },
+              borderRadius: '20px',
+              overflow: 'hidden',
+              flexShrink: 0,
+              border: '1px solid rgba(255,255,255,0.08)',
+              position: 'relative',
+              '&::after': {
+                content: '""',
+                position: 'absolute',
+                inset: 0,
+                borderRadius: '20px',
+                border: '1px solid rgba(255,255,255,0.06)',
+                pointerEvents: 'none',
+              },
+            }}
+          >
+            <Box
+              component="img"
+              src="/images/headshot.webp"
+              alt="David Riva"
+              sx={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                display: 'block',
+              }}
+            />
+          </Box>
+        </FadeIn>
+
+        {/* Bio */}
+        <FadeIn delay={0.2} direction="left">
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="body1" sx={{ color: 'text.secondary', mb: 2.5 }}>
+              Hi, I&apos;m David. I&apos;m a software engineer based in the Bay Area, CA, and a graduate of Colorado
+              State University where I received a B.S. in Computer Science with Summa Cum Laude distinctions. I&apos;m
+              passionate about applied AI engineering and building software that solves real problems.
+            </Typography>
+            <Typography variant="body1" sx={{ color: 'text.secondary', mb: 2.5 }}>
+              I&apos;m experienced in full-stack development, AI orchestration, and big data visualization. My work
+              ranges from production RAG pipelines and agentic AI systems to interactive web applications serving
+              thousands of users.
+            </Typography>
+            <Typography variant="body1" sx={{ color: 'text.secondary', mb: 4 }}>
+              I pride myself on elegant problem-solving, clean architecture, and maintaining high standards of
+              engineering excellence.
+            </Typography>
+
+            {/* Stats */}
+            <Stack direction="row" spacing={{ xs: 3, sm: 5 }} mb={4}>
+              {stats.map((stat) => (
+                <Box key={stat.label}>
+                  <Typography
+                    variant="h3"
+                    sx={{
+                      fontSize: { xs: '1.6rem', md: '2rem' },
+                      background: 'linear-gradient(135deg, #818cf8, #34d399)',
+                      WebkitBackgroundClip: 'text',
+                      WebkitTextFillColor: 'transparent',
+                      backgroundClip: 'text',
+                    }}
+                  >
+                    {stat.value}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.8rem' }}>
+                    {stat.label}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+
+            {/* Actions */}
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Button
+                component="a"
+                href="/documents/resume.pdf"
+                target="_blank"
+                rel="noopener"
+                variant="outlined"
+                startIcon={<DownloadIcon />}
+                sx={{
+                  borderColor: 'rgba(255,255,255,0.12)',
+                  color: '#fafafa',
+                  fontWeight: 600,
+                  '&:hover': {
+                    borderColor: 'primary.main',
+                    bgcolor: 'rgba(129,140,248,0.06)',
+                  },
+                }}
+              >
+                Resume
+              </Button>
+              <IconButton
+                component="a"
+                href="https://github.com/davidjriva"
+                target="_blank"
+                rel="noopener"
+                aria-label="GitHub"
+                sx={{ color: 'text.secondary', '&:hover': { color: '#fafafa' } }}
+              >
+                <GitHubIcon />
+              </IconButton>
+              <IconButton
+                component="a"
+                href="https://www.linkedin.com/in/david-j-riva"
+                target="_blank"
+                rel="noopener"
+                aria-label="LinkedIn"
+                sx={{ color: 'text.secondary', '&:hover': { color: '#fafafa' } }}
+              >
+                <LinkedInIcon />
+              </IconButton>
+            </Stack>
+          </Box>
+        </FadeIn>
+      </Box>
+    </Box>
+  );
+};
+
+export default About;

--- a/next-app/src/components/sections/Awards.jsx
+++ b/next-app/src/components/sections/Awards.jsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import FadeIn from '@/components/sections/FadeIn';
+
+const Awards = () => {
+  const [awards, setAwards] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/awards.json')
+      .then((res) => res.json())
+      .then(setAwards)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <Box
+      id="awards"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 1100,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+          RECOGNITION
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 6 }}>
+          Awards & honors
+        </Typography>
+      </FadeIn>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+          gap: 3,
+        }}
+      >
+        {awards.map((award, i) => (
+          <FadeIn key={award.title} delay={i * 0.1}>
+            <Box
+              sx={{
+                p: 3,
+                borderRadius: '16px',
+                border: '1px solid rgba(255,255,255,0.06)',
+                bgcolor: 'rgba(255,255,255,0.02)',
+                height: '100%',
+                display: 'flex',
+                gap: 2.5,
+                transition: 'border-color 0.3s',
+                '&:hover': { borderColor: 'rgba(129,140,248,0.12)' },
+              }}
+            >
+              <Box
+                sx={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: '12px',
+                  bgcolor: 'rgba(129,140,248,0.08)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <EmojiEventsIcon sx={{ color: 'primary.light', fontSize: 22 }} />
+              </Box>
+              <Box>
+                <Typography variant="h6" sx={{ fontSize: '0.95rem', fontWeight: 700, mb: 0.5, lineHeight: 1.3 }}>
+                  {award.title}
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.82rem', mb: 1 }}>
+                  {award.description}
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.3)', fontSize: '0.75rem' }}>
+                  {award.date}
+                </Typography>
+              </Box>
+            </Box>
+          </FadeIn>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Awards;

--- a/next-app/src/components/sections/Contact.jsx
+++ b/next-app/src/components/sections/Contact.jsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Typography, TextField, Button, Alert, Collapse } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { Turnstile } from '@marsidev/react-turnstile';
+import FadeIn from '@/components/sections/FadeIn';
+
+const fieldSx = {
+  '& .MuiInputLabel-root': { color: 'rgba(255,255,255,0.4)' },
+  '& .MuiOutlinedInput-root': {
+    color: '#fafafa',
+    borderRadius: '12px',
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    '& fieldset': { borderColor: 'rgba(255,255,255,0.08)' },
+    '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.15)' },
+    '&.Mui-focused fieldset': { borderColor: '#818cf8' },
+  },
+};
+
+const Contact = () => {
+  const [formData, setFormData] = useState({ name: '', email: '', subject: '', message: '' });
+  const [status, setStatus] = useState('');
+  const [captchaToken, setCaptchaToken] = useState(null);
+  const [sending, setSending] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSending(true);
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...formData, captchaToken }),
+      });
+      if (res.ok) {
+        setStatus('success');
+        setFormData({ name: '', email: '', subject: '', message: '' });
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Box
+      id="contact"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 700,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Box sx={{ textAlign: 'center', mb: 6 }}>
+          <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+            CONTACT
+          </Typography>
+          <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 2 }}>
+            Get in touch
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'text.secondary', maxWidth: 480, mx: 'auto' }}>
+            Have a question or want to work together? Drop me a message and I&apos;ll get back to you.
+          </Typography>
+        </Box>
+      </FadeIn>
+
+      <FadeIn delay={0.15}>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          sx={{
+            p: { xs: 3, md: 4 },
+            borderRadius: '20px',
+            border: '1px solid rgba(255,255,255,0.06)',
+            bgcolor: 'rgba(255,255,255,0.02)',
+          }}
+        >
+          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2.5, mb: 2.5 }}>
+            <TextField
+              fullWidth
+              label="Name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              required
+              sx={fieldSx}
+            />
+            <TextField
+              fullWidth
+              label="Email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+              sx={fieldSx}
+            />
+          </Box>
+          <TextField
+            fullWidth
+            label="Subject"
+            name="subject"
+            value={formData.subject}
+            onChange={handleChange}
+            required
+            sx={{ ...fieldSx, mb: 2.5 }}
+          />
+          <TextField
+            fullWidth
+            label="Message"
+            name="message"
+            multiline
+            rows={5}
+            value={formData.message}
+            onChange={handleChange}
+            required
+            sx={{ ...fieldSx, mb: 3 }}
+          />
+
+          {!captchaToken && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 3 }}>
+              <Turnstile
+                siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA'}
+                onSuccess={(token) => setCaptchaToken(token)}
+              />
+            </Box>
+          )}
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+            disabled={!captchaToken || sending}
+            endIcon={<SendIcon />}
+            sx={{
+              py: 1.5,
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              borderRadius: '12px',
+              background: 'linear-gradient(135deg, #6366f1, #818cf8)',
+              boxShadow: '0 4px 20px rgba(99,102,241,0.2)',
+              '&:hover': {
+                background: 'linear-gradient(135deg, #4f46e5, #6366f1)',
+                boxShadow: '0 4px 28px rgba(99,102,241,0.3)',
+              },
+              '&.Mui-disabled': {
+                background: 'rgba(255,255,255,0.06)',
+                color: 'rgba(255,255,255,0.25)',
+              },
+            }}
+          >
+            {sending ? 'Sending...' : 'Send Message'}
+          </Button>
+
+          <Collapse in={!!status}>
+            <Alert
+              severity={status === 'success' ? 'success' : 'error'}
+              sx={{
+                mt: 2.5,
+                borderRadius: '12px',
+                bgcolor: status === 'success' ? 'rgba(52,211,153,0.08)' : 'rgba(239,68,68,0.08)',
+                color: status === 'success' ? '#34d399' : '#ef4444',
+                border: `1px solid ${status === 'success' ? 'rgba(52,211,153,0.15)' : 'rgba(239,68,68,0.15)'}`,
+                '& .MuiAlert-icon': {
+                  color: status === 'success' ? '#34d399' : '#ef4444',
+                },
+              }}
+            >
+              {status === 'success' ? 'Message sent successfully!' : 'Failed to send message. Please try again.'}
+            </Alert>
+          </Collapse>
+        </Box>
+      </FadeIn>
+    </Box>
+  );
+};
+
+export default Contact;

--- a/next-app/src/components/sections/Experience.jsx
+++ b/next-app/src/components/sections/Experience.jsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Collapse } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FadeIn from '@/components/sections/FadeIn';
+
+const Experience = () => {
+  const [experiences, setExperiences] = useState([]);
+  const [expandedIndex, setExpandedIndex] = useState(0);
+
+  useEffect(() => {
+    fetch('/data/experiences.json')
+      .then((res) => res.json())
+      .then(setExperiences)
+      .catch(console.error);
+  }, []);
+
+  const toggle = (i) => setExpandedIndex(expandedIndex === i ? -1 : i);
+
+  return (
+    <Box
+      id="experience"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 900,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+          EXPERIENCE
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 6 }}>
+          Where I&apos;ve worked
+        </Typography>
+      </FadeIn>
+
+      <Box sx={{ position: 'relative', pl: { xs: 3, md: 5 } }}>
+        {/* Timeline line */}
+        <Box
+          sx={{
+            position: 'absolute',
+            left: { xs: 7, md: 15 },
+            top: 8,
+            bottom: 8,
+            width: 2,
+            bgcolor: 'rgba(255,255,255,0.06)',
+            borderRadius: 1,
+          }}
+        />
+
+        {experiences.map((exp, i) => {
+          const isExpanded = expandedIndex === i;
+          const isFirst = i === 0;
+
+          return (
+            <FadeIn key={i} delay={i * 0.1}>
+              <Box
+                sx={{
+                  position: 'relative',
+                  mb: i < experiences.length - 1 ? 4 : 0,
+                  cursor: exp.bulletPoints ? 'pointer' : 'default',
+                }}
+                onClick={() => exp.bulletPoints && toggle(i)}
+              >
+                {/* Timeline dot */}
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    left: { xs: -21, md: -29 },
+                    top: 22,
+                    width: 14,
+                    height: 14,
+                    borderRadius: '50%',
+                    border: `2px solid ${isFirst ? '#818cf8' : 'rgba(255,255,255,0.15)'}`,
+                    bgcolor: isFirst ? 'rgba(99,102,241,0.2)' : '#09090b',
+                    zIndex: 1,
+                  }}
+                />
+
+                {/* Card */}
+                <Box
+                  sx={{
+                    p: { xs: 2.5, md: 3 },
+                    borderRadius: '16px',
+                    border: '1px solid',
+                    borderColor: isExpanded ? 'rgba(129,140,248,0.15)' : 'rgba(255,255,255,0.06)',
+                    bgcolor: isExpanded ? 'rgba(129,140,248,0.03)' : 'rgba(255,255,255,0.02)',
+                    transition: 'all 0.3s ease',
+                    '&:hover': {
+                      borderColor: 'rgba(129,140,248,0.12)',
+                      bgcolor: 'rgba(255,255,255,0.03)',
+                    },
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1 }}>
+                    {/* Company logo */}
+                    <Box
+                      component="img"
+                      src={`/images/${exp.logoImage}`}
+                      alt={exp.company}
+                      sx={{
+                        width: 40,
+                        height: 40,
+                        borderRadius: '10px',
+                        objectFit: 'contain',
+                        bgcolor: 'rgba(255,255,255,0.06)',
+                        p: 0.5,
+                        flexShrink: 0,
+                      }}
+                    />
+
+                    <Box sx={{ flex: 1 }}>
+                      <Typography variant="h6" sx={{ fontSize: '1rem', fontWeight: 700, lineHeight: 1.3, mb: 0.3 }}>
+                        {exp.title}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
+                        <Box
+                          component="a"
+                          href={exp.companyWebsiteLink}
+                          target="_blank"
+                          rel="noopener"
+                          sx={{
+                            color: 'primary.light',
+                            textDecoration: 'none',
+                            '&:hover': { textDecoration: 'underline' },
+                          }}
+                        >
+                          {exp.company}
+                        </Box>
+                        {' · '}
+                        {exp.location}
+                      </Typography>
+                    </Box>
+
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+                      <Chip
+                        label={`${exp.startDate} – ${exp.endDate}`}
+                        size="small"
+                        sx={{
+                          height: 26,
+                          fontSize: '0.72rem',
+                          bgcolor: 'rgba(255,255,255,0.04)',
+                          color: 'text.secondary',
+                          border: '1px solid rgba(255,255,255,0.06)',
+                          display: { xs: 'none', sm: 'flex' },
+                        }}
+                      />
+                      {exp.bulletPoints && (
+                        <ExpandMoreIcon
+                          sx={{
+                            color: 'text.secondary',
+                            fontSize: 20,
+                            transform: isExpanded ? 'rotate(180deg)' : 'rotate(0)',
+                            transition: 'transform 0.3s ease',
+                          }}
+                        />
+                      )}
+                    </Box>
+                  </Box>
+
+                  {/* Mobile date */}
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: 'text.secondary',
+                      fontSize: '0.75rem',
+                      ml: 7,
+                      display: { xs: 'block', sm: 'none' },
+                      mb: 1,
+                    }}
+                  >
+                    {exp.startDate} &ndash; {exp.endDate}
+                  </Typography>
+
+                  {/* Expandable bullet points */}
+                  {exp.bulletPoints && (
+                    <Collapse in={isExpanded} timeout={300}>
+                      <Box component="ul" sx={{ mt: 2, ml: 7, pl: 2, mb: 0, listStyleType: 'none' }}>
+                        {exp.bulletPoints.map((point, j) => (
+                          <Box
+                            component="li"
+                            key={j}
+                            sx={{
+                              position: 'relative',
+                              mb: 1.5,
+                              pl: 2,
+                              '&::before': {
+                                content: '""',
+                                position: 'absolute',
+                                left: 0,
+                                top: 10,
+                                width: 4,
+                                height: 4,
+                                borderRadius: '50%',
+                                bgcolor: 'primary.main',
+                                opacity: 0.5,
+                              },
+                            }}
+                          >
+                            <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
+                              {point}
+                            </Typography>
+                          </Box>
+                        ))}
+                      </Box>
+                    </Collapse>
+                  )}
+                </Box>
+              </Box>
+            </FadeIn>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default Experience;

--- a/next-app/src/components/sections/FadeIn.jsx
+++ b/next-app/src/components/sections/FadeIn.jsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { useInView } from 'react-intersection-observer';
+
+const FadeIn = ({ children, delay = 0, direction = 'up', ...props }) => {
+  const { ref, inView } = useInView({ threshold: 0.08, triggerOnce: true });
+
+  const transforms = {
+    up: 'translateY(32px)',
+    down: 'translateY(-32px)',
+    left: 'translateX(32px)',
+    right: 'translateX(-32px)',
+    none: 'none',
+  };
+
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        opacity: inView ? 1 : 0,
+        transform: inView ? 'none' : transforms[direction],
+        transition: `opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) ${delay}s`,
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default FadeIn;

--- a/next-app/src/components/sections/Hero.jsx
+++ b/next-app/src/components/sections/Hero.jsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { Box, Typography, IconButton, Button, Stack } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+
+const Hero = () => {
+  const scrollTo = (id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      const y = el.getBoundingClientRect().top + window.scrollY - 80;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        px: 3,
+      }}
+    >
+      {/* Gradient orbs */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '-20%',
+          right: '-10%',
+          width: { xs: 400, md: 700 },
+          height: { xs: 400, md: 700 },
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(99,102,241,0.15) 0%, transparent 70%)',
+          filter: 'blur(100px)',
+          pointerEvents: 'none',
+          animation: 'heroOrb1 25s ease-in-out infinite',
+          '@keyframes heroOrb1': {
+            '0%, 100%': { transform: 'translate(0, 0) scale(1)' },
+            '33%': { transform: 'translate(-80px, 60px) scale(1.1)' },
+            '66%': { transform: 'translate(40px, -30px) scale(0.95)' },
+          },
+        }}
+      />
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: '-15%',
+          left: '-10%',
+          width: { xs: 350, md: 600 },
+          height: { xs: 350, md: 600 },
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(52,211,153,0.08) 0%, transparent 70%)',
+          filter: 'blur(100px)',
+          pointerEvents: 'none',
+          animation: 'heroOrb2 30s ease-in-out infinite',
+          '@keyframes heroOrb2': {
+            '0%, 100%': { transform: 'translate(0, 0) scale(1)' },
+            '50%': { transform: 'translate(60px, -40px) scale(1.05)' },
+          },
+        }}
+      />
+
+      {/* Noise texture overlay */}
+      <Box
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          opacity: 0.03,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+          backgroundRepeat: 'repeat',
+          pointerEvents: 'none',
+        }}
+      />
+
+      <Box sx={{ position: 'relative', zIndex: 1, textAlign: 'center', maxWidth: 800 }}>
+        <Typography
+          variant="overline"
+          sx={{
+            color: 'primary.main',
+            mb: 3,
+            display: 'block',
+            fontSize: { xs: '0.7rem', md: '0.8rem' },
+          }}
+        >
+          SOFTWARE ENGINEER
+        </Typography>
+
+        <Typography
+          variant="h1"
+          sx={{
+            fontSize: { xs: '3.2rem', sm: '4.5rem', md: '6rem', lg: '7rem' },
+            mb: 3,
+            background: 'linear-gradient(160deg, #fafafa 30%, rgba(161,161,170,0.6) 100%)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            backgroundClip: 'text',
+          }}
+        >
+          David Riva
+        </Typography>
+
+        <Typography
+          variant="body1"
+          sx={{
+            color: 'text.secondary',
+            fontSize: { xs: '1rem', md: '1.2rem' },
+            maxWidth: 580,
+            mx: 'auto',
+            mb: 5,
+            lineHeight: 1.7,
+          }}
+        >
+          Building intelligent applications at the intersection of AI and full-stack engineering.
+        </Typography>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} justifyContent="center" alignItems="center" mb={5}>
+          <Button
+            variant="contained"
+            onClick={() => scrollTo('projects')}
+            sx={{
+              px: 4,
+              py: 1.4,
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              background: 'linear-gradient(135deg, #6366f1, #818cf8)',
+              boxShadow: '0 4px 24px rgba(99,102,241,0.25)',
+              '&:hover': {
+                background: 'linear-gradient(135deg, #4f46e5, #6366f1)',
+                boxShadow: '0 4px 32px rgba(99,102,241,0.35)',
+              },
+            }}
+          >
+            View Projects
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => scrollTo('about')}
+            sx={{
+              px: 4,
+              py: 1.4,
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              borderColor: 'rgba(255,255,255,0.12)',
+              color: '#fafafa',
+              '&:hover': {
+                borderColor: 'rgba(255,255,255,0.25)',
+                bgcolor: 'rgba(255,255,255,0.04)',
+              },
+            }}
+          >
+            About Me
+          </Button>
+        </Stack>
+
+        <Stack direction="row" spacing={1} justifyContent="center">
+          <IconButton
+            component="a"
+            href="https://github.com/davidjriva"
+            target="_blank"
+            rel="noopener"
+            aria-label="GitHub"
+            sx={{
+              color: 'text.secondary',
+              transition: 'color 0.2s, transform 0.2s',
+              '&:hover': { color: '#fafafa', transform: 'translateY(-2px)' },
+            }}
+          >
+            <GitHubIcon fontSize="medium" />
+          </IconButton>
+          <IconButton
+            component="a"
+            href="https://www.linkedin.com/in/david-j-riva"
+            target="_blank"
+            rel="noopener"
+            aria-label="LinkedIn"
+            sx={{
+              color: 'text.secondary',
+              transition: 'color 0.2s, transform 0.2s',
+              '&:hover': { color: '#fafafa', transform: 'translateY(-2px)' },
+            }}
+          >
+            <LinkedInIcon fontSize="medium" />
+          </IconButton>
+        </Stack>
+      </Box>
+
+      {/* Scroll indicator */}
+      <Box
+        component="button"
+        onClick={() => scrollTo('about')}
+        sx={{
+          position: 'absolute',
+          bottom: 40,
+          left: '50%',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          animation: 'scrollPulse 2.5s ease-in-out infinite',
+          '@keyframes scrollPulse': {
+            '0%, 100%': { transform: 'translateX(-50%) translateY(0)', opacity: 0.3 },
+            '50%': { transform: 'translateX(-50%) translateY(10px)', opacity: 0.7 },
+          },
+        }}
+      >
+        <KeyboardArrowDownIcon sx={{ color: 'text.secondary', fontSize: 32 }} />
+      </Box>
+    </Box>
+  );
+};
+
+export default Hero;

--- a/next-app/src/components/sections/Projects.jsx
+++ b/next-app/src/components/sections/Projects.jsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Button, Stack, IconButton, Collapse } from '@mui/material';
+import LaunchIcon from '@mui/icons-material/Launch';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FadeIn from '@/components/sections/FadeIn';
+
+const ProjectCard = ({ project, featured = false }) => {
+  const techTools = project.technologies.flatMap((t) => t.tools);
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        borderRadius: '16px',
+        border: '1px solid rgba(255,255,255,0.06)',
+        bgcolor: 'rgba(255,255,255,0.02)',
+        overflow: 'hidden',
+        transition: 'all 0.3s ease',
+        display: 'flex',
+        flexDirection: featured ? { xs: 'column', md: 'row' } : 'column',
+        '&:hover': {
+          borderColor: 'rgba(129,140,248,0.15)',
+          bgcolor: 'rgba(255,255,255,0.03)',
+          transform: 'translateY(-4px)',
+          boxShadow: '0 12px 40px rgba(0,0,0,0.3)',
+        },
+      }}
+    >
+      {/* Cover image */}
+      <Box
+        sx={{
+          position: 'relative',
+          width: featured ? { xs: '100%', md: '45%' } : '100%',
+          height: featured ? { xs: 220, md: 'auto' } : { xs: 180, sm: 200 },
+          minHeight: featured ? { md: 280 } : undefined,
+          flexShrink: 0,
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          component="img"
+          src={`/images/${project.coverImage}`}
+          alt={project.title}
+          sx={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+            transition: 'transform 0.5s ease',
+            '.MuiBox-root:hover &': { transform: 'scale(1.03)' },
+          }}
+        />
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            background: 'linear-gradient(to top, rgba(9,9,11,0.6) 0%, transparent 50%)',
+            pointerEvents: 'none',
+          }}
+        />
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ p: { xs: 2.5, md: 3 }, flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1, mb: 1 }}>
+          <Typography variant="h6" sx={{ fontSize: featured ? '1.15rem' : '1rem', fontWeight: 700, lineHeight: 1.3 }}>
+            {project.title}
+          </Typography>
+          <IconButton
+            component="a"
+            href={project.link}
+            target="_blank"
+            rel="noopener"
+            size="small"
+            sx={{
+              color: 'text.secondary',
+              flexShrink: 0,
+              '&:hover': { color: 'primary.main' },
+            }}
+          >
+            <GitHubIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Box>
+
+        <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.82rem', mb: 0.5 }}>
+          {project.dateStarted}
+          {project.dateStarted !== project.dateCompleted && ` – ${project.dateCompleted}`}
+        </Typography>
+
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+            fontSize: '0.88rem',
+            mb: 2,
+            flex: 1,
+            display: '-webkit-box',
+            WebkitLineClamp: featured ? 4 : 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {featured ? project.long_description : project.short_description}
+        </Typography>
+
+        <Stack direction="row" flexWrap="wrap" gap={0.8}>
+          {techTools.slice(0, featured ? 8 : 5).map((tool) => (
+            <Chip
+              key={tool}
+              label={tool}
+              size="small"
+              sx={{
+                height: 24,
+                fontSize: '0.7rem',
+                bgcolor: 'rgba(129,140,248,0.08)',
+                color: 'primary.light',
+                border: '1px solid rgba(129,140,248,0.12)',
+              }}
+            />
+          ))}
+          {techTools.length > (featured ? 8 : 5) && (
+            <Chip
+              label={`+${techTools.length - (featured ? 8 : 5)}`}
+              size="small"
+              sx={{
+                height: 24,
+                fontSize: '0.7rem',
+                bgcolor: 'rgba(255,255,255,0.04)',
+                color: 'text.secondary',
+              }}
+            />
+          )}
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+const Projects = () => {
+  const [projects, setProjects] = useState([]);
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    fetch('/data/projects.json')
+      .then((res) => res.json())
+      .then(setProjects)
+      .catch(console.error);
+  }, []);
+
+  const featured = projects.filter((p) => p.featured);
+  const others = projects.filter((p) => !p.featured);
+
+  return (
+    <Box
+      id="projects"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 1200,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+          PROJECTS
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 2 }}>
+          Things I&apos;ve built
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'text.secondary', mb: 6, maxWidth: 600 }}>
+          A selection of personal and professional projects spanning AI, full-stack development, and data engineering.
+        </Typography>
+      </FadeIn>
+
+      {/* Featured projects */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mb: 4 }}>
+        {featured.map((project, i) => (
+          <FadeIn key={project.title} delay={i * 0.1}>
+            <ProjectCard project={project} featured />
+          </FadeIn>
+        ))}
+      </Box>
+
+      {/* Other projects */}
+      <Collapse in={showAll} timeout={500}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', lg: '1fr 1fr 1fr' },
+            gap: 3,
+            mb: 4,
+          }}
+        >
+          {others.map((project, i) => (
+            <FadeIn key={project.title} delay={i * 0.08}>
+              <ProjectCard project={project} />
+            </FadeIn>
+          ))}
+        </Box>
+      </Collapse>
+
+      {others.length > 0 && (
+        <FadeIn>
+          <Box sx={{ textAlign: 'center' }}>
+            <Button
+              onClick={() => setShowAll(!showAll)}
+              variant="outlined"
+              endIcon={
+                <ExpandMoreIcon
+                  sx={{
+                    transform: showAll ? 'rotate(180deg)' : 'rotate(0)',
+                    transition: 'transform 0.3s',
+                  }}
+                />
+              }
+              sx={{
+                borderColor: 'rgba(255,255,255,0.1)',
+                color: 'text.secondary',
+                fontWeight: 600,
+                px: 4,
+                '&:hover': {
+                  borderColor: 'rgba(255,255,255,0.2)',
+                  bgcolor: 'rgba(255,255,255,0.03)',
+                },
+              }}
+            >
+              {showAll ? 'Show Featured Only' : `View All Projects (${projects.length})`}
+            </Button>
+          </Box>
+        </FadeIn>
+      )}
+    </Box>
+  );
+};
+
+export default Projects;

--- a/next-app/src/components/sections/Skills.jsx
+++ b/next-app/src/components/sections/Skills.jsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Box, Typography, Chip, Stack } from '@mui/material';
+import FadeIn from '@/components/sections/FadeIn';
+
+const Skills = () => {
+  const [skills, setSkills] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/skills.json')
+      .then((res) => res.json())
+      .then(setSkills)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <Box
+      id="skills"
+      sx={{
+        py: { xs: 10, md: 14 },
+        px: { xs: 3, sm: 4, md: 6 },
+        maxWidth: 1100,
+        mx: 'auto',
+      }}
+    >
+      <FadeIn>
+        <Typography variant="overline" sx={{ color: 'primary.main', mb: 1, display: 'block' }}>
+          SKILLS
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, mb: 6 }}>
+          Technologies & tools
+        </Typography>
+      </FadeIn>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', lg: '1fr 1fr 1fr' },
+          gap: 3,
+        }}
+      >
+        {skills.map((category, i) => (
+          <FadeIn key={category.title} delay={i * 0.08}>
+            <Box
+              sx={{
+                p: 3,
+                borderRadius: '16px',
+                border: '1px solid rgba(255,255,255,0.06)',
+                bgcolor: 'rgba(255,255,255,0.02)',
+                height: '100%',
+                transition: 'border-color 0.3s',
+                '&:hover': { borderColor: 'rgba(129,140,248,0.12)' },
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  color: 'primary.light',
+                  fontWeight: 600,
+                  fontSize: '0.82rem',
+                  mb: 2,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}
+              >
+                {category.title}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={1}>
+                {category.items.map((item) => (
+                  <Chip
+                    key={item}
+                    label={item}
+                    size="small"
+                    sx={{
+                      height: 28,
+                      fontSize: '0.78rem',
+                      fontWeight: 500,
+                      bgcolor: 'rgba(255,255,255,0.04)',
+                      color: 'text.secondary',
+                      border: '1px solid rgba(255,255,255,0.06)',
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        bgcolor: 'rgba(129,140,248,0.08)',
+                        borderColor: 'rgba(129,140,248,0.15)',
+                        color: '#fafafa',
+                      },
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+          </FadeIn>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Skills;

--- a/next-app/src/theme.js
+++ b/next-app/src/theme.js
@@ -6,30 +6,55 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0b0920',
-      paper: 'rgba(255, 255, 255, 0.04)',
+      default: '#09090b',
+      paper: '#18181b',
     },
     text: {
-      primary: '#ffffff',
-      secondary: 'rgba(255, 255, 255, 0.55)',
+      primary: '#fafafa',
+      secondary: '#a1a1aa',
     },
     primary: {
-      main: '#38c0f2',
+      main: '#818cf8',
+      light: '#a5b4fc',
+      dark: '#6366f1',
     },
     secondary: {
-      main: '#6e40c9',
+      main: '#34d399',
     },
+    divider: 'rgba(255, 255, 255, 0.08)',
   },
   typography: {
-    fontFamily: 'var(--font-montserrat), Arial, sans-serif',
-    h1: { fontWeight: 'bold', fontSize: '2.5rem' },
-    h2: { fontWeight: 'bold' },
-    h3: { fontWeight: 'bold' },
-    h4: { fontWeight: 'bold' },
-    h5: { fontWeight: 'bold' },
-    h6: { fontWeight: 'bold' },
-    body1: { fontWeight: 400, lineHeight: 1.6 },
-    body2: { fontWeight: 400 },
+    fontFamily: 'var(--font-inter), system-ui, sans-serif',
+    h1: { fontWeight: 800, letterSpacing: '-0.025em', lineHeight: 1.1 },
+    h2: { fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.2 },
+    h3: { fontWeight: 600, letterSpacing: '-0.01em' },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    body1: { fontWeight: 400, lineHeight: 1.7 },
+    body2: { fontWeight: 400, lineHeight: 1.6 },
+    overline: { fontWeight: 600, letterSpacing: '0.08em', fontSize: '0.8rem' },
+  },
+  shape: { borderRadius: 12 },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          fontWeight: 500,
+          borderRadius: 10,
+          padding: '10px 24px',
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          fontWeight: 500,
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

Complete visual overhaul of the portfolio website, replacing the particle-heavy glassmorphism design with a refined, minimal dark aesthetic built around purposeful motion and generous whitespace.

### What changed

- **Color palette**: Deep dark (`#09090b`) base with indigo (`#818cf8`) accent gradient, replacing cyan/purple
- **Typography**: Switched from Montserrat to Inter for a cleaner, more modern feel
- **Hero section**: Bold typographic statement with animated gradient orbs instead of particle backgrounds
- **Navigation**: Floating glass navbar with scroll-based opacity and active section highlighting
- **About**: Two-column layout with headshot, bio, gradient stats (2+ years, 11 projects, 4.0 GPA), and resume link
- **Experience**: Interactive vertical timeline with expandable bullet points and company logos
- **Projects**: Bento-inspired cards — featured projects displayed horizontally with cover images, others in a 3-column grid behind a "View All" toggle
- **Skills**: Categorized chip grid in 3-column layout with hover interactions
- **Awards**: 2-column card grid with trophy icon accents
- **Contact**: Centered form with side-by-side name/email fields and improved styling
- **AI Chat**: Moved from hero integration to a floating FAB + Drawer pattern (bottom-right)
- **Animations**: Scroll-driven reveal animations using `react-intersection-observer` (replaces GSAP ScrollTrigger for section reveals)
- **Chat components**: Updated `ChatInput` and `MessageItem` to use new indigo color palette

### Architecture

New component organization:
```
src/components/
├── sections/     # Hero, About, Experience, Projects, Skills, Awards, Contact, FadeIn
├── layout/       # Nav, Footer
└── chat/         # ChatDrawer (floating chat widget)
```

All API routes (`/api/chat`, `/api/token`, `/api/contact`, `/api/health`), the `useChat` hook, `chatConfig.ts`, `search.ts`, and data files are **unchanged**.

## Test plan

- [ ] Verify all sections render correctly on desktop (1280px+)
- [ ] Verify mobile responsiveness (390px viewport)
- [ ] Verify navbar glass effect appears on scroll and active section highlighting works
- [ ] Verify experience timeline expands/collapses on click
- [ ] Verify "View All Projects" toggle shows/hides non-featured projects
- [ ] Verify chat FAB opens the drawer with Turnstile verification flow
- [ ] Verify chat streaming works end-to-end with preset chips and free-form input
- [ ] Verify contact form submits successfully with Turnstile CAPTCHA
- [ ] Verify resume PDF opens in new tab from About section
- [ ] Verify social links (GitHub, LinkedIn) open correct profiles
- [ ] Run `npm run build` — passes clean
- [ ] Run `npm run lint` — no warnings or errors

https://claude.ai/code/session_01C7wraE6tXZ5AgWhBbjCAoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7wraE6tXZ5AgWhBbjCAoD)_